### PR TITLE
Bumped the year

### DIFF
--- a/.circleci/.stale-bot.mjs
+++ b/.circleci/.stale-bot.mjs
@@ -1,6 +1,6 @@
 /**
- * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
 /* eslint-env node */

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
@@ -25,7 +25,7 @@ module.exports = {
 		'ckeditor5-rules/license-header': [ 'error', {
 			headerLines: [
 				'/**',
-				' * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.',
+				' * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.',
 				' * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options',
 				' */'
 			]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
-# For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+# For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
 
 . "$(dirname -- "$0")/_/husky.sh"
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 # For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 
 . "$(dirname -- "$0")/_/husky.sh"

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -15,7 +15,7 @@
 			{
 				"headerLines": [
 					"/*",
-					" * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.",
+					" * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.",
 					" * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options",
 					" */"
 				]

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/docs/_snippets/assets.js
+++ b/docs/_snippets/assets.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/build-classic-source.js
+++ b/docs/_snippets/build-classic-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/build-classic.js
+++ b/docs/_snippets/build-classic.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/build-decoupled-document.js
+++ b/docs/_snippets/build-decoupled-document.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/examples/balloon-block-editor.js
+++ b/docs/_snippets/examples/balloon-block-editor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/examples/balloon-editor.js
+++ b/docs/_snippets/examples/balloon-editor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/examples/bottom-toolbar-editor.js
+++ b/docs/_snippets/examples/bottom-toolbar-editor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/examples/classic-editor-short.js
+++ b/docs/_snippets/examples/classic-editor-short.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/examples/classic-editor.js
+++ b/docs/_snippets/examples/classic-editor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/examples/document-editor.js
+++ b/docs/_snippets/examples/document-editor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/examples/inline-editor.js
+++ b/docs/_snippets/examples/inline-editor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/examples/multi-root-editor.js
+++ b/docs/_snippets/examples/multi-root-editor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/build-image-upload-source.js
+++ b/docs/_snippets/features/build-image-upload-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/build-ui-language-source.js
+++ b/docs/_snippets/features/build-ui-language-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/feature-digest.js
+++ b/docs/_snippets/features/feature-digest.js
@@ -1,4 +1,4 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */

--- a/docs/_snippets/features/image-upload.js
+++ b/docs/_snippets/features/image-upload.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/keyboard-support.js
+++ b/docs/_snippets/features/keyboard-support.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/mathtype.js
+++ b/docs/_snippets/features/mathtype.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/mermaid.js
+++ b/docs/_snippets/features/mermaid.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/placeholder-build.js
+++ b/docs/_snippets/features/placeholder-build.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/placeholder-custom.js
+++ b/docs/_snippets/features/placeholder-custom.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/placeholder.js
+++ b/docs/_snippets/features/placeholder.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/read-only-build.js
+++ b/docs/_snippets/features/read-only-build.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/read-only-hide-toolbar.js
+++ b/docs/_snippets/features/read-only-hide-toolbar.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/read-only.js
+++ b/docs/_snippets/features/read-only.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/ui-language-content.js
+++ b/docs/_snippets/features/ui-language-content.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/ui-language-rtl.js
+++ b/docs/_snippets/features/ui-language-rtl.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/ui-language.js
+++ b/docs/_snippets/features/ui-language.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/update-placeholder.js
+++ b/docs/_snippets/features/update-placeholder.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/features/wproofreader.js
+++ b/docs/_snippets/features/wproofreader.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/development-tools/inspector.js
+++ b/docs/_snippets/framework/development-tools/inspector.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/tutorials/block-widget.js
+++ b/docs/_snippets/framework/tutorials/block-widget.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/tutorials/external-data-widget.js
+++ b/docs/_snippets/framework/tutorials/external-data-widget.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/tutorials/inline-widget.js
+++ b/docs/_snippets/framework/tutorials/inline-widget.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/tutorials/using-react-in-widget.js
+++ b/docs/_snippets/framework/tutorials/using-react-in-widget.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-balloon.js
+++ b/docs/_snippets/framework/ui/ui-balloon.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-button-states.js
+++ b/docs/_snippets/framework/ui/ui-button-states.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-button.js
+++ b/docs/_snippets/framework/ui/ui-button.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-dialog.js
+++ b/docs/_snippets/framework/ui/ui-dialog.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-dropdown-states.js
+++ b/docs/_snippets/framework/ui/ui-dropdown-states.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-dropdown.js
+++ b/docs/_snippets/framework/ui/ui-dropdown.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-icons.js
+++ b/docs/_snippets/framework/ui/ui-icons.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-input-states.js
+++ b/docs/_snippets/framework/ui/ui-input-states.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-input.js
+++ b/docs/_snippets/framework/ui/ui-input.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-modal.js
+++ b/docs/_snippets/framework/ui/ui-modal.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-search.js
+++ b/docs/_snippets/framework/ui/ui-search.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-spinner.js
+++ b/docs/_snippets/framework/ui/ui-spinner.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-switch.js
+++ b/docs/_snippets/framework/ui/ui-switch.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-textarea.js
+++ b/docs/_snippets/framework/ui/ui-textarea.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-toolbar-button.js
+++ b/docs/_snippets/framework/ui/ui-toolbar-button.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-toolbar-compact.js
+++ b/docs/_snippets/framework/ui/ui-toolbar-compact.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-toolbar-multirow.js
+++ b/docs/_snippets/framework/ui/ui-toolbar-multirow.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-toolbar-separator.js
+++ b/docs/_snippets/framework/ui/ui-toolbar-separator.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-toolbar-text.js
+++ b/docs/_snippets/framework/ui/ui-toolbar-text.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/framework/ui/ui-toolbar-wrap.js
+++ b/docs/_snippets/framework/ui/ui-toolbar-wrap.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/getting-started/use-builder.js
+++ b/docs/_snippets/getting-started/use-builder.js
@@ -1,4 +1,4 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */

--- a/docs/_snippets/installation/advanced/dll-builds.js
+++ b/docs/_snippets/installation/advanced/dll-builds.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/installation/getting-and-setting-data/build-autosave-source.js
+++ b/docs/_snippets/installation/getting-and-setting-data/build-autosave-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/installation/getting-and-setting-data/manualsave.js
+++ b/docs/_snippets/installation/getting-and-setting-data/manualsave.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/installation/integrations/framework-integration.js
+++ b/docs/_snippets/installation/integrations/framework-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/installation/setup/blocktoolbar.js
+++ b/docs/_snippets/installation/setup/blocktoolbar.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/installation/setup/build-toolbar-source.js
+++ b/docs/_snippets/installation/setup/build-toolbar-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/installation/setup/toolbar-basic.js
+++ b/docs/_snippets/installation/setup/toolbar-basic.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/installation/setup/toolbar-breakpoint.js
+++ b/docs/_snippets/installation/setup/toolbar-breakpoint.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/installation/setup/toolbar-grouping.js
+++ b/docs/_snippets/installation/setup/toolbar-grouping.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/installation/setup/toolbar-nested-icon.js
+++ b/docs/_snippets/installation/setup/toolbar-nested-icon.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/installation/setup/toolbar-nested-label.js
+++ b/docs/_snippets/installation/setup/toolbar-nested-label.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/installation/setup/toolbar-nested-simple.js
+++ b/docs/_snippets/installation/setup/toolbar-nested-simple.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/installation/setup/toolbar-nested-tooltip.js
+++ b/docs/_snippets/installation/setup/toolbar-nested-tooltip.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/installation/setup/toolbar-separator.js
+++ b/docs/_snippets/installation/setup/toolbar-separator.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/installation/setup/toolbar-wrapping.js
+++ b/docs/_snippets/installation/setup/toolbar-wrapping.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/support/managing-ckeditor-logo-position.js
+++ b/docs/_snippets/support/managing-ckeditor-logo-position.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/support/managing-ckeditor-logo-styling.js
+++ b/docs/_snippets/support/managing-ckeditor-logo-styling.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/tour-balloon.css
+++ b/docs/_snippets/tour-balloon.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/tutorials/abbreviation-level-1.js
+++ b/docs/_snippets/tutorials/abbreviation-level-1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/tutorials/abbreviation-level-2.js
+++ b/docs/_snippets/tutorials/abbreviation-level-2.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/tutorials/abbreviation-level-3.js
+++ b/docs/_snippets/tutorials/abbreviation-level-3.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/tutorials/abbreviationView-level-2.js
+++ b/docs/_snippets/tutorials/abbreviationView-level-2.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/tutorials/abbreviationView-level-3.js
+++ b/docs/_snippets/tutorials/abbreviationView-level-3.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/tutorials/mini-inspector-basic-styles.js
+++ b/docs/_snippets/tutorials/mini-inspector-basic-styles.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/tutorials/timestamp-plugin.js
+++ b/docs/_snippets/tutorials/timestamp-plugin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/_snippets/updating/plugins-mapping/plugins-mapping.js
+++ b/docs/_snippets/updating/plugins-mapping/plugins-mapping.js
@@ -1,4 +1,4 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */

--- a/docs/assets/buildwarningbanner.js
+++ b/docs/assets/buildwarningbanner.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/assets/read-only-export-pdf.css
+++ b/docs/assets/read-only-export-pdf.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/assets/snippet-styles.css
+++ b/docs/assets/snippet-styles.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/assets/snippet.js
+++ b/docs/assets/snippet.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-adapter-ckfinder/LICENSE.md
+++ b/packages/ckeditor5-adapter-ckfinder/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 CKFinder adapter** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-adapter-ckfinder/src/augmentation.ts
+++ b/packages/ckeditor5-adapter-ckfinder/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-adapter-ckfinder/src/index.ts
+++ b/packages/ckeditor5-adapter-ckfinder/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-adapter-ckfinder/src/uploadadapter.ts
+++ b/packages/ckeditor5-adapter-ckfinder/src/uploadadapter.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-adapter-ckfinder/src/utils.ts
+++ b/packages/ckeditor5-adapter-ckfinder/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-adapter-ckfinder/tests/manual/uploadadapter.js
+++ b/packages/ckeditor5-adapter-ckfinder/tests/manual/uploadadapter.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-adapter-ckfinder/tests/uploadadapter.js
+++ b/packages/ckeditor5-adapter-ckfinder/tests/uploadadapter.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-adapter-ckfinder/tests/utils.js
+++ b/packages/ckeditor5-adapter-ckfinder/tests/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-adapter-ckfinder/webpack.config.js
+++ b/packages/ckeditor5-adapter-ckfinder/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/LICENSE.md
+++ b/packages/ckeditor5-alignment/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Text alignment feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-alignment/docs/_snippets/features/build-text-alignment-source.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/build-text-alignment-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-options.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-options.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-toolbar.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-toolbar.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/docs/_snippets/features/text-alignment.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/text-alignment.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/lang/translations/af.po
+++ b/packages/ckeditor5-alignment/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/ar.po
+++ b/packages/ckeditor5-alignment/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/ast.po
+++ b/packages/ckeditor5-alignment/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/az.po
+++ b/packages/ckeditor5-alignment/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/bg.po
+++ b/packages/ckeditor5-alignment/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/bn.po
+++ b/packages/ckeditor5-alignment/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/bs.po
+++ b/packages/ckeditor5-alignment/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/ca.po
+++ b/packages/ckeditor5-alignment/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/cs.po
+++ b/packages/ckeditor5-alignment/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/da.po
+++ b/packages/ckeditor5-alignment/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/de-ch.po
+++ b/packages/ckeditor5-alignment/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/de.po
+++ b/packages/ckeditor5-alignment/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/el.po
+++ b/packages/ckeditor5-alignment/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/en-au.po
+++ b/packages/ckeditor5-alignment/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/en-gb.po
+++ b/packages/ckeditor5-alignment/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/en.po
+++ b/packages/ckeditor5-alignment/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/eo.po
+++ b/packages/ckeditor5-alignment/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/es-co.po
+++ b/packages/ckeditor5-alignment/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/es.po
+++ b/packages/ckeditor5-alignment/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/et.po
+++ b/packages/ckeditor5-alignment/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/eu.po
+++ b/packages/ckeditor5-alignment/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/fa.po
+++ b/packages/ckeditor5-alignment/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/fi.po
+++ b/packages/ckeditor5-alignment/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/fr.po
+++ b/packages/ckeditor5-alignment/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/gl.po
+++ b/packages/ckeditor5-alignment/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/gu.po
+++ b/packages/ckeditor5-alignment/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/he.po
+++ b/packages/ckeditor5-alignment/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/hi.po
+++ b/packages/ckeditor5-alignment/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/hr.po
+++ b/packages/ckeditor5-alignment/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/hu.po
+++ b/packages/ckeditor5-alignment/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/hy.po
+++ b/packages/ckeditor5-alignment/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/id.po
+++ b/packages/ckeditor5-alignment/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/it.po
+++ b/packages/ckeditor5-alignment/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/ja.po
+++ b/packages/ckeditor5-alignment/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/jv.po
+++ b/packages/ckeditor5-alignment/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/kk.po
+++ b/packages/ckeditor5-alignment/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/km.po
+++ b/packages/ckeditor5-alignment/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/kn.po
+++ b/packages/ckeditor5-alignment/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/ko.po
+++ b/packages/ckeditor5-alignment/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/ku.po
+++ b/packages/ckeditor5-alignment/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/lt.po
+++ b/packages/ckeditor5-alignment/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/lv.po
+++ b/packages/ckeditor5-alignment/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/ms.po
+++ b/packages/ckeditor5-alignment/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/nb.po
+++ b/packages/ckeditor5-alignment/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/ne.po
+++ b/packages/ckeditor5-alignment/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/nl.po
+++ b/packages/ckeditor5-alignment/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/no.po
+++ b/packages/ckeditor5-alignment/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/oc.po
+++ b/packages/ckeditor5-alignment/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/pl.po
+++ b/packages/ckeditor5-alignment/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/pt-br.po
+++ b/packages/ckeditor5-alignment/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/pt.po
+++ b/packages/ckeditor5-alignment/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/ro.po
+++ b/packages/ckeditor5-alignment/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/ru.po
+++ b/packages/ckeditor5-alignment/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/si.po
+++ b/packages/ckeditor5-alignment/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/sk.po
+++ b/packages/ckeditor5-alignment/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/sl.po
+++ b/packages/ckeditor5-alignment/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/sq.po
+++ b/packages/ckeditor5-alignment/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-alignment/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/sr.po
+++ b/packages/ckeditor5-alignment/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/sv.po
+++ b/packages/ckeditor5-alignment/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/th.po
+++ b/packages/ckeditor5-alignment/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/ti.po
+++ b/packages/ckeditor5-alignment/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/tk.po
+++ b/packages/ckeditor5-alignment/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/tr.po
+++ b/packages/ckeditor5-alignment/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/tt.po
+++ b/packages/ckeditor5-alignment/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/ug.po
+++ b/packages/ckeditor5-alignment/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/uk.po
+++ b/packages/ckeditor5-alignment/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/ur.po
+++ b/packages/ckeditor5-alignment/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/uz.po
+++ b/packages/ckeditor5-alignment/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/vi.po
+++ b/packages/ckeditor5-alignment/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-alignment/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/lang/translations/zh.po
+++ b/packages/ckeditor5-alignment/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-alignment/src/alignment.ts
+++ b/packages/ckeditor5-alignment/src/alignment.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/src/alignmentcommand.ts
+++ b/packages/ckeditor5-alignment/src/alignmentcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/src/alignmentconfig.ts
+++ b/packages/ckeditor5-alignment/src/alignmentconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/src/alignmentediting.ts
+++ b/packages/ckeditor5-alignment/src/alignmentediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/src/alignmentui.ts
+++ b/packages/ckeditor5-alignment/src/alignmentui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/src/augmentation.ts
+++ b/packages/ckeditor5-alignment/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/src/index.ts
+++ b/packages/ckeditor5-alignment/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/src/utils.ts
+++ b/packages/ckeditor5-alignment/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/tests/alignment.js
+++ b/packages/ckeditor5-alignment/tests/alignment.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/tests/alignmentcommand.js
+++ b/packages/ckeditor5-alignment/tests/alignmentcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/tests/alignmentediting.js
+++ b/packages/ckeditor5-alignment/tests/alignmentediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/tests/alignmentui.js
+++ b/packages/ckeditor5-alignment/tests/alignmentui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/tests/integration.js
+++ b/packages/ckeditor5-alignment/tests/integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/tests/manual/alignment.js
+++ b/packages/ckeditor5-alignment/tests/manual/alignment.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/tests/manual/alignmentbuttons.js
+++ b/packages/ckeditor5-alignment/tests/manual/alignmentbuttons.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/tests/manual/alignmentconfig.js
+++ b/packages/ckeditor5-alignment/tests/manual/alignmentconfig.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/tests/manual/rtl.js
+++ b/packages/ckeditor5-alignment/tests/manual/rtl.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/tests/utils.js
+++ b/packages/ckeditor5-alignment/tests/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-alignment/webpack.config.js
+++ b/packages/ckeditor5-alignment/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autoformat/LICENSE.md
+++ b/packages/ckeditor5-autoformat/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Autoformat feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-autoformat/docs/_snippets/features/autoformat.js
+++ b/packages/ckeditor5-autoformat/docs/_snippets/features/autoformat.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autoformat/lang/translations/af.po
+++ b/packages/ckeditor5-autoformat/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/ar.po
+++ b/packages/ckeditor5-autoformat/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/ast.po
+++ b/packages/ckeditor5-autoformat/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/az.po
+++ b/packages/ckeditor5-autoformat/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/bg.po
+++ b/packages/ckeditor5-autoformat/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/bn.po
+++ b/packages/ckeditor5-autoformat/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/bs.po
+++ b/packages/ckeditor5-autoformat/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/ca.po
+++ b/packages/ckeditor5-autoformat/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/cs.po
+++ b/packages/ckeditor5-autoformat/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/da.po
+++ b/packages/ckeditor5-autoformat/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/de-ch.po
+++ b/packages/ckeditor5-autoformat/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/de.po
+++ b/packages/ckeditor5-autoformat/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/el.po
+++ b/packages/ckeditor5-autoformat/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/en-au.po
+++ b/packages/ckeditor5-autoformat/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/en-gb.po
+++ b/packages/ckeditor5-autoformat/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/en.po
+++ b/packages/ckeditor5-autoformat/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/eo.po
+++ b/packages/ckeditor5-autoformat/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/es-co.po
+++ b/packages/ckeditor5-autoformat/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/es.po
+++ b/packages/ckeditor5-autoformat/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/et.po
+++ b/packages/ckeditor5-autoformat/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/eu.po
+++ b/packages/ckeditor5-autoformat/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/fa.po
+++ b/packages/ckeditor5-autoformat/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/fi.po
+++ b/packages/ckeditor5-autoformat/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/fr.po
+++ b/packages/ckeditor5-autoformat/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/gl.po
+++ b/packages/ckeditor5-autoformat/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/gu.po
+++ b/packages/ckeditor5-autoformat/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/he.po
+++ b/packages/ckeditor5-autoformat/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/hi.po
+++ b/packages/ckeditor5-autoformat/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/hr.po
+++ b/packages/ckeditor5-autoformat/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/hu.po
+++ b/packages/ckeditor5-autoformat/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/hy.po
+++ b/packages/ckeditor5-autoformat/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/id.po
+++ b/packages/ckeditor5-autoformat/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/it.po
+++ b/packages/ckeditor5-autoformat/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/ja.po
+++ b/packages/ckeditor5-autoformat/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/jv.po
+++ b/packages/ckeditor5-autoformat/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/kk.po
+++ b/packages/ckeditor5-autoformat/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/km.po
+++ b/packages/ckeditor5-autoformat/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/kn.po
+++ b/packages/ckeditor5-autoformat/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/ko.po
+++ b/packages/ckeditor5-autoformat/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/ku.po
+++ b/packages/ckeditor5-autoformat/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/lt.po
+++ b/packages/ckeditor5-autoformat/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/lv.po
+++ b/packages/ckeditor5-autoformat/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/ms.po
+++ b/packages/ckeditor5-autoformat/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/nb.po
+++ b/packages/ckeditor5-autoformat/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/ne.po
+++ b/packages/ckeditor5-autoformat/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/nl.po
+++ b/packages/ckeditor5-autoformat/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/no.po
+++ b/packages/ckeditor5-autoformat/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/oc.po
+++ b/packages/ckeditor5-autoformat/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/pl.po
+++ b/packages/ckeditor5-autoformat/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/pt-br.po
+++ b/packages/ckeditor5-autoformat/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/pt.po
+++ b/packages/ckeditor5-autoformat/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/ro.po
+++ b/packages/ckeditor5-autoformat/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/ru.po
+++ b/packages/ckeditor5-autoformat/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/si.po
+++ b/packages/ckeditor5-autoformat/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/sk.po
+++ b/packages/ckeditor5-autoformat/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/sl.po
+++ b/packages/ckeditor5-autoformat/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/sq.po
+++ b/packages/ckeditor5-autoformat/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-autoformat/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/sr.po
+++ b/packages/ckeditor5-autoformat/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/sv.po
+++ b/packages/ckeditor5-autoformat/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/th.po
+++ b/packages/ckeditor5-autoformat/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/ti.po
+++ b/packages/ckeditor5-autoformat/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/tk.po
+++ b/packages/ckeditor5-autoformat/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/tr.po
+++ b/packages/ckeditor5-autoformat/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/tt.po
+++ b/packages/ckeditor5-autoformat/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/ug.po
+++ b/packages/ckeditor5-autoformat/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/uk.po
+++ b/packages/ckeditor5-autoformat/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/ur.po
+++ b/packages/ckeditor5-autoformat/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/uz.po
+++ b/packages/ckeditor5-autoformat/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/vi.po
+++ b/packages/ckeditor5-autoformat/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-autoformat/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/lang/translations/zh.po
+++ b/packages/ckeditor5-autoformat/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autoformat/src/augmentation.ts
+++ b/packages/ckeditor5-autoformat/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autoformat/src/autoformat.ts
+++ b/packages/ckeditor5-autoformat/src/autoformat.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autoformat/src/blockautoformatediting.ts
+++ b/packages/ckeditor5-autoformat/src/blockautoformatediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autoformat/src/index.ts
+++ b/packages/ckeditor5-autoformat/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autoformat/src/inlineautoformatediting.ts
+++ b/packages/ckeditor5-autoformat/src/inlineautoformatediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autoformat/tests/autoformat.js
+++ b/packages/ckeditor5-autoformat/tests/autoformat.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autoformat/tests/blockautoformatediting.js
+++ b/packages/ckeditor5-autoformat/tests/blockautoformatediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autoformat/tests/inlineautoformatediting.js
+++ b/packages/ckeditor5-autoformat/tests/inlineautoformatediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autoformat/tests/manual/autoformat.js
+++ b/packages/ckeditor5-autoformat/tests/manual/autoformat.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autoformat/tests/undointegration.js
+++ b/packages/ckeditor5-autoformat/tests/undointegration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autoformat/webpack.config.js
+++ b/packages/ckeditor5-autoformat/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autosave/LICENSE.md
+++ b/packages/ckeditor5-autosave/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Autosave feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-autosave/docs/_snippets/features/autosave.js
+++ b/packages/ckeditor5-autosave/docs/_snippets/features/autosave.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autosave/lang/translations/af.po
+++ b/packages/ckeditor5-autosave/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/ar.po
+++ b/packages/ckeditor5-autosave/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/ast.po
+++ b/packages/ckeditor5-autosave/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/az.po
+++ b/packages/ckeditor5-autosave/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/bg.po
+++ b/packages/ckeditor5-autosave/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/bn.po
+++ b/packages/ckeditor5-autosave/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/bs.po
+++ b/packages/ckeditor5-autosave/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/ca.po
+++ b/packages/ckeditor5-autosave/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/cs.po
+++ b/packages/ckeditor5-autosave/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/da.po
+++ b/packages/ckeditor5-autosave/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/de-ch.po
+++ b/packages/ckeditor5-autosave/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/de.po
+++ b/packages/ckeditor5-autosave/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/el.po
+++ b/packages/ckeditor5-autosave/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/en-au.po
+++ b/packages/ckeditor5-autosave/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/en-gb.po
+++ b/packages/ckeditor5-autosave/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/en.po
+++ b/packages/ckeditor5-autosave/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/eo.po
+++ b/packages/ckeditor5-autosave/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/es-co.po
+++ b/packages/ckeditor5-autosave/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/es.po
+++ b/packages/ckeditor5-autosave/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/et.po
+++ b/packages/ckeditor5-autosave/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/eu.po
+++ b/packages/ckeditor5-autosave/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/fa.po
+++ b/packages/ckeditor5-autosave/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/fi.po
+++ b/packages/ckeditor5-autosave/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/fr.po
+++ b/packages/ckeditor5-autosave/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/gl.po
+++ b/packages/ckeditor5-autosave/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/gu.po
+++ b/packages/ckeditor5-autosave/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/he.po
+++ b/packages/ckeditor5-autosave/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/hi.po
+++ b/packages/ckeditor5-autosave/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/hr.po
+++ b/packages/ckeditor5-autosave/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/hu.po
+++ b/packages/ckeditor5-autosave/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/hy.po
+++ b/packages/ckeditor5-autosave/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/id.po
+++ b/packages/ckeditor5-autosave/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/it.po
+++ b/packages/ckeditor5-autosave/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/ja.po
+++ b/packages/ckeditor5-autosave/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/jv.po
+++ b/packages/ckeditor5-autosave/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/kk.po
+++ b/packages/ckeditor5-autosave/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/km.po
+++ b/packages/ckeditor5-autosave/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/kn.po
+++ b/packages/ckeditor5-autosave/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/ko.po
+++ b/packages/ckeditor5-autosave/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/ku.po
+++ b/packages/ckeditor5-autosave/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/lt.po
+++ b/packages/ckeditor5-autosave/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/lv.po
+++ b/packages/ckeditor5-autosave/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/ms.po
+++ b/packages/ckeditor5-autosave/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/nb.po
+++ b/packages/ckeditor5-autosave/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/ne.po
+++ b/packages/ckeditor5-autosave/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/nl.po
+++ b/packages/ckeditor5-autosave/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/no.po
+++ b/packages/ckeditor5-autosave/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/oc.po
+++ b/packages/ckeditor5-autosave/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/pl.po
+++ b/packages/ckeditor5-autosave/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/pt-br.po
+++ b/packages/ckeditor5-autosave/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/pt.po
+++ b/packages/ckeditor5-autosave/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/ro.po
+++ b/packages/ckeditor5-autosave/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/ru.po
+++ b/packages/ckeditor5-autosave/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/si.po
+++ b/packages/ckeditor5-autosave/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/sk.po
+++ b/packages/ckeditor5-autosave/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/sl.po
+++ b/packages/ckeditor5-autosave/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/sq.po
+++ b/packages/ckeditor5-autosave/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-autosave/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/sr.po
+++ b/packages/ckeditor5-autosave/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/sv.po
+++ b/packages/ckeditor5-autosave/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/th.po
+++ b/packages/ckeditor5-autosave/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/ti.po
+++ b/packages/ckeditor5-autosave/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/tk.po
+++ b/packages/ckeditor5-autosave/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/tr.po
+++ b/packages/ckeditor5-autosave/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/tt.po
+++ b/packages/ckeditor5-autosave/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/ug.po
+++ b/packages/ckeditor5-autosave/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/uk.po
+++ b/packages/ckeditor5-autosave/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/ur.po
+++ b/packages/ckeditor5-autosave/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/uz.po
+++ b/packages/ckeditor5-autosave/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/vi.po
+++ b/packages/ckeditor5-autosave/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-autosave/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/lang/translations/zh.po
+++ b/packages/ckeditor5-autosave/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-autosave/src/augmentation.ts
+++ b/packages/ckeditor5-autosave/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autosave/src/autosave.ts
+++ b/packages/ckeditor5-autosave/src/autosave.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autosave/src/index.ts
+++ b/packages/ckeditor5-autosave/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autosave/tests/autosave.js
+++ b/packages/ckeditor5-autosave/tests/autosave.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autosave/tests/manual/autosave.js
+++ b/packages/ckeditor5-autosave/tests/manual/autosave.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-autosave/webpack.config.js
+++ b/packages/ckeditor5-autosave/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/LICENSE.md
+++ b/packages/ckeditor5-basic-styles/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Basic styles feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-basic-styles/docs/_snippets/features/basic-styles.js
+++ b/packages/ckeditor5-basic-styles/docs/_snippets/features/basic-styles.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/docs/_snippets/features/build-basic-styles-source.js
+++ b/packages/ckeditor5-basic-styles/docs/_snippets/features/build-basic-styles-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/lang/translations/af.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/ar.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/ast.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/az.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/bg.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/bn.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/bs.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/ca.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/cs.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/da.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/de-ch.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/de.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/el.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/en-au.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/en-gb.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/en.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/eo.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/es-co.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/es.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/et.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/eu.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/fa.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/fi.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/fr.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/gl.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/gu.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/he.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/hi.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/hr.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/hu.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/hy.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/id.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/it.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/ja.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/jv.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/kk.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/km.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/kn.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/ko.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/ku.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/lt.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/lv.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/ms.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/nb.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/ne.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/nl.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/no.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/oc.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/pl.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/pt-br.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/pt.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/ro.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/ru.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/si.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/sk.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/sl.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/sq.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/sr.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/sv.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/th.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/ti.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/tk.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/tr.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/tt.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/ug.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/uk.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/ur.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/uz.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/vi.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/lang/translations/zh.po
+++ b/packages/ckeditor5-basic-styles/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-basic-styles/src/attributecommand.ts
+++ b/packages/ckeditor5-basic-styles/src/attributecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/augmentation.ts
+++ b/packages/ckeditor5-basic-styles/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/bold.ts
+++ b/packages/ckeditor5-basic-styles/src/bold.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/bold/boldediting.ts
+++ b/packages/ckeditor5-basic-styles/src/bold/boldediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/bold/boldui.ts
+++ b/packages/ckeditor5-basic-styles/src/bold/boldui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/code.ts
+++ b/packages/ckeditor5-basic-styles/src/code.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/code/codeediting.ts
+++ b/packages/ckeditor5-basic-styles/src/code/codeediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/code/codeui.ts
+++ b/packages/ckeditor5-basic-styles/src/code/codeui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/index.ts
+++ b/packages/ckeditor5-basic-styles/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/italic.ts
+++ b/packages/ckeditor5-basic-styles/src/italic.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/italic/italicediting.ts
+++ b/packages/ckeditor5-basic-styles/src/italic/italicediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/italic/italicui.ts
+++ b/packages/ckeditor5-basic-styles/src/italic/italicui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/strikethrough.ts
+++ b/packages/ckeditor5-basic-styles/src/strikethrough.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/strikethrough/strikethroughediting.ts
+++ b/packages/ckeditor5-basic-styles/src/strikethrough/strikethroughediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/strikethrough/strikethroughui.ts
+++ b/packages/ckeditor5-basic-styles/src/strikethrough/strikethroughui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/subscript.ts
+++ b/packages/ckeditor5-basic-styles/src/subscript.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/subscript/subscriptediting.ts
+++ b/packages/ckeditor5-basic-styles/src/subscript/subscriptediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/subscript/subscriptui.ts
+++ b/packages/ckeditor5-basic-styles/src/subscript/subscriptui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/superscript.ts
+++ b/packages/ckeditor5-basic-styles/src/superscript.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/superscript/superscriptediting.ts
+++ b/packages/ckeditor5-basic-styles/src/superscript/superscriptediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/superscript/superscriptui.ts
+++ b/packages/ckeditor5-basic-styles/src/superscript/superscriptui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/underline.ts
+++ b/packages/ckeditor5-basic-styles/src/underline.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/underline/underlineediting.ts
+++ b/packages/ckeditor5-basic-styles/src/underline/underlineediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/underline/underlineui.ts
+++ b/packages/ckeditor5-basic-styles/src/underline/underlineui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/src/utils.ts
+++ b/packages/ckeditor5-basic-styles/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/attributecommand.js
+++ b/packages/ckeditor5-basic-styles/tests/attributecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/bold.js
+++ b/packages/ckeditor5-basic-styles/tests/bold.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/bold/boldediting.js
+++ b/packages/ckeditor5-basic-styles/tests/bold/boldediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/bold/boldui.js
+++ b/packages/ckeditor5-basic-styles/tests/bold/boldui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/code.js
+++ b/packages/ckeditor5-basic-styles/tests/code.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/code/codeediting.js
+++ b/packages/ckeditor5-basic-styles/tests/code/codeediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/code/codeui.js
+++ b/packages/ckeditor5-basic-styles/tests/code/codeui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/italic.js
+++ b/packages/ckeditor5-basic-styles/tests/italic.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/italic/italicediting.js
+++ b/packages/ckeditor5-basic-styles/tests/italic/italicediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/italic/italicui.js
+++ b/packages/ckeditor5-basic-styles/tests/italic/italicui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/manual/basic-styles.js
+++ b/packages/ckeditor5-basic-styles/tests/manual/basic-styles.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/strikethrough.js
+++ b/packages/ckeditor5-basic-styles/tests/strikethrough.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/strikethrough/strikethroughediting.js
+++ b/packages/ckeditor5-basic-styles/tests/strikethrough/strikethroughediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/strikethrough/strikethroughui.js
+++ b/packages/ckeditor5-basic-styles/tests/strikethrough/strikethroughui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/subscript.js
+++ b/packages/ckeditor5-basic-styles/tests/subscript.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/subscript/subscriptediting.js
+++ b/packages/ckeditor5-basic-styles/tests/subscript/subscriptediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/subscript/subscriptui.js
+++ b/packages/ckeditor5-basic-styles/tests/subscript/subscriptui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/superscript.js
+++ b/packages/ckeditor5-basic-styles/tests/superscript.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/superscript/superscriptediting.js
+++ b/packages/ckeditor5-basic-styles/tests/superscript/superscriptediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/superscript/superscriptui.js
+++ b/packages/ckeditor5-basic-styles/tests/superscript/superscriptui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/underline.js
+++ b/packages/ckeditor5-basic-styles/tests/underline.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/underline/underlineediting.js
+++ b/packages/ckeditor5-basic-styles/tests/underline/underlineediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/tests/underline/underlineui.js
+++ b/packages/ckeditor5-basic-styles/tests/underline/underlineui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/theme/code.css
+++ b/packages/ckeditor5-basic-styles/theme/code.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-basic-styles/webpack.config.js
+++ b/packages/ckeditor5-basic-styles/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/LICENSE.md
+++ b/packages/ckeditor5-block-quote/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Block quote feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote-source.js
+++ b/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote.js
+++ b/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/docs/_snippets/features/nested-block-quote.js
+++ b/packages/ckeditor5-block-quote/docs/_snippets/features/nested-block-quote.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/lang/translations/af.po
+++ b/packages/ckeditor5-block-quote/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/ar.po
+++ b/packages/ckeditor5-block-quote/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/ast.po
+++ b/packages/ckeditor5-block-quote/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/az.po
+++ b/packages/ckeditor5-block-quote/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/bg.po
+++ b/packages/ckeditor5-block-quote/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/bn.po
+++ b/packages/ckeditor5-block-quote/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/bs.po
+++ b/packages/ckeditor5-block-quote/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/ca.po
+++ b/packages/ckeditor5-block-quote/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/cs.po
+++ b/packages/ckeditor5-block-quote/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/da.po
+++ b/packages/ckeditor5-block-quote/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/de-ch.po
+++ b/packages/ckeditor5-block-quote/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/de.po
+++ b/packages/ckeditor5-block-quote/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/el.po
+++ b/packages/ckeditor5-block-quote/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/en-au.po
+++ b/packages/ckeditor5-block-quote/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/en-gb.po
+++ b/packages/ckeditor5-block-quote/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/en.po
+++ b/packages/ckeditor5-block-quote/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/eo.po
+++ b/packages/ckeditor5-block-quote/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/es-co.po
+++ b/packages/ckeditor5-block-quote/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/es.po
+++ b/packages/ckeditor5-block-quote/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/et.po
+++ b/packages/ckeditor5-block-quote/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/eu.po
+++ b/packages/ckeditor5-block-quote/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/fa.po
+++ b/packages/ckeditor5-block-quote/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/fi.po
+++ b/packages/ckeditor5-block-quote/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/fr.po
+++ b/packages/ckeditor5-block-quote/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/gl.po
+++ b/packages/ckeditor5-block-quote/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/gu.po
+++ b/packages/ckeditor5-block-quote/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/he.po
+++ b/packages/ckeditor5-block-quote/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/hi.po
+++ b/packages/ckeditor5-block-quote/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/hr.po
+++ b/packages/ckeditor5-block-quote/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/hu.po
+++ b/packages/ckeditor5-block-quote/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/hy.po
+++ b/packages/ckeditor5-block-quote/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/id.po
+++ b/packages/ckeditor5-block-quote/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/it.po
+++ b/packages/ckeditor5-block-quote/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/ja.po
+++ b/packages/ckeditor5-block-quote/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/jv.po
+++ b/packages/ckeditor5-block-quote/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/kk.po
+++ b/packages/ckeditor5-block-quote/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/km.po
+++ b/packages/ckeditor5-block-quote/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/kn.po
+++ b/packages/ckeditor5-block-quote/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/ko.po
+++ b/packages/ckeditor5-block-quote/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/ku.po
+++ b/packages/ckeditor5-block-quote/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/lt.po
+++ b/packages/ckeditor5-block-quote/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/lv.po
+++ b/packages/ckeditor5-block-quote/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/ms.po
+++ b/packages/ckeditor5-block-quote/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/nb.po
+++ b/packages/ckeditor5-block-quote/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/ne.po
+++ b/packages/ckeditor5-block-quote/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/nl.po
+++ b/packages/ckeditor5-block-quote/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/no.po
+++ b/packages/ckeditor5-block-quote/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/oc.po
+++ b/packages/ckeditor5-block-quote/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/pl.po
+++ b/packages/ckeditor5-block-quote/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/pt-br.po
+++ b/packages/ckeditor5-block-quote/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/pt.po
+++ b/packages/ckeditor5-block-quote/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/ro.po
+++ b/packages/ckeditor5-block-quote/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/ru.po
+++ b/packages/ckeditor5-block-quote/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/si.po
+++ b/packages/ckeditor5-block-quote/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/sk.po
+++ b/packages/ckeditor5-block-quote/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/sl.po
+++ b/packages/ckeditor5-block-quote/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/sq.po
+++ b/packages/ckeditor5-block-quote/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-block-quote/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/sr.po
+++ b/packages/ckeditor5-block-quote/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/sv.po
+++ b/packages/ckeditor5-block-quote/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/th.po
+++ b/packages/ckeditor5-block-quote/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/ti.po
+++ b/packages/ckeditor5-block-quote/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/tk.po
+++ b/packages/ckeditor5-block-quote/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/tr.po
+++ b/packages/ckeditor5-block-quote/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/tt.po
+++ b/packages/ckeditor5-block-quote/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/ug.po
+++ b/packages/ckeditor5-block-quote/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/uk.po
+++ b/packages/ckeditor5-block-quote/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/ur.po
+++ b/packages/ckeditor5-block-quote/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/uz.po
+++ b/packages/ckeditor5-block-quote/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/vi.po
+++ b/packages/ckeditor5-block-quote/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-block-quote/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/lang/translations/zh.po
+++ b/packages/ckeditor5-block-quote/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-block-quote/src/augmentation.ts
+++ b/packages/ckeditor5-block-quote/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/src/blockquote.ts
+++ b/packages/ckeditor5-block-quote/src/blockquote.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/src/blockquotecommand.ts
+++ b/packages/ckeditor5-block-quote/src/blockquotecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/src/blockquoteediting.ts
+++ b/packages/ckeditor5-block-quote/src/blockquoteediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/src/blockquoteui.ts
+++ b/packages/ckeditor5-block-quote/src/blockquoteui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/src/index.ts
+++ b/packages/ckeditor5-block-quote/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/tests/blockquote.js
+++ b/packages/ckeditor5-block-quote/tests/blockquote.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/tests/blockquotecommand.js
+++ b/packages/ckeditor5-block-quote/tests/blockquotecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/tests/blockquoteediting.js
+++ b/packages/ckeditor5-block-quote/tests/blockquoteediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/tests/blockquoteui.js
+++ b/packages/ckeditor5-block-quote/tests/blockquoteui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/tests/integration.js
+++ b/packages/ckeditor5-block-quote/tests/integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/tests/manual/blockquote.js
+++ b/packages/ckeditor5-block-quote/tests/manual/blockquote.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/tests/manual/blockquotenonesting.js
+++ b/packages/ckeditor5-block-quote/tests/manual/blockquotenonesting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/theme/blockquote.css
+++ b/packages/ckeditor5-block-quote/theme/blockquote.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-block-quote/webpack.config.js
+++ b/packages/ckeditor5-block-quote/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/LICENSE.md
+++ b/packages/ckeditor5-bookmark/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Bookmark feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-bookmark/docs/_snippets/features/bookmark.js
+++ b/packages/ckeditor5-bookmark/docs/_snippets/features/bookmark.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/lang/translations/af.po
+++ b/packages/ckeditor5-bookmark/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/ar.po
+++ b/packages/ckeditor5-bookmark/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/ast.po
+++ b/packages/ckeditor5-bookmark/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/az.po
+++ b/packages/ckeditor5-bookmark/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/bg.po
+++ b/packages/ckeditor5-bookmark/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/bn.po
+++ b/packages/ckeditor5-bookmark/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/bs.po
+++ b/packages/ckeditor5-bookmark/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/ca.po
+++ b/packages/ckeditor5-bookmark/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/cs.po
+++ b/packages/ckeditor5-bookmark/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/da.po
+++ b/packages/ckeditor5-bookmark/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/de-ch.po
+++ b/packages/ckeditor5-bookmark/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/de.po
+++ b/packages/ckeditor5-bookmark/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/el.po
+++ b/packages/ckeditor5-bookmark/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/en-au.po
+++ b/packages/ckeditor5-bookmark/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/en-gb.po
+++ b/packages/ckeditor5-bookmark/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/en.po
+++ b/packages/ckeditor5-bookmark/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/eo.po
+++ b/packages/ckeditor5-bookmark/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/es-co.po
+++ b/packages/ckeditor5-bookmark/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/es.po
+++ b/packages/ckeditor5-bookmark/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/et.po
+++ b/packages/ckeditor5-bookmark/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/eu.po
+++ b/packages/ckeditor5-bookmark/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/fa.po
+++ b/packages/ckeditor5-bookmark/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/fi.po
+++ b/packages/ckeditor5-bookmark/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/fr.po
+++ b/packages/ckeditor5-bookmark/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/gl.po
+++ b/packages/ckeditor5-bookmark/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/gu.po
+++ b/packages/ckeditor5-bookmark/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/he.po
+++ b/packages/ckeditor5-bookmark/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/hi.po
+++ b/packages/ckeditor5-bookmark/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/hr.po
+++ b/packages/ckeditor5-bookmark/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/hu.po
+++ b/packages/ckeditor5-bookmark/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/hy.po
+++ b/packages/ckeditor5-bookmark/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/id.po
+++ b/packages/ckeditor5-bookmark/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/it.po
+++ b/packages/ckeditor5-bookmark/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/ja.po
+++ b/packages/ckeditor5-bookmark/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/jv.po
+++ b/packages/ckeditor5-bookmark/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/kk.po
+++ b/packages/ckeditor5-bookmark/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/km.po
+++ b/packages/ckeditor5-bookmark/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/kn.po
+++ b/packages/ckeditor5-bookmark/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/ko.po
+++ b/packages/ckeditor5-bookmark/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/ku.po
+++ b/packages/ckeditor5-bookmark/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/lt.po
+++ b/packages/ckeditor5-bookmark/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/lv.po
+++ b/packages/ckeditor5-bookmark/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/ms.po
+++ b/packages/ckeditor5-bookmark/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/nb.po
+++ b/packages/ckeditor5-bookmark/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/ne.po
+++ b/packages/ckeditor5-bookmark/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/nl.po
+++ b/packages/ckeditor5-bookmark/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/no.po
+++ b/packages/ckeditor5-bookmark/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/oc.po
+++ b/packages/ckeditor5-bookmark/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/pl.po
+++ b/packages/ckeditor5-bookmark/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/pt-br.po
+++ b/packages/ckeditor5-bookmark/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/pt.po
+++ b/packages/ckeditor5-bookmark/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/ro.po
+++ b/packages/ckeditor5-bookmark/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/ru.po
+++ b/packages/ckeditor5-bookmark/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/si.po
+++ b/packages/ckeditor5-bookmark/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/sk.po
+++ b/packages/ckeditor5-bookmark/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/sl.po
+++ b/packages/ckeditor5-bookmark/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/sq.po
+++ b/packages/ckeditor5-bookmark/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-bookmark/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/sr.po
+++ b/packages/ckeditor5-bookmark/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/sv.po
+++ b/packages/ckeditor5-bookmark/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/th.po
+++ b/packages/ckeditor5-bookmark/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/ti.po
+++ b/packages/ckeditor5-bookmark/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/tk.po
+++ b/packages/ckeditor5-bookmark/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/tr.po
+++ b/packages/ckeditor5-bookmark/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/tt.po
+++ b/packages/ckeditor5-bookmark/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/ug.po
+++ b/packages/ckeditor5-bookmark/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/uk.po
+++ b/packages/ckeditor5-bookmark/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/ur.po
+++ b/packages/ckeditor5-bookmark/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/uz.po
+++ b/packages/ckeditor5-bookmark/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/vi.po
+++ b/packages/ckeditor5-bookmark/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-bookmark/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/lang/translations/zh.po
+++ b/packages/ckeditor5-bookmark/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-bookmark/src/augmentation.ts
+++ b/packages/ckeditor5-bookmark/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/src/bookmark.ts
+++ b/packages/ckeditor5-bookmark/src/bookmark.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/src/bookmarkconfig.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/src/bookmarkediting.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/src/bookmarkui.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/src/index.ts
+++ b/packages/ckeditor5-bookmark/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/src/insertbookmarkcommand.ts
+++ b/packages/ckeditor5-bookmark/src/insertbookmarkcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/src/ui/bookmarkactionsview.ts
+++ b/packages/ckeditor5-bookmark/src/ui/bookmarkactionsview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/src/ui/bookmarkformview.ts
+++ b/packages/ckeditor5-bookmark/src/ui/bookmarkformview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/src/updatebookmarkcommand.ts
+++ b/packages/ckeditor5-bookmark/src/updatebookmarkcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/src/utils.ts
+++ b/packages/ckeditor5-bookmark/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/tests/bookmark.js
+++ b/packages/ckeditor5-bookmark/tests/bookmark.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/tests/bookmarkediting.js
+++ b/packages/ckeditor5-bookmark/tests/bookmarkediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/tests/bookmarkui.js
+++ b/packages/ckeditor5-bookmark/tests/bookmarkui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/tests/index.js
+++ b/packages/ckeditor5-bookmark/tests/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/tests/insertbookmarkcommand.js
+++ b/packages/ckeditor5-bookmark/tests/insertbookmarkcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/tests/manual/bookmark-with-output.js
+++ b/packages/ckeditor5-bookmark/tests/manual/bookmark-with-output.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/tests/manual/bookmark.js
+++ b/packages/ckeditor5-bookmark/tests/manual/bookmark.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/tests/manual/multiroot.js
+++ b/packages/ckeditor5-bookmark/tests/manual/multiroot.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/tests/manual/paste-from-office.js
+++ b/packages/ckeditor5-bookmark/tests/manual/paste-from-office.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/tests/ui/bookmarkactionsview.js
+++ b/packages/ckeditor5-bookmark/tests/ui/bookmarkactionsview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/tests/ui/bookmarkformview.js
+++ b/packages/ckeditor5-bookmark/tests/ui/bookmarkformview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/tests/updatebookmarkcommand.js
+++ b/packages/ckeditor5-bookmark/tests/updatebookmarkcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/theme/bookmark.css
+++ b/packages/ckeditor5-bookmark/theme/bookmark.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/theme/bookmarkactions.css
+++ b/packages/ckeditor5-bookmark/theme/bookmarkactions.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/theme/bookmarkform.css
+++ b/packages/ckeditor5-bookmark/theme/bookmarkform.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-bookmark/webpack.config.js
+++ b/packages/ckeditor5-bookmark/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-balloon-block/.eslintrc.js
+++ b/packages/ckeditor5-build-balloon-block/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-balloon-block/LICENSE.md
+++ b/packages/ckeditor5-build-balloon-block/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Balloon block editor build** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-build-balloon-block/src/ckeditor.ts
+++ b/packages/ckeditor5-build-balloon-block/src/ckeditor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-balloon-block/tests/ckeditor.js
+++ b/packages/ckeditor5-build-balloon-block/tests/ckeditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-balloon-block/tests/manual/ckeditor-cjs-version.js
+++ b/packages/ckeditor5-build-balloon-block/tests/manual/ckeditor-cjs-version.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-balloon-block/tests/manual/ckeditor.js
+++ b/packages/ckeditor5-build-balloon-block/tests/manual/ckeditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-balloon-block/theme/theme.css
+++ b/packages/ckeditor5-build-balloon-block/theme/theme.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-balloon-block/webpack.config.mjs
+++ b/packages/ckeditor5-build-balloon-block/webpack.config.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-balloon/.eslintrc.js
+++ b/packages/ckeditor5-build-balloon/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-balloon/LICENSE.md
+++ b/packages/ckeditor5-build-balloon/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Balloon editor build** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-build-balloon/src/ckeditor.ts
+++ b/packages/ckeditor5-build-balloon/src/ckeditor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-balloon/tests/ckeditor.js
+++ b/packages/ckeditor5-build-balloon/tests/ckeditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-balloon/tests/manual/ckeditor-cjs-version.js
+++ b/packages/ckeditor5-build-balloon/tests/manual/ckeditor-cjs-version.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-balloon/tests/manual/ckeditor.js
+++ b/packages/ckeditor5-build-balloon/tests/manual/ckeditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-balloon/webpack.config.mjs
+++ b/packages/ckeditor5-build-balloon/webpack.config.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-classic/.eslintrc.js
+++ b/packages/ckeditor5-build-classic/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-classic/LICENSE.md
+++ b/packages/ckeditor5-build-classic/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Classic editor build** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-build-classic/src/ckeditor.ts
+++ b/packages/ckeditor5-build-classic/src/ckeditor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-classic/tests/ckeditor.js
+++ b/packages/ckeditor5-build-classic/tests/ckeditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-classic/tests/manual/ckeditor-cjs-version.js
+++ b/packages/ckeditor5-build-classic/tests/manual/ckeditor-cjs-version.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-classic/tests/manual/ckeditor.js
+++ b/packages/ckeditor5-build-classic/tests/manual/ckeditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-classic/webpack.config.mjs
+++ b/packages/ckeditor5-build-classic/webpack.config.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-decoupled-document/.eslintrc.js
+++ b/packages/ckeditor5-build-decoupled-document/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-decoupled-document/LICENSE.md
+++ b/packages/ckeditor5-build-decoupled-document/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Document editor build** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-build-decoupled-document/src/ckeditor.ts
+++ b/packages/ckeditor5-build-decoupled-document/src/ckeditor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-decoupled-document/tests/ckeditor.js
+++ b/packages/ckeditor5-build-decoupled-document/tests/ckeditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-decoupled-document/tests/manual/ckeditor-cjs-version.js
+++ b/packages/ckeditor5-build-decoupled-document/tests/manual/ckeditor-cjs-version.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-decoupled-document/tests/manual/ckeditor.js
+++ b/packages/ckeditor5-build-decoupled-document/tests/manual/ckeditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-decoupled-document/webpack.config.mjs
+++ b/packages/ckeditor5-build-decoupled-document/webpack.config.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-inline/.eslintrc.js
+++ b/packages/ckeditor5-build-inline/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-inline/LICENSE.md
+++ b/packages/ckeditor5-build-inline/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Inline editor build** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-build-inline/src/ckeditor.ts
+++ b/packages/ckeditor5-build-inline/src/ckeditor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-inline/tests/ckeditor.js
+++ b/packages/ckeditor5-build-inline/tests/ckeditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-inline/tests/manual/ckeditor-cjs-version.js
+++ b/packages/ckeditor5-build-inline/tests/manual/ckeditor-cjs-version.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-inline/tests/manual/ckeditor.js
+++ b/packages/ckeditor5-build-inline/tests/manual/ckeditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-inline/webpack.config.mjs
+++ b/packages/ckeditor5-build-inline/webpack.config.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-multi-root/.eslintrc.js
+++ b/packages/ckeditor5-build-multi-root/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-multi-root/LICENSE.md
+++ b/packages/ckeditor5-build-multi-root/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Multi-root editor build** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-build-multi-root/src/ckeditor.ts
+++ b/packages/ckeditor5-build-multi-root/src/ckeditor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-multi-root/tests/ckeditor.js
+++ b/packages/ckeditor5-build-multi-root/tests/ckeditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-multi-root/tests/manual/ckeditor-cjs-version.js
+++ b/packages/ckeditor5-build-multi-root/tests/manual/ckeditor-cjs-version.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-build-multi-root/webpack.config.mjs
+++ b/packages/ckeditor5-build-multi-root/webpack.config.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/LICENSE.md
+++ b/packages/ckeditor5-ckbox/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 CKBox feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](http://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](http://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-ckbox/docs/_snippets/features/build-ckbox-source.js
+++ b/packages/ckeditor5-ckbox/docs/_snippets/features/build-ckbox-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/docs/_snippets/features/ckbox.js
+++ b/packages/ckeditor5-ckbox/docs/_snippets/features/ckbox.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/lang/translations/af.po
+++ b/packages/ckeditor5-ckbox/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/ar.po
+++ b/packages/ckeditor5-ckbox/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/ast.po
+++ b/packages/ckeditor5-ckbox/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/az.po
+++ b/packages/ckeditor5-ckbox/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/bg.po
+++ b/packages/ckeditor5-ckbox/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/bn.po
+++ b/packages/ckeditor5-ckbox/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/bs.po
+++ b/packages/ckeditor5-ckbox/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/ca.po
+++ b/packages/ckeditor5-ckbox/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/cs.po
+++ b/packages/ckeditor5-ckbox/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/da.po
+++ b/packages/ckeditor5-ckbox/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/de-ch.po
+++ b/packages/ckeditor5-ckbox/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/de.po
+++ b/packages/ckeditor5-ckbox/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/el.po
+++ b/packages/ckeditor5-ckbox/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/en-au.po
+++ b/packages/ckeditor5-ckbox/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/en-gb.po
+++ b/packages/ckeditor5-ckbox/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/en.po
+++ b/packages/ckeditor5-ckbox/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/eo.po
+++ b/packages/ckeditor5-ckbox/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/es-co.po
+++ b/packages/ckeditor5-ckbox/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/es.po
+++ b/packages/ckeditor5-ckbox/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/et.po
+++ b/packages/ckeditor5-ckbox/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/eu.po
+++ b/packages/ckeditor5-ckbox/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/fa.po
+++ b/packages/ckeditor5-ckbox/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/fi.po
+++ b/packages/ckeditor5-ckbox/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/fr.po
+++ b/packages/ckeditor5-ckbox/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/gl.po
+++ b/packages/ckeditor5-ckbox/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/gu.po
+++ b/packages/ckeditor5-ckbox/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/he.po
+++ b/packages/ckeditor5-ckbox/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/hi.po
+++ b/packages/ckeditor5-ckbox/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/hr.po
+++ b/packages/ckeditor5-ckbox/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/hu.po
+++ b/packages/ckeditor5-ckbox/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/hy.po
+++ b/packages/ckeditor5-ckbox/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/id.po
+++ b/packages/ckeditor5-ckbox/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/it.po
+++ b/packages/ckeditor5-ckbox/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/ja.po
+++ b/packages/ckeditor5-ckbox/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/jv.po
+++ b/packages/ckeditor5-ckbox/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/kk.po
+++ b/packages/ckeditor5-ckbox/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/km.po
+++ b/packages/ckeditor5-ckbox/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/kn.po
+++ b/packages/ckeditor5-ckbox/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/ko.po
+++ b/packages/ckeditor5-ckbox/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/ku.po
+++ b/packages/ckeditor5-ckbox/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/lt.po
+++ b/packages/ckeditor5-ckbox/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/lv.po
+++ b/packages/ckeditor5-ckbox/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/ms.po
+++ b/packages/ckeditor5-ckbox/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/nb.po
+++ b/packages/ckeditor5-ckbox/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/ne.po
+++ b/packages/ckeditor5-ckbox/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/nl.po
+++ b/packages/ckeditor5-ckbox/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/no.po
+++ b/packages/ckeditor5-ckbox/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/oc.po
+++ b/packages/ckeditor5-ckbox/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/pl.po
+++ b/packages/ckeditor5-ckbox/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/pt-br.po
+++ b/packages/ckeditor5-ckbox/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/pt.po
+++ b/packages/ckeditor5-ckbox/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/ro.po
+++ b/packages/ckeditor5-ckbox/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/ru.po
+++ b/packages/ckeditor5-ckbox/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/si.po
+++ b/packages/ckeditor5-ckbox/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/sk.po
+++ b/packages/ckeditor5-ckbox/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/sl.po
+++ b/packages/ckeditor5-ckbox/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/sq.po
+++ b/packages/ckeditor5-ckbox/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-ckbox/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/sr.po
+++ b/packages/ckeditor5-ckbox/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/sv.po
+++ b/packages/ckeditor5-ckbox/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/th.po
+++ b/packages/ckeditor5-ckbox/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/ti.po
+++ b/packages/ckeditor5-ckbox/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/tk.po
+++ b/packages/ckeditor5-ckbox/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/tr.po
+++ b/packages/ckeditor5-ckbox/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/tt.po
+++ b/packages/ckeditor5-ckbox/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/ug.po
+++ b/packages/ckeditor5-ckbox/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/uk.po
+++ b/packages/ckeditor5-ckbox/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/ur.po
+++ b/packages/ckeditor5-ckbox/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/uz.po
+++ b/packages/ckeditor5-ckbox/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/vi.po
+++ b/packages/ckeditor5-ckbox/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-ckbox/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/lang/translations/zh.po
+++ b/packages/ckeditor5-ckbox/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckbox/src/augmentation.ts
+++ b/packages/ckeditor5-ckbox/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/src/ckbox.ts
+++ b/packages/ckeditor5-ckbox/src/ckbox.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/src/ckboxcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/src/ckboxconfig.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/src/ckboxediting.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/src/ckboximageedit.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditediting.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditui.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/utils.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/src/ckboxui.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/src/ckboxuploadadapter.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxuploadadapter.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/src/ckboxutils.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxutils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/src/index.ts
+++ b/packages/ckeditor5-ckbox/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/src/utils.ts
+++ b/packages/ckeditor5-ckbox/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/tests/_utils/ckbox-config.js
+++ b/packages/ckeditor5-ckbox/tests/_utils/ckbox-config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/tests/_utils/cloudservicescoremock.js
+++ b/packages/ckeditor5-ckbox/tests/_utils/cloudservicescoremock.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/tests/ckbox.js
+++ b/packages/ckeditor5-ckbox/tests/ckbox.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/tests/ckboxcommand.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/tests/ckboxediting.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditediting.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditui.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/utils.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/tests/ckboxui.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/tests/ckboxuploadadapter.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxuploadadapter.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/tests/ckboxutils.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxutils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/tests/manual/ckbox.js
+++ b/packages/ckeditor5-ckbox/tests/manual/ckbox.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/tests/utils.js
+++ b/packages/ckeditor5-ckbox/tests/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/theme/ckboximageedit.css
+++ b/packages/ckeditor5-ckbox/theme/ckboximageedit.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckbox/webpack.config.js
+++ b/packages/ckeditor5-ckbox/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/LICENSE.md
+++ b/packages/ckeditor5-ckfinder/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 CKFinder feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-ckfinder/docs/_snippets/features/build-ckfinder-source.js
+++ b/packages/ckeditor5-ckfinder/docs/_snippets/features/build-ckfinder-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder-options.js
+++ b/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder-options.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder-upload-only.js
+++ b/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder-upload-only.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder.js
+++ b/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/lang/translations/af.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/ar.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/ast.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/az.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/bg.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/bn.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/bs.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/ca.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/cs.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/da.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/de-ch.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/de.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/el.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/en-au.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/en-gb.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/en.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/eo.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/es-co.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/es.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/et.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/eu.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/fa.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/fi.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/fr.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/gl.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/gu.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/he.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/hi.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/hr.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/hu.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/hy.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/id.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/it.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/ja.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/jv.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/kk.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/km.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/kn.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/ko.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/ku.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/lt.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/lv.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/ms.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/nb.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/ne.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/nl.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/no.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/oc.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/pl.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/pt-br.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/pt.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/ro.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/ru.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/si.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/sk.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/sl.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/sq.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/sr.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/sv.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/th.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/ti.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/tk.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/tr.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/tt.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/ug.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/uk.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/ur.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/uz.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/vi.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/lang/translations/zh.po
+++ b/packages/ckeditor5-ckfinder/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ckfinder/src/augmentation.ts
+++ b/packages/ckeditor5-ckfinder/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/src/ckfinder.ts
+++ b/packages/ckeditor5-ckfinder/src/ckfinder.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/src/ckfindercommand.ts
+++ b/packages/ckeditor5-ckfinder/src/ckfindercommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/src/ckfinderconfig.ts
+++ b/packages/ckeditor5-ckfinder/src/ckfinderconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/src/ckfinderediting.ts
+++ b/packages/ckeditor5-ckfinder/src/ckfinderediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/src/ckfinderui.ts
+++ b/packages/ckeditor5-ckfinder/src/ckfinderui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/src/index.ts
+++ b/packages/ckeditor5-ckfinder/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/tests/ckfinder.js
+++ b/packages/ckeditor5-ckfinder/tests/ckfinder.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/tests/ckfindercommand.js
+++ b/packages/ckeditor5-ckfinder/tests/ckfindercommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/tests/ckfinderediting.js
+++ b/packages/ckeditor5-ckfinder/tests/ckfinderediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/tests/ckfinderui.js
+++ b/packages/ckeditor5-ckfinder/tests/ckfinderui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/tests/manual/ckfinder.js
+++ b/packages/ckeditor5-ckfinder/tests/manual/ckfinder.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ckfinder/webpack.config.js
+++ b/packages/ckeditor5-ckfinder/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/LICENSE.md
+++ b/packages/ckeditor5-clipboard/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Clipboard feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/block-balloon-drag-drop.js
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/block-balloon-drag-drop.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/block-drag-drop.js
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/block-drag-drop.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/build-drag-drop-source.js
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/build-drag-drop-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/build-paste-source.js
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/build-paste-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/drag-drop.js
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/drag-drop.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/hcard.js
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/hcard.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/paste-plain-text.js
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/paste-plain-text.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/lang/translations/af.po
+++ b/packages/ckeditor5-clipboard/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/ar.po
+++ b/packages/ckeditor5-clipboard/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/ast.po
+++ b/packages/ckeditor5-clipboard/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/az.po
+++ b/packages/ckeditor5-clipboard/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/bg.po
+++ b/packages/ckeditor5-clipboard/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/bn.po
+++ b/packages/ckeditor5-clipboard/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/bs.po
+++ b/packages/ckeditor5-clipboard/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/ca.po
+++ b/packages/ckeditor5-clipboard/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/cs.po
+++ b/packages/ckeditor5-clipboard/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/da.po
+++ b/packages/ckeditor5-clipboard/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/de-ch.po
+++ b/packages/ckeditor5-clipboard/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/de.po
+++ b/packages/ckeditor5-clipboard/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/el.po
+++ b/packages/ckeditor5-clipboard/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/en-au.po
+++ b/packages/ckeditor5-clipboard/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/en-gb.po
+++ b/packages/ckeditor5-clipboard/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/en.po
+++ b/packages/ckeditor5-clipboard/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/eo.po
+++ b/packages/ckeditor5-clipboard/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/es-co.po
+++ b/packages/ckeditor5-clipboard/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/es.po
+++ b/packages/ckeditor5-clipboard/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/et.po
+++ b/packages/ckeditor5-clipboard/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/eu.po
+++ b/packages/ckeditor5-clipboard/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/fa.po
+++ b/packages/ckeditor5-clipboard/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/fi.po
+++ b/packages/ckeditor5-clipboard/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/fr.po
+++ b/packages/ckeditor5-clipboard/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/gl.po
+++ b/packages/ckeditor5-clipboard/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/gu.po
+++ b/packages/ckeditor5-clipboard/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/he.po
+++ b/packages/ckeditor5-clipboard/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/hi.po
+++ b/packages/ckeditor5-clipboard/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/hr.po
+++ b/packages/ckeditor5-clipboard/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/hu.po
+++ b/packages/ckeditor5-clipboard/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/hy.po
+++ b/packages/ckeditor5-clipboard/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/id.po
+++ b/packages/ckeditor5-clipboard/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/it.po
+++ b/packages/ckeditor5-clipboard/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/ja.po
+++ b/packages/ckeditor5-clipboard/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/jv.po
+++ b/packages/ckeditor5-clipboard/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/kk.po
+++ b/packages/ckeditor5-clipboard/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/km.po
+++ b/packages/ckeditor5-clipboard/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/kn.po
+++ b/packages/ckeditor5-clipboard/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/ko.po
+++ b/packages/ckeditor5-clipboard/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/ku.po
+++ b/packages/ckeditor5-clipboard/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/lt.po
+++ b/packages/ckeditor5-clipboard/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/lv.po
+++ b/packages/ckeditor5-clipboard/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/ms.po
+++ b/packages/ckeditor5-clipboard/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/nb.po
+++ b/packages/ckeditor5-clipboard/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/ne.po
+++ b/packages/ckeditor5-clipboard/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/nl.po
+++ b/packages/ckeditor5-clipboard/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/no.po
+++ b/packages/ckeditor5-clipboard/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/oc.po
+++ b/packages/ckeditor5-clipboard/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/pl.po
+++ b/packages/ckeditor5-clipboard/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/pt-br.po
+++ b/packages/ckeditor5-clipboard/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/pt.po
+++ b/packages/ckeditor5-clipboard/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/ro.po
+++ b/packages/ckeditor5-clipboard/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/ru.po
+++ b/packages/ckeditor5-clipboard/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/si.po
+++ b/packages/ckeditor5-clipboard/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/sk.po
+++ b/packages/ckeditor5-clipboard/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/sl.po
+++ b/packages/ckeditor5-clipboard/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/sq.po
+++ b/packages/ckeditor5-clipboard/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-clipboard/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/sr.po
+++ b/packages/ckeditor5-clipboard/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/sv.po
+++ b/packages/ckeditor5-clipboard/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/th.po
+++ b/packages/ckeditor5-clipboard/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/ti.po
+++ b/packages/ckeditor5-clipboard/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/tk.po
+++ b/packages/ckeditor5-clipboard/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/tr.po
+++ b/packages/ckeditor5-clipboard/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/tt.po
+++ b/packages/ckeditor5-clipboard/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/ug.po
+++ b/packages/ckeditor5-clipboard/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/uk.po
+++ b/packages/ckeditor5-clipboard/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/ur.po
+++ b/packages/ckeditor5-clipboard/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/uz.po
+++ b/packages/ckeditor5-clipboard/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/vi.po
+++ b/packages/ckeditor5-clipboard/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-clipboard/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/lang/translations/zh.po
+++ b/packages/ckeditor5-clipboard/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-clipboard/src/augmentation.ts
+++ b/packages/ckeditor5-clipboard/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/src/clipboard.ts
+++ b/packages/ckeditor5-clipboard/src/clipboard.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/src/clipboardobserver.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/src/dragdrop.ts
+++ b/packages/ckeditor5-clipboard/src/dragdrop.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/src/dragdropblocktoolbar.ts
+++ b/packages/ckeditor5-clipboard/src/dragdropblocktoolbar.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/src/dragdroptarget.ts
+++ b/packages/ckeditor5-clipboard/src/dragdroptarget.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/src/index.ts
+++ b/packages/ckeditor5-clipboard/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/src/lineview.ts
+++ b/packages/ckeditor5-clipboard/src/lineview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/src/pasteplaintext.ts
+++ b/packages/ckeditor5-clipboard/src/pasteplaintext.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/src/utils/normalizeclipboarddata.ts
+++ b/packages/ckeditor5-clipboard/src/utils/normalizeclipboarddata.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/src/utils/plaintexttohtml.ts
+++ b/packages/ckeditor5-clipboard/src/utils/plaintexttohtml.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.ts
+++ b/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/clipboard.js
+++ b/packages/ckeditor5-clipboard/tests/clipboard.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/clipboardmarkersutils.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardmarkersutils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/clipboardobserver.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/dragdrop.js
+++ b/packages/ckeditor5-clipboard/tests/dragdrop.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/dragdropblocktoolbar.js
+++ b/packages/ckeditor5-clipboard/tests/dragdropblocktoolbar.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/dragdroptarget.js
+++ b/packages/ckeditor5-clipboard/tests/dragdroptarget.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/manual/copycut.js
+++ b/packages/ckeditor5-clipboard/tests/manual/copycut.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/manual/dragdrop-blocks.js
+++ b/packages/ckeditor5-clipboard/tests/manual/dragdrop-blocks.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/manual/dragdrop.js
+++ b/packages/ckeditor5-clipboard/tests/manual/dragdrop.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/manual/dragdroplists.js
+++ b/packages/ckeditor5-clipboard/tests/manual/dragdroplists.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/manual/pasting.js
+++ b/packages/ckeditor5-clipboard/tests/manual/pasting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/pasteplaintext.js
+++ b/packages/ckeditor5-clipboard/tests/pasteplaintext.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/pasting-integration.js
+++ b/packages/ckeditor5-clipboard/tests/pasting-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/utils/customtitleplugin.js
+++ b/packages/ckeditor5-clipboard/tests/utils/customtitleplugin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/utils/normalizeclipboarddata.js
+++ b/packages/ckeditor5-clipboard/tests/utils/normalizeclipboarddata.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/utils/plaintexttohtml.js
+++ b/packages/ckeditor5-clipboard/tests/utils/plaintexttohtml.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/tests/utils/viewtoplaintext.js
+++ b/packages/ckeditor5-clipboard/tests/utils/viewtoplaintext.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-clipboard/theme/clipboard.css
+++ b/packages/ckeditor5-clipboard/theme/clipboard.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/LICENSE.md
+++ b/packages/ckeditor5-cloud-services/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Cloud Services integration** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-cloud-services/src/augmentation.ts
+++ b/packages/ckeditor5-cloud-services/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/src/cloudservices.ts
+++ b/packages/ckeditor5-cloud-services/src/cloudservices.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/src/cloudservicesconfig.ts
+++ b/packages/ckeditor5-cloud-services/src/cloudservicesconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/src/cloudservicescore.ts
+++ b/packages/ckeditor5-cloud-services/src/cloudservicescore.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/src/index.ts
+++ b/packages/ckeditor5-cloud-services/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/src/token/token.ts
+++ b/packages/ckeditor5-cloud-services/src/token/token.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/src/uploadgateway/fileuploader.ts
+++ b/packages/ckeditor5-cloud-services/src/uploadgateway/fileuploader.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/src/uploadgateway/uploadgateway.ts
+++ b/packages/ckeditor5-cloud-services/src/uploadgateway/uploadgateway.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/tests/_utils/cloud-services-config.js
+++ b/packages/ckeditor5-cloud-services/tests/_utils/cloud-services-config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/tests/_utils/tokenmock.js
+++ b/packages/ckeditor5-cloud-services/tests/_utils/tokenmock.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/tests/cloudservices.js
+++ b/packages/ckeditor5-cloud-services/tests/cloudservices.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/tests/cloudservicescore.js
+++ b/packages/ckeditor5-cloud-services/tests/cloudservicescore.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/tests/manual/token.js
+++ b/packages/ckeditor5-cloud-services/tests/manual/token.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/tests/token/token.js
+++ b/packages/ckeditor5-cloud-services/tests/token/token.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/tests/uploadgateway/fileuploader.js
+++ b/packages/ckeditor5-cloud-services/tests/uploadgateway/fileuploader.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/tests/uploadgateway/uploadgateway.js
+++ b/packages/ckeditor5-cloud-services/tests/uploadgateway/uploadgateway.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-cloud-services/webpack.config.js
+++ b/packages/ckeditor5-cloud-services/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/LICENSE.md
+++ b/packages/ckeditor5-code-block/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Code block feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-code-block/docs/_snippets/features/build-code-block-source.js
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/build-code-block-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/docs/_snippets/features/code-block-custom-languages.js
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/code-block-custom-languages.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/docs/_snippets/features/code-block.js
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/code-block.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/lang/translations/af.po
+++ b/packages/ckeditor5-code-block/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/ar.po
+++ b/packages/ckeditor5-code-block/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/ast.po
+++ b/packages/ckeditor5-code-block/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/az.po
+++ b/packages/ckeditor5-code-block/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/bg.po
+++ b/packages/ckeditor5-code-block/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/bn.po
+++ b/packages/ckeditor5-code-block/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/bs.po
+++ b/packages/ckeditor5-code-block/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/ca.po
+++ b/packages/ckeditor5-code-block/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/cs.po
+++ b/packages/ckeditor5-code-block/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/da.po
+++ b/packages/ckeditor5-code-block/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/de-ch.po
+++ b/packages/ckeditor5-code-block/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/de.po
+++ b/packages/ckeditor5-code-block/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/el.po
+++ b/packages/ckeditor5-code-block/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/en-au.po
+++ b/packages/ckeditor5-code-block/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/en-gb.po
+++ b/packages/ckeditor5-code-block/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/en.po
+++ b/packages/ckeditor5-code-block/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/eo.po
+++ b/packages/ckeditor5-code-block/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/es-co.po
+++ b/packages/ckeditor5-code-block/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/es.po
+++ b/packages/ckeditor5-code-block/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/et.po
+++ b/packages/ckeditor5-code-block/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/eu.po
+++ b/packages/ckeditor5-code-block/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/fa.po
+++ b/packages/ckeditor5-code-block/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/fi.po
+++ b/packages/ckeditor5-code-block/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/fr.po
+++ b/packages/ckeditor5-code-block/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/gl.po
+++ b/packages/ckeditor5-code-block/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/gu.po
+++ b/packages/ckeditor5-code-block/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/he.po
+++ b/packages/ckeditor5-code-block/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/hi.po
+++ b/packages/ckeditor5-code-block/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/hr.po
+++ b/packages/ckeditor5-code-block/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/hu.po
+++ b/packages/ckeditor5-code-block/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/hy.po
+++ b/packages/ckeditor5-code-block/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/id.po
+++ b/packages/ckeditor5-code-block/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/it.po
+++ b/packages/ckeditor5-code-block/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/ja.po
+++ b/packages/ckeditor5-code-block/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/jv.po
+++ b/packages/ckeditor5-code-block/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/kk.po
+++ b/packages/ckeditor5-code-block/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/km.po
+++ b/packages/ckeditor5-code-block/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/kn.po
+++ b/packages/ckeditor5-code-block/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/ko.po
+++ b/packages/ckeditor5-code-block/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/ku.po
+++ b/packages/ckeditor5-code-block/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/lt.po
+++ b/packages/ckeditor5-code-block/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/lv.po
+++ b/packages/ckeditor5-code-block/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/ms.po
+++ b/packages/ckeditor5-code-block/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/nb.po
+++ b/packages/ckeditor5-code-block/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/ne.po
+++ b/packages/ckeditor5-code-block/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/nl.po
+++ b/packages/ckeditor5-code-block/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/no.po
+++ b/packages/ckeditor5-code-block/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/oc.po
+++ b/packages/ckeditor5-code-block/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/pl.po
+++ b/packages/ckeditor5-code-block/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/pt-br.po
+++ b/packages/ckeditor5-code-block/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/pt.po
+++ b/packages/ckeditor5-code-block/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/ro.po
+++ b/packages/ckeditor5-code-block/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/ru.po
+++ b/packages/ckeditor5-code-block/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/si.po
+++ b/packages/ckeditor5-code-block/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/sk.po
+++ b/packages/ckeditor5-code-block/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/sl.po
+++ b/packages/ckeditor5-code-block/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/sq.po
+++ b/packages/ckeditor5-code-block/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-code-block/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/sr.po
+++ b/packages/ckeditor5-code-block/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/sv.po
+++ b/packages/ckeditor5-code-block/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/th.po
+++ b/packages/ckeditor5-code-block/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/ti.po
+++ b/packages/ckeditor5-code-block/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/tk.po
+++ b/packages/ckeditor5-code-block/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/tr.po
+++ b/packages/ckeditor5-code-block/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/tt.po
+++ b/packages/ckeditor5-code-block/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/ug.po
+++ b/packages/ckeditor5-code-block/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/uk.po
+++ b/packages/ckeditor5-code-block/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/ur.po
+++ b/packages/ckeditor5-code-block/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/uz.po
+++ b/packages/ckeditor5-code-block/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/vi.po
+++ b/packages/ckeditor5-code-block/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-code-block/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/lang/translations/zh.po
+++ b/packages/ckeditor5-code-block/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-code-block/src/augmentation.ts
+++ b/packages/ckeditor5-code-block/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/src/codeblock.ts
+++ b/packages/ckeditor5-code-block/src/codeblock.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/src/codeblockcommand.ts
+++ b/packages/ckeditor5-code-block/src/codeblockcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/src/codeblockconfig.ts
+++ b/packages/ckeditor5-code-block/src/codeblockconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/src/codeblockediting.ts
+++ b/packages/ckeditor5-code-block/src/codeblockediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/src/codeblockui.ts
+++ b/packages/ckeditor5-code-block/src/codeblockui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/src/converters.ts
+++ b/packages/ckeditor5-code-block/src/converters.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/src/indentcodeblockcommand.ts
+++ b/packages/ckeditor5-code-block/src/indentcodeblockcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/src/index.ts
+++ b/packages/ckeditor5-code-block/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/src/outdentcodeblockcommand.ts
+++ b/packages/ckeditor5-code-block/src/outdentcodeblockcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/src/utils.ts
+++ b/packages/ckeditor5-code-block/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/tests/codeblock-integration.js
+++ b/packages/ckeditor5-code-block/tests/codeblock-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/tests/codeblock.js
+++ b/packages/ckeditor5-code-block/tests/codeblock.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/tests/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/tests/codeblockcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/tests/codeblockui.js
+++ b/packages/ckeditor5-code-block/tests/codeblockui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/tests/indentcodeblockcommand.js
+++ b/packages/ckeditor5-code-block/tests/indentcodeblockcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/tests/manual/codeblock.js
+++ b/packages/ckeditor5-code-block/tests/manual/codeblock.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/tests/manual/rtl.js
+++ b/packages/ckeditor5-code-block/tests/manual/rtl.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/tests/outdentcodeblockcommand.js
+++ b/packages/ckeditor5-code-block/tests/outdentcodeblockcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/tests/utils.js
+++ b/packages/ckeditor5-code-block/tests/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/theme/codeblock.css
+++ b/packages/ckeditor5-code-block/theme/codeblock.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-code-block/webpack.config.js
+++ b/packages/ckeditor5-code-block/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/LICENSE.md
+++ b/packages/ckeditor5-core/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Core editor architecture** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-core/lang/translations/af.po
+++ b/packages/ckeditor5-core/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/ar.po
+++ b/packages/ckeditor5-core/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/ast.po
+++ b/packages/ckeditor5-core/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/az.po
+++ b/packages/ckeditor5-core/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/bg.po
+++ b/packages/ckeditor5-core/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/bn.po
+++ b/packages/ckeditor5-core/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/bs.po
+++ b/packages/ckeditor5-core/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/ca.po
+++ b/packages/ckeditor5-core/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/cs.po
+++ b/packages/ckeditor5-core/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/da.po
+++ b/packages/ckeditor5-core/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/de-ch.po
+++ b/packages/ckeditor5-core/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/de.po
+++ b/packages/ckeditor5-core/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/el.po
+++ b/packages/ckeditor5-core/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/en-au.po
+++ b/packages/ckeditor5-core/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/en-gb.po
+++ b/packages/ckeditor5-core/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/en.po
+++ b/packages/ckeditor5-core/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/eo.po
+++ b/packages/ckeditor5-core/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/es-co.po
+++ b/packages/ckeditor5-core/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/es.po
+++ b/packages/ckeditor5-core/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/et.po
+++ b/packages/ckeditor5-core/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/eu.po
+++ b/packages/ckeditor5-core/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/fa.po
+++ b/packages/ckeditor5-core/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/fi.po
+++ b/packages/ckeditor5-core/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/fr.po
+++ b/packages/ckeditor5-core/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/gl.po
+++ b/packages/ckeditor5-core/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/gu.po
+++ b/packages/ckeditor5-core/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/he.po
+++ b/packages/ckeditor5-core/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/hi.po
+++ b/packages/ckeditor5-core/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/hr.po
+++ b/packages/ckeditor5-core/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/hu.po
+++ b/packages/ckeditor5-core/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/hy.po
+++ b/packages/ckeditor5-core/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/id.po
+++ b/packages/ckeditor5-core/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/it.po
+++ b/packages/ckeditor5-core/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/ja.po
+++ b/packages/ckeditor5-core/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/jv.po
+++ b/packages/ckeditor5-core/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/kk.po
+++ b/packages/ckeditor5-core/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/km.po
+++ b/packages/ckeditor5-core/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/kn.po
+++ b/packages/ckeditor5-core/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/ko.po
+++ b/packages/ckeditor5-core/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/ku.po
+++ b/packages/ckeditor5-core/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/lt.po
+++ b/packages/ckeditor5-core/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/lv.po
+++ b/packages/ckeditor5-core/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/ms.po
+++ b/packages/ckeditor5-core/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/nb.po
+++ b/packages/ckeditor5-core/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/ne.po
+++ b/packages/ckeditor5-core/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/nl.po
+++ b/packages/ckeditor5-core/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/no.po
+++ b/packages/ckeditor5-core/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/oc.po
+++ b/packages/ckeditor5-core/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/pl.po
+++ b/packages/ckeditor5-core/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/pt-br.po
+++ b/packages/ckeditor5-core/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/pt.po
+++ b/packages/ckeditor5-core/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/ro.po
+++ b/packages/ckeditor5-core/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/ru.po
+++ b/packages/ckeditor5-core/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/si.po
+++ b/packages/ckeditor5-core/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/sk.po
+++ b/packages/ckeditor5-core/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/sl.po
+++ b/packages/ckeditor5-core/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/sq.po
+++ b/packages/ckeditor5-core/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-core/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/sr.po
+++ b/packages/ckeditor5-core/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/sv.po
+++ b/packages/ckeditor5-core/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/th.po
+++ b/packages/ckeditor5-core/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/ti.po
+++ b/packages/ckeditor5-core/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/tk.po
+++ b/packages/ckeditor5-core/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/tr.po
+++ b/packages/ckeditor5-core/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/tt.po
+++ b/packages/ckeditor5-core/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/ug.po
+++ b/packages/ckeditor5-core/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/uk.po
+++ b/packages/ckeditor5-core/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/ur.po
+++ b/packages/ckeditor5-core/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/uz.po
+++ b/packages/ckeditor5-core/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/vi.po
+++ b/packages/ckeditor5-core/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-core/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/lang/translations/zh.po
+++ b/packages/ckeditor5-core/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-core/src/accessibility.ts
+++ b/packages/ckeditor5-core/src/accessibility.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/augmentation.ts
+++ b/packages/ckeditor5-core/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/command.ts
+++ b/packages/ckeditor5-core/src/command.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/commandcollection.ts
+++ b/packages/ckeditor5-core/src/commandcollection.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/context.ts
+++ b/packages/ckeditor5-core/src/context.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/contextplugin.ts
+++ b/packages/ckeditor5-core/src/contextplugin.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/editingkeystrokehandler.ts
+++ b/packages/ckeditor5-core/src/editingkeystrokehandler.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/editor/editor.ts
+++ b/packages/ckeditor5-core/src/editor/editor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/editor/editorconfig.ts
+++ b/packages/ckeditor5-core/src/editor/editorconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/editor/utils/attachtoform.ts
+++ b/packages/ckeditor5-core/src/editor/utils/attachtoform.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/editor/utils/dataapimixin.ts
+++ b/packages/ckeditor5-core/src/editor/utils/dataapimixin.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/editor/utils/editorusagedata.ts
+++ b/packages/ckeditor5-core/src/editor/utils/editorusagedata.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/editor/utils/elementapimixin.ts
+++ b/packages/ckeditor5-core/src/editor/utils/elementapimixin.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/editor/utils/securesourceelement.ts
+++ b/packages/ckeditor5-core/src/editor/utils/securesourceelement.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/index.ts
+++ b/packages/ckeditor5-core/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/multicommand.ts
+++ b/packages/ckeditor5-core/src/multicommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/pendingactions.ts
+++ b/packages/ckeditor5-core/src/pendingactions.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/plugin.ts
+++ b/packages/ckeditor5-core/src/plugin.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/plugincollection.ts
+++ b/packages/ckeditor5-core/src/plugincollection.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/src/typings.ts
+++ b/packages/ckeditor5-core/src/typings.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/_utils-tests/articlepluginset.js
+++ b/packages/ckeditor5-core/tests/_utils-tests/articlepluginset.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/_utils-tests/classictesteditor.js
+++ b/packages/ckeditor5-core/tests/_utils-tests/classictesteditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/_utils-tests/cleanup.js
+++ b/packages/ckeditor5-core/tests/_utils-tests/cleanup.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/_utils-tests/createsinonsandbox.js
+++ b/packages/ckeditor5-core/tests/_utils-tests/createsinonsandbox.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/_utils-tests/generatelicensekey.js
+++ b/packages/ckeditor5-core/tests/_utils-tests/generatelicensekey.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/_utils-tests/modeltesteditor.js
+++ b/packages/ckeditor5-core/tests/_utils-tests/modeltesteditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/_utils-tests/utils.js
+++ b/packages/ckeditor5-core/tests/_utils-tests/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/_utils-tests/virtualtesteditor.js
+++ b/packages/ckeditor5-core/tests/_utils-tests/virtualtesteditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/_utils/articlepluginset.js
+++ b/packages/ckeditor5-core/tests/_utils/articlepluginset.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/_utils/classictesteditor.js
+++ b/packages/ckeditor5-core/tests/_utils/classictesteditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/_utils/cleanup.js
+++ b/packages/ckeditor5-core/tests/_utils/cleanup.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/_utils/generatelicensekey.js
+++ b/packages/ckeditor5-core/tests/_utils/generatelicensekey.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/_utils/memory.js
+++ b/packages/ckeditor5-core/tests/_utils/memory.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/_utils/modeltesteditor.js
+++ b/packages/ckeditor5-core/tests/_utils/modeltesteditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/_utils/utils.js
+++ b/packages/ckeditor5-core/tests/_utils/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/_utils/virtualtesteditor.js
+++ b/packages/ckeditor5-core/tests/_utils/virtualtesteditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/accessibility.js
+++ b/packages/ckeditor5-core/tests/accessibility.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/command.js
+++ b/packages/ckeditor5-core/tests/command.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/commandcollection.js
+++ b/packages/ckeditor5-core/tests/commandcollection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/context.js
+++ b/packages/ckeditor5-core/tests/context.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/contextplugin.js
+++ b/packages/ckeditor5-core/tests/contextplugin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/editingkeystrokehandler.js
+++ b/packages/ckeditor5-core/tests/editingkeystrokehandler.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/editor/editor.js
+++ b/packages/ckeditor5-core/tests/editor/editor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/editor/licensecheck.js
+++ b/packages/ckeditor5-core/tests/editor/licensecheck.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/editor/utils/attachtoform.js
+++ b/packages/ckeditor5-core/tests/editor/utils/attachtoform.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/editor/utils/dataapimixin.js
+++ b/packages/ckeditor5-core/tests/editor/utils/dataapimixin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/editor/utils/editorusagedata.js
+++ b/packages/ckeditor5-core/tests/editor/utils/editorusagedata.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/editor/utils/elementapimixin.js
+++ b/packages/ckeditor5-core/tests/editor/utils/elementapimixin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/editor/utils/securesourceelement.js
+++ b/packages/ckeditor5-core/tests/editor/utils/securesourceelement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/manual/formsubmit.js
+++ b/packages/ckeditor5-core/tests/manual/formsubmit.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/manual/pendingactions.js
+++ b/packages/ckeditor5-core/tests/manual/pendingactions.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/manual/readonly.js
+++ b/packages/ckeditor5-core/tests/manual/readonly.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/manual/version-collision.js
+++ b/packages/ckeditor5-core/tests/manual/version-collision.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/multicommand.js
+++ b/packages/ckeditor5-core/tests/multicommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/pendingactions.js
+++ b/packages/ckeditor5-core/tests/pendingactions.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/plugin.js
+++ b/packages/ckeditor5-core/tests/plugin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-core/tests/plugincollection.js
+++ b/packages/ckeditor5-core/tests/plugincollection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-easy-image/LICENSE.md
+++ b/packages/ckeditor5-easy-image/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Easy Image feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-easy-image/docs/_snippets/features/easy-image.js
+++ b/packages/ckeditor5-easy-image/docs/_snippets/features/easy-image.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-easy-image/src/augmentation.ts
+++ b/packages/ckeditor5-easy-image/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-easy-image/src/cloudservicesuploadadapter.ts
+++ b/packages/ckeditor5-easy-image/src/cloudservicesuploadadapter.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-easy-image/src/easyimage.ts
+++ b/packages/ckeditor5-easy-image/src/easyimage.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-easy-image/src/index.ts
+++ b/packages/ckeditor5-easy-image/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-easy-image/tests/_utils/uploadgatewaymock.js
+++ b/packages/ckeditor5-easy-image/tests/_utils/uploadgatewaymock.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-easy-image/tests/cloudservicesuploadadapter.js
+++ b/packages/ckeditor5-easy-image/tests/cloudservicesuploadadapter.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-easy-image/tests/easyimage.js
+++ b/packages/ckeditor5-easy-image/tests/easyimage.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-easy-image/tests/manual/easyimage.js
+++ b/packages/ckeditor5-easy-image/tests/manual/easyimage.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-easy-image/webpack.config.js
+++ b/packages/ckeditor5-easy-image/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-balloon/LICENSE.md
+++ b/packages/ckeditor5-editor-balloon/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Balloon editor** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-editor-balloon/src/ballooneditor.ts
+++ b/packages/ckeditor5-editor-balloon/src/ballooneditor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-balloon/src/ballooneditorui.ts
+++ b/packages/ckeditor5-editor-balloon/src/ballooneditorui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-balloon/src/ballooneditoruiview.ts
+++ b/packages/ckeditor5-editor-balloon/src/ballooneditoruiview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-balloon/src/index.ts
+++ b/packages/ckeditor5-editor-balloon/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-balloon/tests/ballooneditor.js
+++ b/packages/ckeditor5-editor-balloon/tests/ballooneditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-balloon/tests/ballooneditorui.js
+++ b/packages/ckeditor5-editor-balloon/tests/ballooneditorui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-balloon/tests/ballooneditoruiview.js
+++ b/packages/ckeditor5-editor-balloon/tests/ballooneditoruiview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-balloon/tests/manual/ballooneditor-data.js
+++ b/packages/ckeditor5-editor-balloon/tests/manual/ballooneditor-data.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-balloon/tests/manual/ballooneditor.js
+++ b/packages/ckeditor5-editor-balloon/tests/manual/ballooneditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-balloon/tests/manual/memory.js
+++ b/packages/ckeditor5-editor-balloon/tests/manual/memory.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-balloon/tests/manual/placeholder.js
+++ b/packages/ckeditor5-editor-balloon/tests/manual/placeholder.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-balloon/webpack.config.js
+++ b/packages/ckeditor5-editor-balloon/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-classic/LICENSE.md
+++ b/packages/ckeditor5-editor-classic/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Classic editor** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-editor-classic/src/classiceditor.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-classic/src/classiceditorui.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditorui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-classic/src/classiceditoruiview.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditoruiview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-classic/src/index.ts
+++ b/packages/ckeditor5-editor-classic/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-classic/tests/classiceditor.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-classic/tests/classiceditorui.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditorui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-classic/tests/classiceditoruiview.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditoruiview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-classic/tests/manual/classiceditor-data.js
+++ b/packages/ckeditor5-editor-classic/tests/manual/classiceditor-data.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-classic/tests/manual/classiceditor.js
+++ b/packages/ckeditor5-editor-classic/tests/manual/classiceditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-classic/tests/manual/memory.js
+++ b/packages/ckeditor5-editor-classic/tests/manual/memory.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-classic/tests/manual/placeholder.js
+++ b/packages/ckeditor5-editor-classic/tests/manual/placeholder.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-classic/tests/manual/stickypanel.js
+++ b/packages/ckeditor5-editor-classic/tests/manual/stickypanel.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-classic/tests/manual/tickets/60/1.js
+++ b/packages/ckeditor5-editor-classic/tests/manual/tickets/60/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.js
+++ b/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-classic/theme/classiceditor.css
+++ b/packages/ckeditor5-editor-classic/theme/classiceditor.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-classic/webpack.config.js
+++ b/packages/ckeditor5-editor-classic/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-decoupled/LICENSE.md
+++ b/packages/ckeditor5-editor-decoupled/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Decoupled editor** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitor.ts
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitorui.ts
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitorui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitoruiview.ts
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitoruiview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-decoupled/src/index.ts
+++ b/packages/ckeditor5-editor-decoupled/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-decoupled/tests/decouplededitor.js
+++ b/packages/ckeditor5-editor-decoupled/tests/decouplededitor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-decoupled/tests/decouplededitorui.js
+++ b/packages/ckeditor5-editor-decoupled/tests/decouplededitorui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-decoupled/tests/decouplededitoruiview.js
+++ b/packages/ckeditor5-editor-decoupled/tests/decouplededitoruiview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-decoupled/tests/manual/decouplededitor-editable.js
+++ b/packages/ckeditor5-editor-decoupled/tests/manual/decouplededitor-editable.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-decoupled/tests/manual/decouplededitor.js
+++ b/packages/ckeditor5-editor-decoupled/tests/manual/decouplededitor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-decoupled/tests/manual/memory.js
+++ b/packages/ckeditor5-editor-decoupled/tests/manual/memory.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-decoupled/tests/manual/placeholder.js
+++ b/packages/ckeditor5-editor-decoupled/tests/manual/placeholder.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-decoupled/webpack.config.js
+++ b/packages/ckeditor5-editor-decoupled/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/LICENSE.md
+++ b/packages/ckeditor5-editor-inline/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Inline editor** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-editor-inline/src/index.ts
+++ b/packages/ckeditor5-editor-inline/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/src/inlineeditor.ts
+++ b/packages/ckeditor5-editor-inline/src/inlineeditor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/src/inlineeditorui.ts
+++ b/packages/ckeditor5-editor-inline/src/inlineeditorui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/src/inlineeditoruiview.ts
+++ b/packages/ckeditor5-editor-inline/src/inlineeditoruiview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/tests/inlineeditor.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/tests/inlineeditoruiview.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditoruiview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/tests/manual/inlineeditor-data.js
+++ b/packages/ckeditor5-editor-inline/tests/manual/inlineeditor-data.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/tests/manual/inlineeditor.js
+++ b/packages/ckeditor5-editor-inline/tests/manual/inlineeditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/tests/manual/memory.js
+++ b/packages/ckeditor5-editor-inline/tests/manual/memory.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/tests/manual/placeholder.js
+++ b/packages/ckeditor5-editor-inline/tests/manual/placeholder.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/tests/manual/rtl.js
+++ b/packages/ckeditor5-editor-inline/tests/manual/rtl.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/tests/manual/tickets/23/1.js
+++ b/packages/ckeditor5-editor-inline/tests/manual/tickets/23/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/tests/manual/tickets/4/1.js
+++ b/packages/ckeditor5-editor-inline/tests/manual/tickets/4/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.js
+++ b/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/theme/inlineeditor.css
+++ b/packages/ckeditor5-editor-inline/theme/inlineeditor.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-inline/webpack.config.js
+++ b/packages/ckeditor5-editor-inline/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-multi-root/LICENSE.md
+++ b/packages/ckeditor5-editor-multi-root/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Multi-root editor** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-editor-multi-root/src/augmentation.ts
+++ b/packages/ckeditor5-editor-multi-root/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-multi-root/src/index.ts
+++ b/packages/ckeditor5-editor-multi-root/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditorui.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditorui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditoruiview.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditoruiview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-multi-root/tests/manual/memory.js
+++ b/packages/ckeditor5-editor-multi-root/tests/manual/memory.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-multi-root/tests/manual/multirooteditor-detached.js
+++ b/packages/ckeditor5-editor-multi-root/tests/manual/multirooteditor-detached.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-multi-root/tests/manual/multirooteditor.js
+++ b/packages/ckeditor5-editor-multi-root/tests/manual/multirooteditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-multi-root/tests/manual/placeholder.js
+++ b/packages/ckeditor5-editor-multi-root/tests/manual/placeholder.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditorui.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditorui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditoruiview.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditoruiview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-editor-multi-root/webpack.config.js
+++ b/packages/ckeditor5-editor-multi-root/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/LICENSE.md
+++ b/packages/ckeditor5-engine/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Editing engine** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/build-custom-element-converter-source.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/build-custom-element-converter-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/build-element-reconversion-source.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/build-element-reconversion-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/build-extending-content-source.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/build-extending-content-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/element-reconversion-demo.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/element-reconversion-demo.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-add-external-link-target.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-add-external-link-target.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-add-heading-class.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-add-heading-class.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-add-link-class.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-add-link-class.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-add-unsafe-link-class.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-add-unsafe-link-class.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-allow-div-attributes.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-allow-div-attributes.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-allow-link-target.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-allow-link-target.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-arbitrary-attribute-values.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-arbitrary-attribute-values.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-custom-element-converter.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-custom-element-converter.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-custom-figure-attributes.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-custom-figure-attributes.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector-bold.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector-bold.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector-heading-interactive.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector-heading-interactive.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector-heading.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector-heading.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector-paragraph.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector-paragraph.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector-structure.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector-structure.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector-upcast-attribute.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector-upcast-attribute.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector-upcast-element.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector-upcast-element.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/controller/datacontroller.ts
+++ b/packages/ckeditor5-engine/src/controller/datacontroller.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/controller/editingcontroller.ts
+++ b/packages/ckeditor5-engine/src/controller/editingcontroller.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/conversion/conversion.ts
+++ b/packages/ckeditor5-engine/src/conversion/conversion.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/conversion/conversionhelpers.ts
+++ b/packages/ckeditor5-engine/src/conversion/conversionhelpers.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/conversion/downcastdispatcher.ts
+++ b/packages/ckeditor5-engine/src/conversion/downcastdispatcher.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.ts
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/conversion/mapper.ts
+++ b/packages/ckeditor5-engine/src/conversion/mapper.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/conversion/modelconsumable.ts
+++ b/packages/ckeditor5-engine/src/conversion/modelconsumable.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/conversion/upcastdispatcher.ts
+++ b/packages/ckeditor5-engine/src/conversion/upcastdispatcher.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.ts
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/conversion/viewconsumable.ts
+++ b/packages/ckeditor5-engine/src/conversion/viewconsumable.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/dataprocessor/basichtmlwriter.ts
+++ b/packages/ckeditor5-engine/src/dataprocessor/basichtmlwriter.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/dataprocessor/dataprocessor.ts
+++ b/packages/ckeditor5-engine/src/dataprocessor/dataprocessor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/dataprocessor/htmldataprocessor.ts
+++ b/packages/ckeditor5-engine/src/dataprocessor/htmldataprocessor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/dataprocessor/htmlwriter.ts
+++ b/packages/ckeditor5-engine/src/dataprocessor/htmlwriter.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/dataprocessor/xmldataprocessor.ts
+++ b/packages/ckeditor5-engine/src/dataprocessor/xmldataprocessor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/dev-utils/model.ts
+++ b/packages/ckeditor5-engine/src/dev-utils/model.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/dev-utils/operationreplayer.ts
+++ b/packages/ckeditor5-engine/src/dev-utils/operationreplayer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/dev-utils/utils.ts
+++ b/packages/ckeditor5-engine/src/dev-utils/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/dev-utils/view.ts
+++ b/packages/ckeditor5-engine/src/dev-utils/view.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/batch.ts
+++ b/packages/ckeditor5-engine/src/model/batch.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/differ.ts
+++ b/packages/ckeditor5-engine/src/model/differ.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/document.ts
+++ b/packages/ckeditor5-engine/src/model/document.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/documentfragment.ts
+++ b/packages/ckeditor5-engine/src/model/documentfragment.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/documentselection.ts
+++ b/packages/ckeditor5-engine/src/model/documentselection.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/element.ts
+++ b/packages/ckeditor5-engine/src/model/element.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/history.ts
+++ b/packages/ckeditor5-engine/src/model/history.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/item.ts
+++ b/packages/ckeditor5-engine/src/model/item.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/liveposition.ts
+++ b/packages/ckeditor5-engine/src/model/liveposition.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/liverange.ts
+++ b/packages/ckeditor5-engine/src/model/liverange.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/markercollection.ts
+++ b/packages/ckeditor5-engine/src/model/markercollection.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/model.ts
+++ b/packages/ckeditor5-engine/src/model/model.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/node.ts
+++ b/packages/ckeditor5-engine/src/model/node.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/nodelist.ts
+++ b/packages/ckeditor5-engine/src/model/nodelist.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/operation/attributeoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/attributeoperation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/operation/detachoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/detachoperation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/operation/insertoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/insertoperation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/operation/markeroperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/markeroperation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/operation/mergeoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/mergeoperation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/operation/moveoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/moveoperation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/operation/nooperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/nooperation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/operation/operation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/operation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/operation/operationfactory.ts
+++ b/packages/ckeditor5-engine/src/model/operation/operationfactory.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/operation/renameoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/renameoperation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/operation/rootattributeoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/rootattributeoperation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/operation/rootoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/rootoperation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/operation/splitoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/splitoperation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/operation/transform.ts
+++ b/packages/ckeditor5-engine/src/model/operation/transform.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/operation/utils.ts
+++ b/packages/ckeditor5-engine/src/model/operation/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/position.ts
+++ b/packages/ckeditor5-engine/src/model/position.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/range.ts
+++ b/packages/ckeditor5-engine/src/model/range.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/rootelement.ts
+++ b/packages/ckeditor5-engine/src/model/rootelement.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/schema.ts
+++ b/packages/ckeditor5-engine/src/model/schema.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/selection.ts
+++ b/packages/ckeditor5-engine/src/model/selection.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/text.ts
+++ b/packages/ckeditor5-engine/src/model/text.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/textproxy.ts
+++ b/packages/ckeditor5-engine/src/model/textproxy.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/treewalker.ts
+++ b/packages/ckeditor5-engine/src/model/treewalker.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/typecheckable.ts
+++ b/packages/ckeditor5-engine/src/model/typecheckable.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/utils/autoparagraphing.ts
+++ b/packages/ckeditor5-engine/src/model/utils/autoparagraphing.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/utils/deletecontent.ts
+++ b/packages/ckeditor5-engine/src/model/utils/deletecontent.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/utils/getselectedcontent.ts
+++ b/packages/ckeditor5-engine/src/model/utils/getselectedcontent.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/utils/insertcontent.ts
+++ b/packages/ckeditor5-engine/src/model/utils/insertcontent.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/utils/insertobject.ts
+++ b/packages/ckeditor5-engine/src/model/utils/insertobject.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/utils/modifyselection.ts
+++ b/packages/ckeditor5-engine/src/model/utils/modifyselection.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/utils/selection-post-fixer.ts
+++ b/packages/ckeditor5-engine/src/model/utils/selection-post-fixer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/model/writer.ts
+++ b/packages/ckeditor5-engine/src/model/writer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/attributeelement.ts
+++ b/packages/ckeditor5-engine/src/view/attributeelement.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/containerelement.ts
+++ b/packages/ckeditor5-engine/src/view/containerelement.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/datatransfer.ts
+++ b/packages/ckeditor5-engine/src/view/datatransfer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/document.ts
+++ b/packages/ckeditor5-engine/src/view/document.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/documentfragment.ts
+++ b/packages/ckeditor5-engine/src/view/documentfragment.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/documentselection.ts
+++ b/packages/ckeditor5-engine/src/view/documentselection.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/domconverter.ts
+++ b/packages/ckeditor5-engine/src/view/domconverter.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/downcastwriter.ts
+++ b/packages/ckeditor5-engine/src/view/downcastwriter.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/editableelement.ts
+++ b/packages/ckeditor5-engine/src/view/editableelement.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/element.ts
+++ b/packages/ckeditor5-engine/src/view/element.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/elementdefinition.ts
+++ b/packages/ckeditor5-engine/src/view/elementdefinition.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/emptyelement.ts
+++ b/packages/ckeditor5-engine/src/view/emptyelement.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/filler.ts
+++ b/packages/ckeditor5-engine/src/view/filler.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/item.ts
+++ b/packages/ckeditor5-engine/src/view/item.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/matcher.ts
+++ b/packages/ckeditor5-engine/src/view/matcher.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/node.ts
+++ b/packages/ckeditor5-engine/src/view/node.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/arrowkeysobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/arrowkeysobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/bubblingemittermixin.ts
+++ b/packages/ckeditor5-engine/src/view/observer/bubblingemittermixin.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/bubblingeventinfo.ts
+++ b/packages/ckeditor5-engine/src/view/observer/bubblingeventinfo.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/clickobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/clickobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/compositionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/compositionobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/domeventdata.ts
+++ b/packages/ckeditor5-engine/src/view/observer/domeventdata.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/domeventobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/domeventobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/fakeselectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/fakeselectionobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/focusobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/focusobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/inputobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/inputobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/keyobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/keyobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/mouseobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/mouseobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/mutationobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/mutationobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/observer.ts
+++ b/packages/ckeditor5-engine/src/view/observer/observer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/tabobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/tabobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/observer/touchobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/touchobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/placeholder.ts
+++ b/packages/ckeditor5-engine/src/view/placeholder.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/position.ts
+++ b/packages/ckeditor5-engine/src/view/position.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/range.ts
+++ b/packages/ckeditor5-engine/src/view/range.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/rawelement.ts
+++ b/packages/ckeditor5-engine/src/view/rawelement.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/renderer.ts
+++ b/packages/ckeditor5-engine/src/view/renderer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/rooteditableelement.ts
+++ b/packages/ckeditor5-engine/src/view/rooteditableelement.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/selection.ts
+++ b/packages/ckeditor5-engine/src/view/selection.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/styles/background.ts
+++ b/packages/ckeditor5-engine/src/view/styles/background.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/styles/border.ts
+++ b/packages/ckeditor5-engine/src/view/styles/border.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/styles/margin.ts
+++ b/packages/ckeditor5-engine/src/view/styles/margin.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/styles/padding.ts
+++ b/packages/ckeditor5-engine/src/view/styles/padding.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/styles/utils.ts
+++ b/packages/ckeditor5-engine/src/view/styles/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/stylesmap.ts
+++ b/packages/ckeditor5-engine/src/view/stylesmap.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/text.ts
+++ b/packages/ckeditor5-engine/src/view/text.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/textproxy.ts
+++ b/packages/ckeditor5-engine/src/view/textproxy.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/treewalker.ts
+++ b/packages/ckeditor5-engine/src/view/treewalker.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/typecheckable.ts
+++ b/packages/ckeditor5-engine/src/view/typecheckable.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/uielement.ts
+++ b/packages/ckeditor5-engine/src/view/uielement.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/upcastwriter.ts
+++ b/packages/ckeditor5-engine/src/view/upcastwriter.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/src/view/view.ts
+++ b/packages/ckeditor5-engine/src/view/view.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/common.js
+++ b/packages/ckeditor5-engine/tests/common.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/controller/datacontroller.js
+++ b/packages/ckeditor5-engine/tests/controller/datacontroller.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/controller/editingcontroller.js
+++ b/packages/ckeditor5-engine/tests/controller/editingcontroller.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/conversion/conversion.js
+++ b/packages/ckeditor5-engine/tests/conversion/conversion.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/conversion/conversionhelpers.js
+++ b/packages/ckeditor5-engine/tests/conversion/conversionhelpers.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/conversion/downcastdispatcher.js
+++ b/packages/ckeditor5-engine/tests/conversion/downcastdispatcher.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/conversion/downcasthelpers.js
+++ b/packages/ckeditor5-engine/tests/conversion/downcasthelpers.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/conversion/mapper.js
+++ b/packages/ckeditor5-engine/tests/conversion/mapper.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/conversion/modelconsumable.js
+++ b/packages/ckeditor5-engine/tests/conversion/modelconsumable.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/conversion/upcastdispatcher.js
+++ b/packages/ckeditor5-engine/tests/conversion/upcastdispatcher.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/conversion/viewconsumable.js
+++ b/packages/ckeditor5-engine/tests/conversion/viewconsumable.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/dataprocessor/_utils/xsstemplates.js
+++ b/packages/ckeditor5-engine/tests/dataprocessor/_utils/xsstemplates.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/dataprocessor/basichtmlwriter.js
+++ b/packages/ckeditor5-engine/tests/dataprocessor/basichtmlwriter.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/dataprocessor/htmldataprocessor.js
+++ b/packages/ckeditor5-engine/tests/dataprocessor/htmldataprocessor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/dataprocessor/xmldataprocessor.js
+++ b/packages/ckeditor5-engine/tests/dataprocessor/xmldataprocessor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/dev-utils/model.js
+++ b/packages/ckeditor5-engine/tests/dev-utils/model.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/dev-utils/operationreplayer.js
+++ b/packages/ckeditor5-engine/tests/dev-utils/operationreplayer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/dev-utils/view.js
+++ b/packages/ckeditor5-engine/tests/dev-utils/view.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/element-reconversion.js
+++ b/packages/ckeditor5-engine/tests/manual/element-reconversion.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/highlight.js
+++ b/packages/ckeditor5-engine/tests/manual/highlight.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/markers.js
+++ b/packages/ckeditor5-engine/tests/manual/markers.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/nestededitable.css
+++ b/packages/ckeditor5-engine/tests/manual/nestededitable.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/nestededitable.js
+++ b/packages/ckeditor5-engine/tests/manual/nestededitable.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/placeholder.js
+++ b/packages/ckeditor5-engine/tests/manual/placeholder.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/selection.css
+++ b/packages/ckeditor5-engine/tests/manual/selection.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/selection.js
+++ b/packages/ckeditor5-engine/tests/manual/selection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/slot-conversion.js
+++ b/packages/ckeditor5-engine/tests/manual/slot-conversion.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/tickets/10430/1.js
+++ b/packages/ckeditor5-engine/tests/manual/tickets/10430/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/tickets/1088/1.js
+++ b/packages/ckeditor5-engine/tests/manual/tickets/1088/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/tickets/1439/1.js
+++ b/packages/ckeditor5-engine/tests/manual/tickets/1439/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/tickets/401/1.js
+++ b/packages/ckeditor5-engine/tests/manual/tickets/401/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/tickets/4600/1.js
+++ b/packages/ckeditor5-engine/tests/manual/tickets/4600/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/tickets/462/1.js
+++ b/packages/ckeditor5-engine/tests/manual/tickets/462/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/tickets/475/1.js
+++ b/packages/ckeditor5-engine/tests/manual/tickets/475/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/tickets/603/1.js
+++ b/packages/ckeditor5-engine/tests/manual/tickets/603/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/tickets/629/1.js
+++ b/packages/ckeditor5-engine/tests/manual/tickets/629/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/tickets/7892/1.js
+++ b/packages/ckeditor5-engine/tests/manual/tickets/7892/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/tickets/880/1.js
+++ b/packages/ckeditor5-engine/tests/manual/tickets/880/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/tickets/887/1.js
+++ b/packages/ckeditor5-engine/tests/manual/tickets/887/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/tickets/ckeditor5-721/1.js
+++ b/packages/ckeditor5-engine/tests/manual/tickets/ckeditor5-721/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/view/clickobserver.js
+++ b/packages/ckeditor5-engine/tests/manual/view/clickobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/view/compositionobserver.js
+++ b/packages/ckeditor5-engine/tests/manual/view/compositionobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/view/deep-render.js
+++ b/packages/ckeditor5-engine/tests/manual/view/deep-render.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/view/fakeselection.js
+++ b/packages/ckeditor5-engine/tests/manual/view/fakeselection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/view/focus.js
+++ b/packages/ckeditor5-engine/tests/manual/view/focus.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/view/focusobserver.js
+++ b/packages/ckeditor5-engine/tests/manual/view/focusobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/view/immutable.js
+++ b/packages/ckeditor5-engine/tests/manual/view/immutable.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/view/inline-filler.js
+++ b/packages/ckeditor5-engine/tests/manual/view/inline-filler.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/view/keyobserver.js
+++ b/packages/ckeditor5-engine/tests/manual/view/keyobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/view/mutationobserver.js
+++ b/packages/ckeditor5-engine/tests/manual/view/mutationobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/view/noselection-iframe.js
+++ b/packages/ckeditor5-engine/tests/manual/view/noselection-iframe.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/view/noselection.js
+++ b/packages/ckeditor5-engine/tests/manual/view/noselection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/view/selectionobserver.js
+++ b/packages/ckeditor5-engine/tests/manual/view/selectionobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/view/uielement.js
+++ b/packages/ckeditor5-engine/tests/manual/view/uielement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/manual/view/x-index.js
+++ b/packages/ckeditor5-engine/tests/manual/view/x-index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/_utils/utils.js
+++ b/packages/ckeditor5-engine/tests/model/_utils/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/batch.js
+++ b/packages/ckeditor5-engine/tests/model/batch.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/differ.js
+++ b/packages/ckeditor5-engine/tests/model/differ.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/document.js
+++ b/packages/ckeditor5-engine/tests/model/document.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/documentfragment.js
+++ b/packages/ckeditor5-engine/tests/model/documentfragment.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/documentselection.js
+++ b/packages/ckeditor5-engine/tests/model/documentselection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/element.js
+++ b/packages/ckeditor5-engine/tests/model/element.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/history.js
+++ b/packages/ckeditor5-engine/tests/model/history.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/liveposition.js
+++ b/packages/ckeditor5-engine/tests/model/liveposition.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/liverange.js
+++ b/packages/ckeditor5-engine/tests/model/liverange.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/markercollection.js
+++ b/packages/ckeditor5-engine/tests/model/markercollection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/model.js
+++ b/packages/ckeditor5-engine/tests/model/model.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/node.js
+++ b/packages/ckeditor5-engine/tests/model/node.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/nodelist.js
+++ b/packages/ckeditor5-engine/tests/model/nodelist.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/attributeoperation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/attributeoperation.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/detachoperation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/detachoperation.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/insertoperation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/insertoperation.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/markeroperation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/markeroperation.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/mergeoperation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/mergeoperation.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/moveoperation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/moveoperation.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/nooperation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/nooperation.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/operation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/operation.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/operationfactory.js
+++ b/packages/ckeditor5-engine/tests/model/operation/operationfactory.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/renameoperation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/renameoperation.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/rootattributeoperation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/rootattributeoperation.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/rootoperation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/rootoperation.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/splitoperation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/splitoperation.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform/attribute.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/attribute.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform/delete.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/delete.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform/insert.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/insert.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform/marker.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/marker.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform/merge.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/merge.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform/move.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/move.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform/remove.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/remove.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform/rename.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/rename.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform/root.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/root.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform/split.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/split.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform/undo.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/undo.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform/unwrap.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/unwrap.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform/utils.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform/wrap.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/wrap.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/operation/utils.js
+++ b/packages/ckeditor5-engine/tests/model/operation/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/position.js
+++ b/packages/ckeditor5-engine/tests/model/position.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/range.js
+++ b/packages/ckeditor5-engine/tests/model/range.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/rootelement.js
+++ b/packages/ckeditor5-engine/tests/model/rootelement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/schema.js
+++ b/packages/ckeditor5-engine/tests/model/schema.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/selection.js
+++ b/packages/ckeditor5-engine/tests/model/selection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/text.js
+++ b/packages/ckeditor5-engine/tests/model/text.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/textproxy.js
+++ b/packages/ckeditor5-engine/tests/model/textproxy.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/treewalker.js
+++ b/packages/ckeditor5-engine/tests/model/treewalker.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/utils-tests/utils.js
+++ b/packages/ckeditor5-engine/tests/model/utils-tests/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/utils/deletecontent.js
+++ b/packages/ckeditor5-engine/tests/model/utils/deletecontent.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/utils/getselectedcontent.js
+++ b/packages/ckeditor5-engine/tests/model/utils/getselectedcontent.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/utils/insertcontent.js
+++ b/packages/ckeditor5-engine/tests/model/utils/insertcontent.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/utils/insertobject.js
+++ b/packages/ckeditor5-engine/tests/model/utils/insertobject.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/utils/modifyselection.js
+++ b/packages/ckeditor5-engine/tests/model/utils/modifyselection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/utils/selection-post-fixer.js
+++ b/packages/ckeditor5-engine/tests/model/utils/selection-post-fixer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/model/writer.js
+++ b/packages/ckeditor5-engine/tests/model/writer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/tickets/11585.js
+++ b/packages/ckeditor5-engine/tests/tickets/11585.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/tickets/11925.js
+++ b/packages/ckeditor5-engine/tests/tickets/11925.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/tickets/1267.js
+++ b/packages/ckeditor5-engine/tests/tickets/1267.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/tickets/1281.js
+++ b/packages/ckeditor5-engine/tests/tickets/1281.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/tickets/1323.js
+++ b/packages/ckeditor5-engine/tests/tickets/1323.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/tickets/1653.js
+++ b/packages/ckeditor5-engine/tests/tickets/1653.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/tickets/5564.js
+++ b/packages/ckeditor5-engine/tests/tickets/5564.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/tickets/699.js
+++ b/packages/ckeditor5-engine/tests/tickets/699.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/tickets/984.js
+++ b/packages/ckeditor5-engine/tests/tickets/984.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/_utils/createdocumentmock.js
+++ b/packages/ckeditor5-engine/tests/view/_utils/createdocumentmock.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/_utils/createroot.js
+++ b/packages/ckeditor5-engine/tests/view/_utils/createroot.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/attributeelement.js
+++ b/packages/ckeditor5-engine/tests/view/attributeelement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/containerelement.js
+++ b/packages/ckeditor5-engine/tests/view/containerelement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/datatransfer.js
+++ b/packages/ckeditor5-engine/tests/view/datatransfer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/document.js
+++ b/packages/ckeditor5-engine/tests/view/document.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/documentfragment.js
+++ b/packages/ckeditor5-engine/tests/view/documentfragment.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/documentselection.js
+++ b/packages/ckeditor5-engine/tests/view/documentselection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/domconverter/binding.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/binding.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/domconverter/dom-to-view.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/dom-to-view.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/domconverter/rawcontent.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/rawcontent.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/domconverter/rawelement.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/rawelement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/domconverter/uielement.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/uielement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/domconverter/view-to-dom.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/view-to-dom.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/domconverter/whitespace-handling-integration.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/whitespace-handling-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/downcastwriter/breakattributes.js
+++ b/packages/ckeditor5-engine/tests/view/downcastwriter/breakattributes.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/downcastwriter/breakcontainer.js
+++ b/packages/ckeditor5-engine/tests/view/downcastwriter/breakcontainer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/downcastwriter/clear.js
+++ b/packages/ckeditor5-engine/tests/view/downcastwriter/clear.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/downcastwriter/insert.js
+++ b/packages/ckeditor5-engine/tests/view/downcastwriter/insert.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/downcastwriter/mergeattributes.js
+++ b/packages/ckeditor5-engine/tests/view/downcastwriter/mergeattributes.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/downcastwriter/mergecontainers.js
+++ b/packages/ckeditor5-engine/tests/view/downcastwriter/mergecontainers.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/downcastwriter/move.js
+++ b/packages/ckeditor5-engine/tests/view/downcastwriter/move.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/downcastwriter/remove.js
+++ b/packages/ckeditor5-engine/tests/view/downcastwriter/remove.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/downcastwriter/rename.js
+++ b/packages/ckeditor5-engine/tests/view/downcastwriter/rename.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/downcastwriter/unwrap.js
+++ b/packages/ckeditor5-engine/tests/view/downcastwriter/unwrap.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/downcastwriter/wrap.js
+++ b/packages/ckeditor5-engine/tests/view/downcastwriter/wrap.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/downcastwriter/writer.js
+++ b/packages/ckeditor5-engine/tests/view/downcastwriter/writer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/editableelement.js
+++ b/packages/ckeditor5-engine/tests/view/editableelement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/element.js
+++ b/packages/ckeditor5-engine/tests/view/element.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/emptyelement.js
+++ b/packages/ckeditor5-engine/tests/view/emptyelement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/filler.js
+++ b/packages/ckeditor5-engine/tests/view/filler.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/matcher.js
+++ b/packages/ckeditor5-engine/tests/view/matcher.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/node.js
+++ b/packages/ckeditor5-engine/tests/view/node.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/arrowkeysobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/arrowkeysobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/bubblingemittermixin.js
+++ b/packages/ckeditor5-engine/tests/view/observer/bubblingemittermixin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/bubblingeventinfo.js
+++ b/packages/ckeditor5-engine/tests/view/observer/bubblingeventinfo.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/clickobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/clickobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/compositionobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/compositionobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/domeventdata.js
+++ b/packages/ckeditor5-engine/tests/view/observer/domeventdata.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/domeventobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/domeventobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/fakeselectionobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/fakeselectionobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/focusobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/focusobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/inputobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/inputobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/keyobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/keyobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/mouseobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/mouseobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/mutationobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/mutationobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/observer.js
+++ b/packages/ckeditor5-engine/tests/view/observer/observer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/tabobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/tabobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/observer/touchobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/touchobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/placeholder.js
+++ b/packages/ckeditor5-engine/tests/view/placeholder.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/position.js
+++ b/packages/ckeditor5-engine/tests/view/position.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/range.js
+++ b/packages/ckeditor5-engine/tests/view/range.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/rawelement.js
+++ b/packages/ckeditor5-engine/tests/view/rawelement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/renderer.js
+++ b/packages/ckeditor5-engine/tests/view/renderer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/rooteditableelement.js
+++ b/packages/ckeditor5-engine/tests/view/rooteditableelement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/selection.js
+++ b/packages/ckeditor5-engine/tests/view/selection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/styles/background.js
+++ b/packages/ckeditor5-engine/tests/view/styles/background.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/styles/border.js
+++ b/packages/ckeditor5-engine/tests/view/styles/border.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/styles/margin.js
+++ b/packages/ckeditor5-engine/tests/view/styles/margin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/styles/padding.js
+++ b/packages/ckeditor5-engine/tests/view/styles/padding.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/styles/utils.js
+++ b/packages/ckeditor5-engine/tests/view/styles/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/stylesmap.js
+++ b/packages/ckeditor5-engine/tests/view/stylesmap.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/text.js
+++ b/packages/ckeditor5-engine/tests/view/text.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/textproxy.js
+++ b/packages/ckeditor5-engine/tests/view/textproxy.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/treewalker.js
+++ b/packages/ckeditor5-engine/tests/view/treewalker.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/uielement.js
+++ b/packages/ckeditor5-engine/tests/view/uielement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/upcastwriter.js
+++ b/packages/ckeditor5-engine/tests/view/upcastwriter.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/utils-tests/createdocumentmock.js
+++ b/packages/ckeditor5-engine/tests/view/utils-tests/createdocumentmock.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/utils-tests/createroot.js
+++ b/packages/ckeditor5-engine/tests/view/utils-tests/createroot.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/view/jumpoverinlinefiller.js
+++ b/packages/ckeditor5-engine/tests/view/view/jumpoverinlinefiller.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/view/jumpoveruielement.js
+++ b/packages/ckeditor5-engine/tests/view/view/jumpoveruielement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/tests/view/view/view.js
+++ b/packages/ckeditor5-engine/tests/view/view/view.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/theme/placeholder.css
+++ b/packages/ckeditor5-engine/theme/placeholder.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-engine/theme/renderer.css
+++ b/packages/ckeditor5-engine/theme/renderer.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-enter/LICENSE.md
+++ b/packages/ckeditor5-enter/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Enter feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-enter/lang/translations/af.po
+++ b/packages/ckeditor5-enter/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/ar.po
+++ b/packages/ckeditor5-enter/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/ast.po
+++ b/packages/ckeditor5-enter/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/az.po
+++ b/packages/ckeditor5-enter/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/bg.po
+++ b/packages/ckeditor5-enter/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/bn.po
+++ b/packages/ckeditor5-enter/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/bs.po
+++ b/packages/ckeditor5-enter/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/ca.po
+++ b/packages/ckeditor5-enter/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/cs.po
+++ b/packages/ckeditor5-enter/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/da.po
+++ b/packages/ckeditor5-enter/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/de-ch.po
+++ b/packages/ckeditor5-enter/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/de.po
+++ b/packages/ckeditor5-enter/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/el.po
+++ b/packages/ckeditor5-enter/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/en-au.po
+++ b/packages/ckeditor5-enter/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/en-gb.po
+++ b/packages/ckeditor5-enter/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/en.po
+++ b/packages/ckeditor5-enter/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/eo.po
+++ b/packages/ckeditor5-enter/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/es-co.po
+++ b/packages/ckeditor5-enter/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/es.po
+++ b/packages/ckeditor5-enter/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/et.po
+++ b/packages/ckeditor5-enter/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/eu.po
+++ b/packages/ckeditor5-enter/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/fa.po
+++ b/packages/ckeditor5-enter/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/fi.po
+++ b/packages/ckeditor5-enter/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/fr.po
+++ b/packages/ckeditor5-enter/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/gl.po
+++ b/packages/ckeditor5-enter/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/gu.po
+++ b/packages/ckeditor5-enter/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/he.po
+++ b/packages/ckeditor5-enter/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/hi.po
+++ b/packages/ckeditor5-enter/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/hr.po
+++ b/packages/ckeditor5-enter/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/hu.po
+++ b/packages/ckeditor5-enter/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/hy.po
+++ b/packages/ckeditor5-enter/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/id.po
+++ b/packages/ckeditor5-enter/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/it.po
+++ b/packages/ckeditor5-enter/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/ja.po
+++ b/packages/ckeditor5-enter/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/jv.po
+++ b/packages/ckeditor5-enter/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/kk.po
+++ b/packages/ckeditor5-enter/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/km.po
+++ b/packages/ckeditor5-enter/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/kn.po
+++ b/packages/ckeditor5-enter/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/ko.po
+++ b/packages/ckeditor5-enter/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/ku.po
+++ b/packages/ckeditor5-enter/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/lt.po
+++ b/packages/ckeditor5-enter/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/lv.po
+++ b/packages/ckeditor5-enter/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/ms.po
+++ b/packages/ckeditor5-enter/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/nb.po
+++ b/packages/ckeditor5-enter/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/ne.po
+++ b/packages/ckeditor5-enter/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/nl.po
+++ b/packages/ckeditor5-enter/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/no.po
+++ b/packages/ckeditor5-enter/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/oc.po
+++ b/packages/ckeditor5-enter/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/pl.po
+++ b/packages/ckeditor5-enter/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/pt-br.po
+++ b/packages/ckeditor5-enter/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/pt.po
+++ b/packages/ckeditor5-enter/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/ro.po
+++ b/packages/ckeditor5-enter/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/ru.po
+++ b/packages/ckeditor5-enter/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/si.po
+++ b/packages/ckeditor5-enter/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/sk.po
+++ b/packages/ckeditor5-enter/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/sl.po
+++ b/packages/ckeditor5-enter/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/sq.po
+++ b/packages/ckeditor5-enter/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-enter/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/sr.po
+++ b/packages/ckeditor5-enter/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/sv.po
+++ b/packages/ckeditor5-enter/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/th.po
+++ b/packages/ckeditor5-enter/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/ti.po
+++ b/packages/ckeditor5-enter/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/tk.po
+++ b/packages/ckeditor5-enter/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/tr.po
+++ b/packages/ckeditor5-enter/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/tt.po
+++ b/packages/ckeditor5-enter/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/ug.po
+++ b/packages/ckeditor5-enter/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/uk.po
+++ b/packages/ckeditor5-enter/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/ur.po
+++ b/packages/ckeditor5-enter/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/uz.po
+++ b/packages/ckeditor5-enter/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/vi.po
+++ b/packages/ckeditor5-enter/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-enter/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/lang/translations/zh.po
+++ b/packages/ckeditor5-enter/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-enter/src/augmentation.ts
+++ b/packages/ckeditor5-enter/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-enter/src/enter.ts
+++ b/packages/ckeditor5-enter/src/enter.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-enter/src/entercommand.ts
+++ b/packages/ckeditor5-enter/src/entercommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-enter/src/enterobserver.ts
+++ b/packages/ckeditor5-enter/src/enterobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-enter/src/index.ts
+++ b/packages/ckeditor5-enter/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-enter/src/shiftenter.ts
+++ b/packages/ckeditor5-enter/src/shiftenter.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-enter/src/shiftentercommand.ts
+++ b/packages/ckeditor5-enter/src/shiftentercommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-enter/src/utils.ts
+++ b/packages/ckeditor5-enter/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-enter/tests/enter.js
+++ b/packages/ckeditor5-enter/tests/enter.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-enter/tests/entercommand.js
+++ b/packages/ckeditor5-enter/tests/entercommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-enter/tests/enterobserver.js
+++ b/packages/ckeditor5-enter/tests/enterobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-enter/tests/manual/enter.js
+++ b/packages/ckeditor5-enter/tests/manual/enter.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-enter/tests/shiftenter-integration.js
+++ b/packages/ckeditor5-enter/tests/shiftenter-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-enter/tests/shiftenter.js
+++ b/packages/ckeditor5-enter/tests/shiftenter.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-enter/tests/shiftentercommand.js
+++ b/packages/ckeditor5-enter/tests/shiftentercommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-enter/tests/utils.js
+++ b/packages/ckeditor5-enter/tests/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-essentials/LICENSE.md
+++ b/packages/ckeditor5-essentials/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 essentials plugin** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-essentials/src/augmentation.ts
+++ b/packages/ckeditor5-essentials/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-essentials/src/essentials.ts
+++ b/packages/ckeditor5-essentials/src/essentials.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-essentials/src/index.ts
+++ b/packages/ckeditor5-essentials/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-essentials/tests/essentials.js
+++ b/packages/ckeditor5-essentials/tests/essentials.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-essentials/tests/manual/essentials.js
+++ b/packages/ckeditor5-essentials/tests/manual/essentials.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-essentials/webpack.config.js
+++ b/packages/ckeditor5-essentials/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/LICENSE.md
+++ b/packages/ckeditor5-find-and-replace/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Find and replace feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-find-and-replace/docs/_snippets/features/build-find-and-replace-source.js
+++ b/packages/ckeditor5-find-and-replace/docs/_snippets/features/build-find-and-replace-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace-dropdown.js
+++ b/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace-dropdown.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace.js
+++ b/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/lang/translations/af.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/ar.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/ast.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/az.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/bg.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/bn.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/bs.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/ca.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/cs.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/da.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/de-ch.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/de.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/el.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/en-au.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/en-gb.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/en.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/eo.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/es-co.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/es.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/et.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/eu.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/fa.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/fi.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/fr.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/gl.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/gu.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/he.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/hi.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/hr.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/hu.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/hy.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/id.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/it.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/ja.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/jv.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/kk.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/km.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/kn.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/ko.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/ku.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/lt.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/lv.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/ms.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/nb.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/ne.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/nl.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/no.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/oc.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/pl.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/pt-br.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/pt.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/ro.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/ru.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/si.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/sk.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/sl.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/sq.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/sr.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/sv.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/th.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/ti.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/tk.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/tr.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/tt.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/ug.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/uk.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/ur.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/uz.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/vi.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/lang/translations/zh.po
+++ b/packages/ckeditor5-find-and-replace/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-find-and-replace/src/augmentation.ts
+++ b/packages/ckeditor5-find-and-replace/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/src/findandreplace.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplace.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceconfig.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceediting.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/src/findandreplacestate.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplacestate.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceui.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceutils.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceutils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/src/findcommand.ts
+++ b/packages/ckeditor5-find-and-replace/src/findcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/src/findnextcommand.ts
+++ b/packages/ckeditor5-find-and-replace/src/findnextcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/src/findpreviouscommand.ts
+++ b/packages/ckeditor5-find-and-replace/src/findpreviouscommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/src/index.ts
+++ b/packages/ckeditor5-find-and-replace/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/src/replaceallcommand.ts
+++ b/packages/ckeditor5-find-and-replace/src/replaceallcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/src/replacecommand.ts
+++ b/packages/ckeditor5-find-and-replace/src/replacecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/src/replacecommandbase.ts
+++ b/packages/ckeditor5-find-and-replace/src/replacecommandbase.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.ts
+++ b/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/tests/findandreplace.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplace.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/tests/findandreplaceediting.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplaceediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/tests/findandreplacestate.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplacestate.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/tests/findandreplaceui.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplaceui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/tests/findandreplaceutils.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplaceutils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/tests/findcommand.js
+++ b/packages/ckeditor5-find-and-replace/tests/findcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/tests/findnextcommand.js
+++ b/packages/ckeditor5-find-and-replace/tests/findnextcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/tests/findpreviouscommand.js
+++ b/packages/ckeditor5-find-and-replace/tests/findpreviouscommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/tests/manual/findandreplace.js
+++ b/packages/ckeditor5-find-and-replace/tests/manual/findandreplace.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/tests/manual/multiroot.js
+++ b/packages/ckeditor5-find-and-replace/tests/manual/multiroot.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/tests/manual/scrolling.js
+++ b/packages/ckeditor5-find-and-replace/tests/manual/scrolling.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/tests/replaceallcommand.js
+++ b/packages/ckeditor5-find-and-replace/tests/replaceallcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/tests/replacecommand.js
+++ b/packages/ckeditor5-find-and-replace/tests/replacecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/tests/ui/findandreplaceformview.js
+++ b/packages/ckeditor5-find-and-replace/tests/ui/findandreplaceformview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/theme/findandreplace.css
+++ b/packages/ckeditor5-find-and-replace/theme/findandreplace.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/theme/findandreplaceform.css
+++ b/packages/ckeditor5-find-and-replace/theme/findandreplaceform.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-find-and-replace/webpack.config.js
+++ b/packages/ckeditor5-find-and-replace/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/LICENSE.md
+++ b/packages/ckeditor5-font/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Font feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-font/docs/_snippets/features/build-font-source.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/build-font-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-color-and-background-color-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-color-and-background-color-options.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-family-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-family-options.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-named-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-named-options.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-numeric-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-numeric-options.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/docs/_snippets/features/font.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/font.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/lang/translations/af.po
+++ b/packages/ckeditor5-font/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/ar.po
+++ b/packages/ckeditor5-font/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/ast.po
+++ b/packages/ckeditor5-font/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/az.po
+++ b/packages/ckeditor5-font/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/bg.po
+++ b/packages/ckeditor5-font/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/bn.po
+++ b/packages/ckeditor5-font/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/bs.po
+++ b/packages/ckeditor5-font/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/ca.po
+++ b/packages/ckeditor5-font/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/cs.po
+++ b/packages/ckeditor5-font/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/da.po
+++ b/packages/ckeditor5-font/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/de-ch.po
+++ b/packages/ckeditor5-font/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/de.po
+++ b/packages/ckeditor5-font/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/el.po
+++ b/packages/ckeditor5-font/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/en-au.po
+++ b/packages/ckeditor5-font/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/en-gb.po
+++ b/packages/ckeditor5-font/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/en.po
+++ b/packages/ckeditor5-font/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/eo.po
+++ b/packages/ckeditor5-font/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/es-co.po
+++ b/packages/ckeditor5-font/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/es.po
+++ b/packages/ckeditor5-font/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/et.po
+++ b/packages/ckeditor5-font/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/eu.po
+++ b/packages/ckeditor5-font/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/fa.po
+++ b/packages/ckeditor5-font/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/fi.po
+++ b/packages/ckeditor5-font/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/fr.po
+++ b/packages/ckeditor5-font/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/gl.po
+++ b/packages/ckeditor5-font/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/gu.po
+++ b/packages/ckeditor5-font/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/he.po
+++ b/packages/ckeditor5-font/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/hi.po
+++ b/packages/ckeditor5-font/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/hr.po
+++ b/packages/ckeditor5-font/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/hu.po
+++ b/packages/ckeditor5-font/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/hy.po
+++ b/packages/ckeditor5-font/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/id.po
+++ b/packages/ckeditor5-font/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/it.po
+++ b/packages/ckeditor5-font/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/ja.po
+++ b/packages/ckeditor5-font/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/jv.po
+++ b/packages/ckeditor5-font/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/kk.po
+++ b/packages/ckeditor5-font/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/km.po
+++ b/packages/ckeditor5-font/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/kn.po
+++ b/packages/ckeditor5-font/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/ko.po
+++ b/packages/ckeditor5-font/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/ku.po
+++ b/packages/ckeditor5-font/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/lt.po
+++ b/packages/ckeditor5-font/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/lv.po
+++ b/packages/ckeditor5-font/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/ms.po
+++ b/packages/ckeditor5-font/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/nb.po
+++ b/packages/ckeditor5-font/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/ne.po
+++ b/packages/ckeditor5-font/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/nl.po
+++ b/packages/ckeditor5-font/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/no.po
+++ b/packages/ckeditor5-font/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/oc.po
+++ b/packages/ckeditor5-font/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/pl.po
+++ b/packages/ckeditor5-font/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/pt-br.po
+++ b/packages/ckeditor5-font/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/pt.po
+++ b/packages/ckeditor5-font/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/ro.po
+++ b/packages/ckeditor5-font/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/ru.po
+++ b/packages/ckeditor5-font/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/si.po
+++ b/packages/ckeditor5-font/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/sk.po
+++ b/packages/ckeditor5-font/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/sl.po
+++ b/packages/ckeditor5-font/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/sq.po
+++ b/packages/ckeditor5-font/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-font/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/sr.po
+++ b/packages/ckeditor5-font/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/sv.po
+++ b/packages/ckeditor5-font/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/th.po
+++ b/packages/ckeditor5-font/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/ti.po
+++ b/packages/ckeditor5-font/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/tk.po
+++ b/packages/ckeditor5-font/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/tr.po
+++ b/packages/ckeditor5-font/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/tt.po
+++ b/packages/ckeditor5-font/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/ug.po
+++ b/packages/ckeditor5-font/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/uk.po
+++ b/packages/ckeditor5-font/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/ur.po
+++ b/packages/ckeditor5-font/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/uz.po
+++ b/packages/ckeditor5-font/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/vi.po
+++ b/packages/ckeditor5-font/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-font/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/lang/translations/zh.po
+++ b/packages/ckeditor5-font/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-font/src/augmentation.ts
+++ b/packages/ckeditor5-font/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/font.ts
+++ b/packages/ckeditor5-font/src/font.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontbackgroundcolor.ts
+++ b/packages/ckeditor5-font/src/fontbackgroundcolor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorcommand.ts
+++ b/packages/ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorediting.ts
+++ b/packages/ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorui.ts
+++ b/packages/ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontcolor.ts
+++ b/packages/ckeditor5-font/src/fontcolor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontcolor/fontcolorcommand.ts
+++ b/packages/ckeditor5-font/src/fontcolor/fontcolorcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontcolor/fontcolorediting.ts
+++ b/packages/ckeditor5-font/src/fontcolor/fontcolorediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontcolor/fontcolorui.ts
+++ b/packages/ckeditor5-font/src/fontcolor/fontcolorui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontcommand.ts
+++ b/packages/ckeditor5-font/src/fontcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontconfig.ts
+++ b/packages/ckeditor5-font/src/fontconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontfamily.ts
+++ b/packages/ckeditor5-font/src/fontfamily.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontfamily/fontfamilycommand.ts
+++ b/packages/ckeditor5-font/src/fontfamily/fontfamilycommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontfamily/fontfamilyediting.ts
+++ b/packages/ckeditor5-font/src/fontfamily/fontfamilyediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontfamily/fontfamilyui.ts
+++ b/packages/ckeditor5-font/src/fontfamily/fontfamilyui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontfamily/utils.ts
+++ b/packages/ckeditor5-font/src/fontfamily/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontsize.ts
+++ b/packages/ckeditor5-font/src/fontsize.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontsize/fontsizecommand.ts
+++ b/packages/ckeditor5-font/src/fontsize/fontsizecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontsize/fontsizeediting.ts
+++ b/packages/ckeditor5-font/src/fontsize/fontsizeediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontsize/fontsizeui.ts
+++ b/packages/ckeditor5-font/src/fontsize/fontsizeui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/fontsize/utils.ts
+++ b/packages/ckeditor5-font/src/fontsize/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/index.ts
+++ b/packages/ckeditor5-font/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/ui/colorui.ts
+++ b/packages/ckeditor5-font/src/ui/colorui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/src/utils.ts
+++ b/packages/ckeditor5-font/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/_utils/testcolorplugin.js
+++ b/packages/ckeditor5-font/tests/_utils/testcolorplugin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/font.js
+++ b/packages/ckeditor5-font/tests/font.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontbackgroundcolor.js
+++ b/packages/ckeditor5-font/tests/fontbackgroundcolor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontbackgroundcolor/fontbackgroundcolorcommand.js
+++ b/packages/ckeditor5-font/tests/fontbackgroundcolor/fontbackgroundcolorcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontbackgroundcolor/fontbackgroundcoloreditng.js
+++ b/packages/ckeditor5-font/tests/fontbackgroundcolor/fontbackgroundcoloreditng.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontbackgroundcolor/fontbackgroundcolorui.js
+++ b/packages/ckeditor5-font/tests/fontbackgroundcolor/fontbackgroundcolorui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontcolor.js
+++ b/packages/ckeditor5-font/tests/fontcolor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontcolor/fontcolorcommand.js
+++ b/packages/ckeditor5-font/tests/fontcolor/fontcolorcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontcolor/fontcolorediting.js
+++ b/packages/ckeditor5-font/tests/fontcolor/fontcolorediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontcolor/fontcolorui.js
+++ b/packages/ckeditor5-font/tests/fontcolor/fontcolorui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontcommand.js
+++ b/packages/ckeditor5-font/tests/fontcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontfamily.js
+++ b/packages/ckeditor5-font/tests/fontfamily.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontfamily/fontfamilycommand.js
+++ b/packages/ckeditor5-font/tests/fontfamily/fontfamilycommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontfamily/fontfamilyediting.js
+++ b/packages/ckeditor5-font/tests/fontfamily/fontfamilyediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontfamily/fontfamilyui.js
+++ b/packages/ckeditor5-font/tests/fontfamily/fontfamilyui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontfamily/utils.js
+++ b/packages/ckeditor5-font/tests/fontfamily/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontsize.js
+++ b/packages/ckeditor5-font/tests/fontsize.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontsize/fontsizecommand.js
+++ b/packages/ckeditor5-font/tests/fontsize/fontsizecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontsize/fontsizeui.js
+++ b/packages/ckeditor5-font/tests/fontsize/fontsizeui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontsize/integration.js
+++ b/packages/ckeditor5-font/tests/fontsize/integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/fontsize/utils.js
+++ b/packages/ckeditor5-font/tests/fontsize/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/integration.js
+++ b/packages/ckeditor5-font/tests/integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/manual/font-color-picker.js
+++ b/packages/ckeditor5-font/tests/manual/font-color-picker.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/manual/font-color.js
+++ b/packages/ckeditor5-font/tests/manual/font-color.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/manual/font-family.js
+++ b/packages/ckeditor5-font/tests/manual/font-family.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/manual/font-size-numeric.js
+++ b/packages/ckeditor5-font/tests/manual/font-size-numeric.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/manual/font-size-presets.js
+++ b/packages/ckeditor5-font/tests/manual/font-size-presets.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/manual/tickets/15580/1.js
+++ b/packages/ckeditor5-font/tests/manual/tickets/15580/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/manual/tickets/8233/1.js
+++ b/packages/ckeditor5-font/tests/manual/tickets/8233/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/ui/colorselectorview.js
+++ b/packages/ckeditor5-font/tests/ui/colorselectorview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/ui/colorui.js
+++ b/packages/ckeditor5-font/tests/ui/colorui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/tests/utils.js
+++ b/packages/ckeditor5-font/tests/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/theme/fontsize.css
+++ b/packages/ckeditor5-font/theme/fontsize.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-font/webpack.config.js
+++ b/packages/ckeditor5-font/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/LICENSE.md
+++ b/packages/ckeditor5-heading/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Headings feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-heading/docs/_snippets/features/custom-heading-buttons.js
+++ b/packages/ckeditor5-heading/docs/_snippets/features/custom-heading-buttons.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/docs/_snippets/features/custom-heading-elements.js
+++ b/packages/ckeditor5-heading/docs/_snippets/features/custom-heading-elements.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/docs/_snippets/features/custom-heading-levels.js
+++ b/packages/ckeditor5-heading/docs/_snippets/features/custom-heading-levels.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/docs/_snippets/features/default-headings.js
+++ b/packages/ckeditor5-heading/docs/_snippets/features/default-headings.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/docs/_snippets/features/heading-buttons.js
+++ b/packages/ckeditor5-heading/docs/_snippets/features/heading-buttons.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/docs/_snippets/features/heading-source.js
+++ b/packages/ckeditor5-heading/docs/_snippets/features/heading-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/docs/_snippets/features/title.js
+++ b/packages/ckeditor5-heading/docs/_snippets/features/title.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/lang/translations/af.po
+++ b/packages/ckeditor5-heading/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/ar.po
+++ b/packages/ckeditor5-heading/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/ast.po
+++ b/packages/ckeditor5-heading/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/az.po
+++ b/packages/ckeditor5-heading/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/bg.po
+++ b/packages/ckeditor5-heading/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/bn.po
+++ b/packages/ckeditor5-heading/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/bs.po
+++ b/packages/ckeditor5-heading/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/ca.po
+++ b/packages/ckeditor5-heading/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/cs.po
+++ b/packages/ckeditor5-heading/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/da.po
+++ b/packages/ckeditor5-heading/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/de-ch.po
+++ b/packages/ckeditor5-heading/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/de.po
+++ b/packages/ckeditor5-heading/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/el.po
+++ b/packages/ckeditor5-heading/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/en-au.po
+++ b/packages/ckeditor5-heading/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/en-gb.po
+++ b/packages/ckeditor5-heading/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/en.po
+++ b/packages/ckeditor5-heading/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/eo.po
+++ b/packages/ckeditor5-heading/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/es-co.po
+++ b/packages/ckeditor5-heading/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/es.po
+++ b/packages/ckeditor5-heading/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/et.po
+++ b/packages/ckeditor5-heading/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/eu.po
+++ b/packages/ckeditor5-heading/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/fa.po
+++ b/packages/ckeditor5-heading/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/fi.po
+++ b/packages/ckeditor5-heading/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/fr.po
+++ b/packages/ckeditor5-heading/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/gl.po
+++ b/packages/ckeditor5-heading/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/gu.po
+++ b/packages/ckeditor5-heading/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/he.po
+++ b/packages/ckeditor5-heading/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/hi.po
+++ b/packages/ckeditor5-heading/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/hr.po
+++ b/packages/ckeditor5-heading/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/hu.po
+++ b/packages/ckeditor5-heading/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/hy.po
+++ b/packages/ckeditor5-heading/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/id.po
+++ b/packages/ckeditor5-heading/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/it.po
+++ b/packages/ckeditor5-heading/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/ja.po
+++ b/packages/ckeditor5-heading/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/jv.po
+++ b/packages/ckeditor5-heading/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/kk.po
+++ b/packages/ckeditor5-heading/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/km.po
+++ b/packages/ckeditor5-heading/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/kn.po
+++ b/packages/ckeditor5-heading/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/ko.po
+++ b/packages/ckeditor5-heading/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/ku.po
+++ b/packages/ckeditor5-heading/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/lt.po
+++ b/packages/ckeditor5-heading/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/lv.po
+++ b/packages/ckeditor5-heading/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/ms.po
+++ b/packages/ckeditor5-heading/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/nb.po
+++ b/packages/ckeditor5-heading/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/ne.po
+++ b/packages/ckeditor5-heading/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/nl.po
+++ b/packages/ckeditor5-heading/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/no.po
+++ b/packages/ckeditor5-heading/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/oc.po
+++ b/packages/ckeditor5-heading/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/pl.po
+++ b/packages/ckeditor5-heading/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/pt-br.po
+++ b/packages/ckeditor5-heading/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/pt.po
+++ b/packages/ckeditor5-heading/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/ro.po
+++ b/packages/ckeditor5-heading/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/ru.po
+++ b/packages/ckeditor5-heading/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/si.po
+++ b/packages/ckeditor5-heading/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/sk.po
+++ b/packages/ckeditor5-heading/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/sl.po
+++ b/packages/ckeditor5-heading/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/sq.po
+++ b/packages/ckeditor5-heading/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-heading/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/sr.po
+++ b/packages/ckeditor5-heading/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/sv.po
+++ b/packages/ckeditor5-heading/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/th.po
+++ b/packages/ckeditor5-heading/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/ti.po
+++ b/packages/ckeditor5-heading/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/tk.po
+++ b/packages/ckeditor5-heading/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/tr.po
+++ b/packages/ckeditor5-heading/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/tt.po
+++ b/packages/ckeditor5-heading/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/ug.po
+++ b/packages/ckeditor5-heading/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/uk.po
+++ b/packages/ckeditor5-heading/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/ur.po
+++ b/packages/ckeditor5-heading/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/uz.po
+++ b/packages/ckeditor5-heading/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/vi.po
+++ b/packages/ckeditor5-heading/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-heading/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/lang/translations/zh.po
+++ b/packages/ckeditor5-heading/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-heading/src/augmentation.ts
+++ b/packages/ckeditor5-heading/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/src/heading.ts
+++ b/packages/ckeditor5-heading/src/heading.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/src/headingbuttonsui.ts
+++ b/packages/ckeditor5-heading/src/headingbuttonsui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/src/headingcommand.ts
+++ b/packages/ckeditor5-heading/src/headingcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/src/headingconfig.ts
+++ b/packages/ckeditor5-heading/src/headingconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/src/headingediting.ts
+++ b/packages/ckeditor5-heading/src/headingediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/src/headingui.ts
+++ b/packages/ckeditor5-heading/src/headingui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/src/index.ts
+++ b/packages/ckeditor5-heading/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/src/title.ts
+++ b/packages/ckeditor5-heading/src/title.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/src/utils.ts
+++ b/packages/ckeditor5-heading/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/tests/heading.js
+++ b/packages/ckeditor5-heading/tests/heading.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/tests/headingbuttonsui.js
+++ b/packages/ckeditor5-heading/tests/headingbuttonsui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/tests/headingcommand.js
+++ b/packages/ckeditor5-heading/tests/headingcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/tests/headingediting.js
+++ b/packages/ckeditor5-heading/tests/headingediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/tests/headingui.js
+++ b/packages/ckeditor5-heading/tests/headingui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/tests/integration.js
+++ b/packages/ckeditor5-heading/tests/integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/tests/manual/heading-buttons.js
+++ b/packages/ckeditor5-heading/tests/manual/heading-buttons.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/tests/manual/heading.js
+++ b/packages/ckeditor5-heading/tests/manual/heading.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/tests/manual/title.js
+++ b/packages/ckeditor5-heading/tests/manual/title.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/tests/tickets/40.js
+++ b/packages/ckeditor5-heading/tests/tickets/40.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/tests/title-integration.js
+++ b/packages/ckeditor5-heading/tests/title-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/tests/title.js
+++ b/packages/ckeditor5-heading/tests/title.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/tests/utils.js
+++ b/packages/ckeditor5-heading/tests/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/theme/heading.css
+++ b/packages/ckeditor5-heading/theme/heading.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-heading/webpack.config.js
+++ b/packages/ckeditor5-heading/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/LICENSE.md
+++ b/packages/ckeditor5-highlight/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Highlight feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-highlight/docs/_snippets/features/build-highlight-source.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/build-highlight-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-colors-inline.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-colors-inline.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-colors-variables.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-colors-variables.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-options.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-options.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/docs/_snippets/features/highlight-buttons.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/highlight-buttons.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/docs/_snippets/features/highlight.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/highlight.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/lang/translations/af.po
+++ b/packages/ckeditor5-highlight/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/ar.po
+++ b/packages/ckeditor5-highlight/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/ast.po
+++ b/packages/ckeditor5-highlight/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/az.po
+++ b/packages/ckeditor5-highlight/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/bg.po
+++ b/packages/ckeditor5-highlight/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/bn.po
+++ b/packages/ckeditor5-highlight/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/bs.po
+++ b/packages/ckeditor5-highlight/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/ca.po
+++ b/packages/ckeditor5-highlight/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/cs.po
+++ b/packages/ckeditor5-highlight/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/da.po
+++ b/packages/ckeditor5-highlight/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/de-ch.po
+++ b/packages/ckeditor5-highlight/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/de.po
+++ b/packages/ckeditor5-highlight/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/el.po
+++ b/packages/ckeditor5-highlight/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/en-au.po
+++ b/packages/ckeditor5-highlight/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/en-gb.po
+++ b/packages/ckeditor5-highlight/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/en.po
+++ b/packages/ckeditor5-highlight/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/eo.po
+++ b/packages/ckeditor5-highlight/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/es-co.po
+++ b/packages/ckeditor5-highlight/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/es.po
+++ b/packages/ckeditor5-highlight/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/et.po
+++ b/packages/ckeditor5-highlight/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/eu.po
+++ b/packages/ckeditor5-highlight/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/fa.po
+++ b/packages/ckeditor5-highlight/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/fi.po
+++ b/packages/ckeditor5-highlight/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/fr.po
+++ b/packages/ckeditor5-highlight/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/gl.po
+++ b/packages/ckeditor5-highlight/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/gu.po
+++ b/packages/ckeditor5-highlight/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/he.po
+++ b/packages/ckeditor5-highlight/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/hi.po
+++ b/packages/ckeditor5-highlight/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/hr.po
+++ b/packages/ckeditor5-highlight/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/hu.po
+++ b/packages/ckeditor5-highlight/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/hy.po
+++ b/packages/ckeditor5-highlight/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/id.po
+++ b/packages/ckeditor5-highlight/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/it.po
+++ b/packages/ckeditor5-highlight/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/ja.po
+++ b/packages/ckeditor5-highlight/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/jv.po
+++ b/packages/ckeditor5-highlight/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/kk.po
+++ b/packages/ckeditor5-highlight/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/km.po
+++ b/packages/ckeditor5-highlight/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/kn.po
+++ b/packages/ckeditor5-highlight/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/ko.po
+++ b/packages/ckeditor5-highlight/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/ku.po
+++ b/packages/ckeditor5-highlight/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/lt.po
+++ b/packages/ckeditor5-highlight/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/lv.po
+++ b/packages/ckeditor5-highlight/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/ms.po
+++ b/packages/ckeditor5-highlight/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/nb.po
+++ b/packages/ckeditor5-highlight/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/ne.po
+++ b/packages/ckeditor5-highlight/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/nl.po
+++ b/packages/ckeditor5-highlight/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/no.po
+++ b/packages/ckeditor5-highlight/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/oc.po
+++ b/packages/ckeditor5-highlight/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/pl.po
+++ b/packages/ckeditor5-highlight/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/pt-br.po
+++ b/packages/ckeditor5-highlight/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/pt.po
+++ b/packages/ckeditor5-highlight/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/ro.po
+++ b/packages/ckeditor5-highlight/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/ru.po
+++ b/packages/ckeditor5-highlight/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/si.po
+++ b/packages/ckeditor5-highlight/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/sk.po
+++ b/packages/ckeditor5-highlight/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/sl.po
+++ b/packages/ckeditor5-highlight/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/sq.po
+++ b/packages/ckeditor5-highlight/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-highlight/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/sr.po
+++ b/packages/ckeditor5-highlight/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/sv.po
+++ b/packages/ckeditor5-highlight/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/th.po
+++ b/packages/ckeditor5-highlight/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/ti.po
+++ b/packages/ckeditor5-highlight/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/tk.po
+++ b/packages/ckeditor5-highlight/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/tr.po
+++ b/packages/ckeditor5-highlight/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/tt.po
+++ b/packages/ckeditor5-highlight/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/ug.po
+++ b/packages/ckeditor5-highlight/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/uk.po
+++ b/packages/ckeditor5-highlight/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/ur.po
+++ b/packages/ckeditor5-highlight/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/uz.po
+++ b/packages/ckeditor5-highlight/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/vi.po
+++ b/packages/ckeditor5-highlight/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-highlight/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/lang/translations/zh.po
+++ b/packages/ckeditor5-highlight/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-highlight/src/augmentation.ts
+++ b/packages/ckeditor5-highlight/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/src/highlight.ts
+++ b/packages/ckeditor5-highlight/src/highlight.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/src/highlightcommand.ts
+++ b/packages/ckeditor5-highlight/src/highlightcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/src/highlightconfig.ts
+++ b/packages/ckeditor5-highlight/src/highlightconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/src/highlightediting.ts
+++ b/packages/ckeditor5-highlight/src/highlightediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/src/highlightui.ts
+++ b/packages/ckeditor5-highlight/src/highlightui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/src/index.ts
+++ b/packages/ckeditor5-highlight/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/tests/highlight.js
+++ b/packages/ckeditor5-highlight/tests/highlight.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/tests/highlightcommand.js
+++ b/packages/ckeditor5-highlight/tests/highlightcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/tests/highlightediting.js
+++ b/packages/ckeditor5-highlight/tests/highlightediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/tests/highlightui.js
+++ b/packages/ckeditor5-highlight/tests/highlightui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/tests/integration.js
+++ b/packages/ckeditor5-highlight/tests/integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/tests/manual/highlight-buttons.js
+++ b/packages/ckeditor5-highlight/tests/manual/highlight-buttons.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/tests/manual/highlight.js
+++ b/packages/ckeditor5-highlight/tests/manual/highlight.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/theme/highlight.css
+++ b/packages/ckeditor5-highlight/theme/highlight.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-highlight/webpack.config.js
+++ b/packages/ckeditor5-highlight/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-horizontal-line/LICENSE.md
+++ b/packages/ckeditor5-horizontal-line/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Horizontal line feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-horizontal-line/docs/_snippets/features/horizontal-line.js
+++ b/packages/ckeditor5-horizontal-line/docs/_snippets/features/horizontal-line.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-horizontal-line/lang/translations/af.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/ar.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/ast.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/az.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/bg.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/bn.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/bs.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/ca.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/cs.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/da.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/de-ch.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/de.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/el.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/en-au.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/en-gb.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/en.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/eo.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/es-co.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/es.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/et.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/eu.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/fa.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/fi.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/fr.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/gl.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/gu.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/he.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/hi.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/hr.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/hu.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/hy.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/id.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/it.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/ja.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/jv.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/kk.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/km.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/kn.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/ko.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/ku.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/lt.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/lv.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/ms.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/nb.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/ne.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/nl.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/no.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/oc.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/pl.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/pt-br.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/pt.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/ro.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/ru.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/si.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/sk.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/sl.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/sq.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/sr.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/sv.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/th.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/ti.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/tk.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/tr.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/tt.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/ug.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/uk.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/ur.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/uz.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/vi.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/lang/translations/zh.po
+++ b/packages/ckeditor5-horizontal-line/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-horizontal-line/src/augmentation.ts
+++ b/packages/ckeditor5-horizontal-line/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-horizontal-line/src/horizontalline.ts
+++ b/packages/ckeditor5-horizontal-line/src/horizontalline.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-horizontal-line/src/horizontallinecommand.ts
+++ b/packages/ckeditor5-horizontal-line/src/horizontallinecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-horizontal-line/src/horizontallineediting.ts
+++ b/packages/ckeditor5-horizontal-line/src/horizontallineediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-horizontal-line/src/horizontallineui.ts
+++ b/packages/ckeditor5-horizontal-line/src/horizontallineui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-horizontal-line/src/index.ts
+++ b/packages/ckeditor5-horizontal-line/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-horizontal-line/tests/horizontalline.js
+++ b/packages/ckeditor5-horizontal-line/tests/horizontalline.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-horizontal-line/tests/horizontallinecommand.js
+++ b/packages/ckeditor5-horizontal-line/tests/horizontallinecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-horizontal-line/tests/horizontallineediting.js
+++ b/packages/ckeditor5-horizontal-line/tests/horizontallineediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-horizontal-line/tests/horizontallineui.js
+++ b/packages/ckeditor5-horizontal-line/tests/horizontallineui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-horizontal-line/tests/manual/horizontalline.js
+++ b/packages/ckeditor5-horizontal-line/tests/manual/horizontalline.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-horizontal-line/theme/horizontalline.css
+++ b/packages/ckeditor5-horizontal-line/theme/horizontalline.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-horizontal-line/webpack.config.js
+++ b/packages/ckeditor5-horizontal-line/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-embed/LICENSE.md
+++ b/packages/ckeditor5-html-embed/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 HTML embed feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-html-embed/docs/_snippets/features/html-embed.js
+++ b/packages/ckeditor5-html-embed/docs/_snippets/features/html-embed.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-embed/lang/translations/af.po
+++ b/packages/ckeditor5-html-embed/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/ar.po
+++ b/packages/ckeditor5-html-embed/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/ast.po
+++ b/packages/ckeditor5-html-embed/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/az.po
+++ b/packages/ckeditor5-html-embed/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/bg.po
+++ b/packages/ckeditor5-html-embed/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/bn.po
+++ b/packages/ckeditor5-html-embed/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/bs.po
+++ b/packages/ckeditor5-html-embed/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/ca.po
+++ b/packages/ckeditor5-html-embed/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/cs.po
+++ b/packages/ckeditor5-html-embed/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/da.po
+++ b/packages/ckeditor5-html-embed/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/de-ch.po
+++ b/packages/ckeditor5-html-embed/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/de.po
+++ b/packages/ckeditor5-html-embed/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/el.po
+++ b/packages/ckeditor5-html-embed/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/en-au.po
+++ b/packages/ckeditor5-html-embed/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/en-gb.po
+++ b/packages/ckeditor5-html-embed/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/en.po
+++ b/packages/ckeditor5-html-embed/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/eo.po
+++ b/packages/ckeditor5-html-embed/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/es-co.po
+++ b/packages/ckeditor5-html-embed/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/es.po
+++ b/packages/ckeditor5-html-embed/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/et.po
+++ b/packages/ckeditor5-html-embed/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/eu.po
+++ b/packages/ckeditor5-html-embed/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/fa.po
+++ b/packages/ckeditor5-html-embed/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/fi.po
+++ b/packages/ckeditor5-html-embed/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/fr.po
+++ b/packages/ckeditor5-html-embed/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/gl.po
+++ b/packages/ckeditor5-html-embed/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/gu.po
+++ b/packages/ckeditor5-html-embed/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/he.po
+++ b/packages/ckeditor5-html-embed/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/hi.po
+++ b/packages/ckeditor5-html-embed/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/hr.po
+++ b/packages/ckeditor5-html-embed/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/hu.po
+++ b/packages/ckeditor5-html-embed/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/hy.po
+++ b/packages/ckeditor5-html-embed/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/id.po
+++ b/packages/ckeditor5-html-embed/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/it.po
+++ b/packages/ckeditor5-html-embed/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/ja.po
+++ b/packages/ckeditor5-html-embed/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/jv.po
+++ b/packages/ckeditor5-html-embed/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/kk.po
+++ b/packages/ckeditor5-html-embed/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/km.po
+++ b/packages/ckeditor5-html-embed/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/kn.po
+++ b/packages/ckeditor5-html-embed/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/ko.po
+++ b/packages/ckeditor5-html-embed/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/ku.po
+++ b/packages/ckeditor5-html-embed/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/lt.po
+++ b/packages/ckeditor5-html-embed/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/lv.po
+++ b/packages/ckeditor5-html-embed/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/ms.po
+++ b/packages/ckeditor5-html-embed/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/nb.po
+++ b/packages/ckeditor5-html-embed/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/ne.po
+++ b/packages/ckeditor5-html-embed/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/nl.po
+++ b/packages/ckeditor5-html-embed/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/no.po
+++ b/packages/ckeditor5-html-embed/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/oc.po
+++ b/packages/ckeditor5-html-embed/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/pl.po
+++ b/packages/ckeditor5-html-embed/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/pt-br.po
+++ b/packages/ckeditor5-html-embed/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/pt.po
+++ b/packages/ckeditor5-html-embed/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/ro.po
+++ b/packages/ckeditor5-html-embed/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/ru.po
+++ b/packages/ckeditor5-html-embed/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/si.po
+++ b/packages/ckeditor5-html-embed/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/sk.po
+++ b/packages/ckeditor5-html-embed/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/sl.po
+++ b/packages/ckeditor5-html-embed/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/sq.po
+++ b/packages/ckeditor5-html-embed/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-html-embed/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/sr.po
+++ b/packages/ckeditor5-html-embed/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/sv.po
+++ b/packages/ckeditor5-html-embed/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/th.po
+++ b/packages/ckeditor5-html-embed/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/ti.po
+++ b/packages/ckeditor5-html-embed/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/tk.po
+++ b/packages/ckeditor5-html-embed/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/tr.po
+++ b/packages/ckeditor5-html-embed/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/tt.po
+++ b/packages/ckeditor5-html-embed/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/ug.po
+++ b/packages/ckeditor5-html-embed/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/uk.po
+++ b/packages/ckeditor5-html-embed/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/ur.po
+++ b/packages/ckeditor5-html-embed/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/uz.po
+++ b/packages/ckeditor5-html-embed/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/vi.po
+++ b/packages/ckeditor5-html-embed/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-html-embed/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/lang/translations/zh.po
+++ b/packages/ckeditor5-html-embed/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-embed/src/augmentation.ts
+++ b/packages/ckeditor5-html-embed/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-embed/src/htmlembed.ts
+++ b/packages/ckeditor5-html-embed/src/htmlembed.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-embed/src/htmlembedcommand.ts
+++ b/packages/ckeditor5-html-embed/src/htmlembedcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-embed/src/htmlembedconfig.ts
+++ b/packages/ckeditor5-html-embed/src/htmlembedconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-embed/src/htmlembedediting.ts
+++ b/packages/ckeditor5-html-embed/src/htmlembedediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-embed/src/htmlembedui.ts
+++ b/packages/ckeditor5-html-embed/src/htmlembedui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-embed/src/index.ts
+++ b/packages/ckeditor5-html-embed/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-embed/tests/htmlembed.js
+++ b/packages/ckeditor5-html-embed/tests/htmlembed.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-embed/tests/htmlembedcommand.js
+++ b/packages/ckeditor5-html-embed/tests/htmlembedcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-embed/tests/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/tests/htmlembedediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-embed/tests/htmlembedui.js
+++ b/packages/ckeditor5-html-embed/tests/htmlembedui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-embed/tests/manual/htmlembed.js
+++ b/packages/ckeditor5-html-embed/tests/manual/htmlembed.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-embed/tests/manual/tickets/8328/1.js
+++ b/packages/ckeditor5-html-embed/tests/manual/tickets/8328/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-embed/theme/htmlembed.css
+++ b/packages/ckeditor5-html-embed/theme/htmlembed.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-embed/webpack.config.js
+++ b/packages/ckeditor5-html-embed/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/LICENSE.md
+++ b/packages/ckeditor5-html-support/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 HTML support feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-html-support/docs/_snippets/features/full-page-html.css
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/full-page-html.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/docs/_snippets/features/full-page-html.js
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/full-page-html.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support-source.js
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support.css
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support.js
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/docs/_snippets/features/html-comment.js
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/html-comment.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/lang/translations/af.po
+++ b/packages/ckeditor5-html-support/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/ar.po
+++ b/packages/ckeditor5-html-support/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/ast.po
+++ b/packages/ckeditor5-html-support/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/az.po
+++ b/packages/ckeditor5-html-support/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/bg.po
+++ b/packages/ckeditor5-html-support/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/bn.po
+++ b/packages/ckeditor5-html-support/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/bs.po
+++ b/packages/ckeditor5-html-support/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/ca.po
+++ b/packages/ckeditor5-html-support/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/cs.po
+++ b/packages/ckeditor5-html-support/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/da.po
+++ b/packages/ckeditor5-html-support/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/de-ch.po
+++ b/packages/ckeditor5-html-support/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/de.po
+++ b/packages/ckeditor5-html-support/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/el.po
+++ b/packages/ckeditor5-html-support/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/en-au.po
+++ b/packages/ckeditor5-html-support/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/en-gb.po
+++ b/packages/ckeditor5-html-support/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/en.po
+++ b/packages/ckeditor5-html-support/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/eo.po
+++ b/packages/ckeditor5-html-support/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/es-co.po
+++ b/packages/ckeditor5-html-support/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/es.po
+++ b/packages/ckeditor5-html-support/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/et.po
+++ b/packages/ckeditor5-html-support/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/eu.po
+++ b/packages/ckeditor5-html-support/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/fa.po
+++ b/packages/ckeditor5-html-support/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/fi.po
+++ b/packages/ckeditor5-html-support/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/fr.po
+++ b/packages/ckeditor5-html-support/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/gl.po
+++ b/packages/ckeditor5-html-support/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/gu.po
+++ b/packages/ckeditor5-html-support/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/he.po
+++ b/packages/ckeditor5-html-support/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/hi.po
+++ b/packages/ckeditor5-html-support/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/hr.po
+++ b/packages/ckeditor5-html-support/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/hu.po
+++ b/packages/ckeditor5-html-support/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/hy.po
+++ b/packages/ckeditor5-html-support/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/id.po
+++ b/packages/ckeditor5-html-support/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/it.po
+++ b/packages/ckeditor5-html-support/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/ja.po
+++ b/packages/ckeditor5-html-support/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/jv.po
+++ b/packages/ckeditor5-html-support/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/kk.po
+++ b/packages/ckeditor5-html-support/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/km.po
+++ b/packages/ckeditor5-html-support/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/kn.po
+++ b/packages/ckeditor5-html-support/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/ko.po
+++ b/packages/ckeditor5-html-support/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/ku.po
+++ b/packages/ckeditor5-html-support/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/lt.po
+++ b/packages/ckeditor5-html-support/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/lv.po
+++ b/packages/ckeditor5-html-support/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/ms.po
+++ b/packages/ckeditor5-html-support/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/nb.po
+++ b/packages/ckeditor5-html-support/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/ne.po
+++ b/packages/ckeditor5-html-support/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/nl.po
+++ b/packages/ckeditor5-html-support/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/no.po
+++ b/packages/ckeditor5-html-support/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/oc.po
+++ b/packages/ckeditor5-html-support/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/pl.po
+++ b/packages/ckeditor5-html-support/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/pt-br.po
+++ b/packages/ckeditor5-html-support/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/pt.po
+++ b/packages/ckeditor5-html-support/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/ro.po
+++ b/packages/ckeditor5-html-support/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/ru.po
+++ b/packages/ckeditor5-html-support/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/si.po
+++ b/packages/ckeditor5-html-support/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/sk.po
+++ b/packages/ckeditor5-html-support/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/sl.po
+++ b/packages/ckeditor5-html-support/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/sq.po
+++ b/packages/ckeditor5-html-support/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-html-support/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/sr.po
+++ b/packages/ckeditor5-html-support/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/sv.po
+++ b/packages/ckeditor5-html-support/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/th.po
+++ b/packages/ckeditor5-html-support/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/ti.po
+++ b/packages/ckeditor5-html-support/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/tk.po
+++ b/packages/ckeditor5-html-support/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/tr.po
+++ b/packages/ckeditor5-html-support/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/tt.po
+++ b/packages/ckeditor5-html-support/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/ug.po
+++ b/packages/ckeditor5-html-support/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/uk.po
+++ b/packages/ckeditor5-html-support/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/ur.po
+++ b/packages/ckeditor5-html-support/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/uz.po
+++ b/packages/ckeditor5-html-support/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/vi.po
+++ b/packages/ckeditor5-html-support/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-html-support/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/lang/translations/zh.po
+++ b/packages/ckeditor5-html-support/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-html-support/src/augmentation.ts
+++ b/packages/ckeditor5-html-support/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/converters.ts
+++ b/packages/ckeditor5-html-support/src/converters.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/datafilter.ts
+++ b/packages/ckeditor5-html-support/src/datafilter.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/dataschema.ts
+++ b/packages/ckeditor5-html-support/src/dataschema.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/fullpage.ts
+++ b/packages/ckeditor5-html-support/src/fullpage.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/generalhtmlsupport.ts
+++ b/packages/ckeditor5-html-support/src/generalhtmlsupport.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/generalhtmlsupportconfig.ts
+++ b/packages/ckeditor5-html-support/src/generalhtmlsupportconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/htmlcomment.ts
+++ b/packages/ckeditor5-html-support/src/htmlcomment.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/htmlpagedataprocessor.ts
+++ b/packages/ckeditor5-html-support/src/htmlpagedataprocessor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/index.ts
+++ b/packages/ckeditor5-html-support/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/integrations/codeblock.ts
+++ b/packages/ckeditor5-html-support/src/integrations/codeblock.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/integrations/customelement.ts
+++ b/packages/ckeditor5-html-support/src/integrations/customelement.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/integrations/dualcontent.ts
+++ b/packages/ckeditor5-html-support/src/integrations/dualcontent.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/integrations/heading.ts
+++ b/packages/ckeditor5-html-support/src/integrations/heading.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/integrations/image.ts
+++ b/packages/ckeditor5-html-support/src/integrations/image.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/integrations/integrationutils.ts
+++ b/packages/ckeditor5-html-support/src/integrations/integrationutils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/integrations/list.ts
+++ b/packages/ckeditor5-html-support/src/integrations/list.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/integrations/mediaembed.ts
+++ b/packages/ckeditor5-html-support/src/integrations/mediaembed.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/integrations/script.ts
+++ b/packages/ckeditor5-html-support/src/integrations/script.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/integrations/style.ts
+++ b/packages/ckeditor5-html-support/src/integrations/style.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/integrations/table.ts
+++ b/packages/ckeditor5-html-support/src/integrations/table.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/schemadefinitions.ts
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/src/utils.ts
+++ b/packages/ckeditor5-html-support/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/_utils/utils.js
+++ b/packages/ckeditor5-html-support/tests/_utils/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/datafilter.js
+++ b/packages/ckeditor5-html-support/tests/datafilter.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/dataschema.js
+++ b/packages/ckeditor5-html-support/tests/dataschema.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/fullpage.js
+++ b/packages/ckeditor5-html-support/tests/fullpage.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/generalhtmlsupport.js
+++ b/packages/ckeditor5-html-support/tests/generalhtmlsupport.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/htmlcomment-integration.js
+++ b/packages/ckeditor5-html-support/tests/htmlcomment-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/htmlcomment.js
+++ b/packages/ckeditor5-html-support/tests/htmlcomment.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/htmlpagedataprocessor.js
+++ b/packages/ckeditor5-html-support/tests/htmlpagedataprocessor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/integrations/codeblock.js
+++ b/packages/ckeditor5-html-support/tests/integrations/codeblock.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/integrations/customelement.js
+++ b/packages/ckeditor5-html-support/tests/integrations/customelement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/integrations/dualcontent.js
+++ b/packages/ckeditor5-html-support/tests/integrations/dualcontent.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/integrations/heading.js
+++ b/packages/ckeditor5-html-support/tests/integrations/heading.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/integrations/image.js
+++ b/packages/ckeditor5-html-support/tests/integrations/image.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/integrations/list.js
+++ b/packages/ckeditor5-html-support/tests/integrations/list.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/integrations/mediaembed.js
+++ b/packages/ckeditor5-html-support/tests/integrations/mediaembed.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/integrations/script.js
+++ b/packages/ckeditor5-html-support/tests/integrations/script.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/integrations/style.js
+++ b/packages/ckeditor5-html-support/tests/integrations/style.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/integrations/table.js
+++ b/packages/ckeditor5-html-support/tests/integrations/table.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/codeblock.js
+++ b/packages/ckeditor5-html-support/tests/manual/codeblock.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/customelements.js
+++ b/packages/ckeditor5-html-support/tests/manual/customelements.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/div.js
+++ b/packages/ckeditor5-html-support/tests/manual/div.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/documentlist.js
+++ b/packages/ckeditor5-html-support/tests/manual/documentlist.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/fullpage.js
+++ b/packages/ckeditor5-html-support/tests/manual/fullpage.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/ghs-all-features.js
+++ b/packages/ckeditor5-html-support/tests/manual/ghs-all-features.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/ghs-custom-config.js
+++ b/packages/ckeditor5-html-support/tests/manual/ghs-custom-config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/ghs-empty-inline.js
+++ b/packages/ckeditor5-html-support/tests/manual/ghs-empty-inline.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/ghs-link.js
+++ b/packages/ckeditor5-html-support/tests/manual/ghs-link.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/ghs-no-features.js
+++ b/packages/ckeditor5-html-support/tests/manual/ghs-no-features.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/ghs-template-element.js
+++ b/packages/ckeditor5-html-support/tests/manual/ghs-template-element.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/htmlcomment.js
+++ b/packages/ckeditor5-html-support/tests/manual/htmlcomment.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/image.js
+++ b/packages/ckeditor5-html-support/tests/manual/image.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/mediaembed.js
+++ b/packages/ckeditor5-html-support/tests/manual/mediaembed.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/objects.js
+++ b/packages/ckeditor5-html-support/tests/manual/objects.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/pfo-table.js
+++ b/packages/ckeditor5-html-support/tests/manual/pfo-table.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/svg-render.js
+++ b/packages/ckeditor5-html-support/tests/manual/svg-render.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/manual/table.js
+++ b/packages/ckeditor5-html-support/tests/manual/table.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/schemadefinitions.js
+++ b/packages/ckeditor5-html-support/tests/schemadefinitions.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/tickets/13803.js
+++ b/packages/ckeditor5-html-support/tests/tickets/13803.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/tests/tickets/14683.js
+++ b/packages/ckeditor5-html-support/tests/tickets/14683.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/theme/datafilter.css
+++ b/packages/ckeditor5-html-support/theme/datafilter.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-html-support/webpack.config.js
+++ b/packages/ckeditor5-html-support/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/LICENSE.md
+++ b/packages/ckeditor5-image/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Image feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-image/docs/_snippets/features/build-image-source.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/build-image-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/docs/_snippets/features/image-caption.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-caption.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/docs/_snippets/features/image-full.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-full.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/docs/_snippets/features/image-insert-via-pasting-url-into-editor.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-insert-via-pasting-url-into-editor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/docs/_snippets/features/image-insert-via-url.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-insert-via-url.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/docs/_snippets/features/image-link.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-link.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/docs/_snippets/features/image-resize-buttons-dropdown.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-resize-buttons-dropdown.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/docs/_snippets/features/image-resize-buttons.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-resize-buttons.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/docs/_snippets/features/image-resize-px.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-resize-px.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/docs/_snippets/features/image-resize.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-resize.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/docs/_snippets/features/image-responsive.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-responsive.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/docs/_snippets/features/image-semantical-style.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-semantical-style.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/docs/_snippets/features/image-style-custom.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-style-custom.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/docs/_snippets/features/image-style-presentational.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-style-presentational.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/docs/_snippets/features/image-text-alternative.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-text-alternative.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/lang/translations/af.po
+++ b/packages/ckeditor5-image/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/ar.po
+++ b/packages/ckeditor5-image/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/ast.po
+++ b/packages/ckeditor5-image/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/az.po
+++ b/packages/ckeditor5-image/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/bg.po
+++ b/packages/ckeditor5-image/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/bn.po
+++ b/packages/ckeditor5-image/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/bs.po
+++ b/packages/ckeditor5-image/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/ca.po
+++ b/packages/ckeditor5-image/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/cs.po
+++ b/packages/ckeditor5-image/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/da.po
+++ b/packages/ckeditor5-image/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/de-ch.po
+++ b/packages/ckeditor5-image/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/de.po
+++ b/packages/ckeditor5-image/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/el.po
+++ b/packages/ckeditor5-image/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/en-au.po
+++ b/packages/ckeditor5-image/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/en-gb.po
+++ b/packages/ckeditor5-image/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/en.po
+++ b/packages/ckeditor5-image/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/eo.po
+++ b/packages/ckeditor5-image/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/es-co.po
+++ b/packages/ckeditor5-image/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/es.po
+++ b/packages/ckeditor5-image/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/et.po
+++ b/packages/ckeditor5-image/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/eu.po
+++ b/packages/ckeditor5-image/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/fa.po
+++ b/packages/ckeditor5-image/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/fi.po
+++ b/packages/ckeditor5-image/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/fr.po
+++ b/packages/ckeditor5-image/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/gl.po
+++ b/packages/ckeditor5-image/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/gu.po
+++ b/packages/ckeditor5-image/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/he.po
+++ b/packages/ckeditor5-image/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/hi.po
+++ b/packages/ckeditor5-image/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/hr.po
+++ b/packages/ckeditor5-image/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/hu.po
+++ b/packages/ckeditor5-image/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/hy.po
+++ b/packages/ckeditor5-image/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/id.po
+++ b/packages/ckeditor5-image/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/it.po
+++ b/packages/ckeditor5-image/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/ja.po
+++ b/packages/ckeditor5-image/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/jv.po
+++ b/packages/ckeditor5-image/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/kk.po
+++ b/packages/ckeditor5-image/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/km.po
+++ b/packages/ckeditor5-image/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/kn.po
+++ b/packages/ckeditor5-image/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/ko.po
+++ b/packages/ckeditor5-image/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/ku.po
+++ b/packages/ckeditor5-image/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/lt.po
+++ b/packages/ckeditor5-image/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/lv.po
+++ b/packages/ckeditor5-image/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/ms.po
+++ b/packages/ckeditor5-image/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/nb.po
+++ b/packages/ckeditor5-image/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/ne.po
+++ b/packages/ckeditor5-image/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/nl.po
+++ b/packages/ckeditor5-image/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/no.po
+++ b/packages/ckeditor5-image/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/oc.po
+++ b/packages/ckeditor5-image/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/pl.po
+++ b/packages/ckeditor5-image/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/pt-br.po
+++ b/packages/ckeditor5-image/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/pt.po
+++ b/packages/ckeditor5-image/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/ro.po
+++ b/packages/ckeditor5-image/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/ru.po
+++ b/packages/ckeditor5-image/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/si.po
+++ b/packages/ckeditor5-image/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/sk.po
+++ b/packages/ckeditor5-image/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/sl.po
+++ b/packages/ckeditor5-image/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/sq.po
+++ b/packages/ckeditor5-image/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-image/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/sr.po
+++ b/packages/ckeditor5-image/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/sv.po
+++ b/packages/ckeditor5-image/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/th.po
+++ b/packages/ckeditor5-image/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/ti.po
+++ b/packages/ckeditor5-image/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/tk.po
+++ b/packages/ckeditor5-image/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/tr.po
+++ b/packages/ckeditor5-image/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/tt.po
+++ b/packages/ckeditor5-image/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/ug.po
+++ b/packages/ckeditor5-image/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/uk.po
+++ b/packages/ckeditor5-image/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/ur.po
+++ b/packages/ckeditor5-image/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/uz.po
+++ b/packages/ckeditor5-image/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/vi.po
+++ b/packages/ckeditor5-image/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-image/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/lang/translations/zh.po
+++ b/packages/ckeditor5-image/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-image/src/augmentation.ts
+++ b/packages/ckeditor5-image/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/autoimage.ts
+++ b/packages/ckeditor5-image/src/autoimage.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/image.ts
+++ b/packages/ckeditor5-image/src/image.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/image/converters.ts
+++ b/packages/ckeditor5-image/src/image/converters.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/image/imageblockediting.ts
+++ b/packages/ckeditor5-image/src/image/imageblockediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/image/imageediting.ts
+++ b/packages/ckeditor5-image/src/image/imageediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/image/imageinlineediting.ts
+++ b/packages/ckeditor5-image/src/image/imageinlineediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/image/imageloadobserver.ts
+++ b/packages/ckeditor5-image/src/image/imageloadobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/image/imageplaceholder.ts
+++ b/packages/ckeditor5-image/src/image/imageplaceholder.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/image/imagetypecommand.ts
+++ b/packages/ckeditor5-image/src/image/imagetypecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/image/insertimagecommand.ts
+++ b/packages/ckeditor5-image/src/image/insertimagecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/image/replaceimagesourcecommand.ts
+++ b/packages/ckeditor5-image/src/image/replaceimagesourcecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/image/ui/utils.ts
+++ b/packages/ckeditor5-image/src/image/ui/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/image/utils.ts
+++ b/packages/ckeditor5-image/src/image/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageblock.ts
+++ b/packages/ckeditor5-image/src/imageblock.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagecaption.ts
+++ b/packages/ckeditor5-image/src/imagecaption.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagecaption/imagecaptionediting.ts
+++ b/packages/ckeditor5-image/src/imagecaption/imagecaptionediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagecaption/imagecaptionui.ts
+++ b/packages/ckeditor5-image/src/imagecaption/imagecaptionui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagecaption/imagecaptionutils.ts
+++ b/packages/ckeditor5-image/src/imagecaption/imagecaptionutils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagecaption/toggleimagecaptioncommand.ts
+++ b/packages/ckeditor5-image/src/imagecaption/toggleimagecaptioncommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageconfig.ts
+++ b/packages/ckeditor5-image/src/imageconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageinline.ts
+++ b/packages/ckeditor5-image/src/imageinline.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageinsert.ts
+++ b/packages/ckeditor5-image/src/imageinsert.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageinsert/imageinsertui.ts
+++ b/packages/ckeditor5-image/src/imageinsert/imageinsertui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageinsert/imageinsertviaurlui.ts
+++ b/packages/ckeditor5-image/src/imageinsert/imageinsertviaurlui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageinsert/ui/imageinsertformview.ts
+++ b/packages/ckeditor5-image/src/imageinsert/ui/imageinsertformview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageinsert/ui/imageinserturlview.ts
+++ b/packages/ckeditor5-image/src/imageinsert/ui/imageinserturlview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageinsertviaurl.ts
+++ b/packages/ckeditor5-image/src/imageinsertviaurl.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageresize.ts
+++ b/packages/ckeditor5-image/src/imageresize.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageresize/imagecustomresizeui.ts
+++ b/packages/ckeditor5-image/src/imageresize/imagecustomresizeui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageresize/imageresizebuttons.ts
+++ b/packages/ckeditor5-image/src/imageresize/imageresizebuttons.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageresize/imageresizeediting.ts
+++ b/packages/ckeditor5-image/src/imageresize/imageresizeediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageresize/imageresizehandles.ts
+++ b/packages/ckeditor5-image/src/imageresize/imageresizehandles.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageresize/resizeimagecommand.ts
+++ b/packages/ckeditor5-image/src/imageresize/resizeimagecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageresize/ui/imagecustomresizeformview.ts
+++ b/packages/ckeditor5-image/src/imageresize/ui/imagecustomresizeformview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageresize/utils/getselectedimageeditornodes.ts
+++ b/packages/ckeditor5-image/src/imageresize/utils/getselectedimageeditornodes.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageresize/utils/getselectedimagepossibleresizerange.ts
+++ b/packages/ckeditor5-image/src/imageresize/utils/getselectedimagepossibleresizerange.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageresize/utils/getselectedimagewidthinunits.ts
+++ b/packages/ckeditor5-image/src/imageresize/utils/getselectedimagewidthinunits.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageresize/utils/tryparsedimensionwithunit.ts
+++ b/packages/ckeditor5-image/src/imageresize/utils/tryparsedimensionwithunit.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagesizeattributes.ts
+++ b/packages/ckeditor5-image/src/imagesizeattributes.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagestyle.ts
+++ b/packages/ckeditor5-image/src/imagestyle.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagestyle/converters.ts
+++ b/packages/ckeditor5-image/src/imagestyle/converters.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagestyle/imagestylecommand.ts
+++ b/packages/ckeditor5-image/src/imagestyle/imagestylecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagestyle/imagestyleediting.ts
+++ b/packages/ckeditor5-image/src/imagestyle/imagestyleediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagestyle/imagestyleui.ts
+++ b/packages/ckeditor5-image/src/imagestyle/imagestyleui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagestyle/utils.ts
+++ b/packages/ckeditor5-image/src/imagestyle/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagetextalternative.ts
+++ b/packages/ckeditor5-image/src/imagetextalternative.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagetextalternative/imagetextalternativecommand.ts
+++ b/packages/ckeditor5-image/src/imagetextalternative/imagetextalternativecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagetextalternative/imagetextalternativeediting.ts
+++ b/packages/ckeditor5-image/src/imagetextalternative/imagetextalternativeediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagetextalternative/imagetextalternativeui.ts
+++ b/packages/ckeditor5-image/src/imagetextalternative/imagetextalternativeui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagetextalternative/ui/textalternativeformview.ts
+++ b/packages/ckeditor5-image/src/imagetextalternative/ui/textalternativeformview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imagetoolbar.ts
+++ b/packages/ckeditor5-image/src/imagetoolbar.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageupload.ts
+++ b/packages/ckeditor5-image/src/imageupload.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageupload/imageuploadprogress.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadprogress.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageupload/imageuploadui.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageupload/uploadimagecommand.ts
+++ b/packages/ckeditor5-image/src/imageupload/uploadimagecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageupload/utils.ts
+++ b/packages/ckeditor5-image/src/imageupload/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/imageutils.ts
+++ b/packages/ckeditor5-image/src/imageutils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/index.ts
+++ b/packages/ckeditor5-image/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/src/pictureediting.ts
+++ b/packages/ckeditor5-image/src/pictureediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/autoimage.js
+++ b/packages/ckeditor5-image/tests/autoimage.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/image.js
+++ b/packages/ckeditor5-image/tests/image.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/image/converters.js
+++ b/packages/ckeditor5-image/tests/image/converters.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/image/imageblockediting.js
+++ b/packages/ckeditor5-image/tests/image/imageblockediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/image/imageediting.js
+++ b/packages/ckeditor5-image/tests/image/imageediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/image/imageinlineediting.js
+++ b/packages/ckeditor5-image/tests/image/imageinlineediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/image/imageloadobserver.js
+++ b/packages/ckeditor5-image/tests/image/imageloadobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/image/imageplaceholder.js
+++ b/packages/ckeditor5-image/tests/image/imageplaceholder.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/image/imagetypecommand.js
+++ b/packages/ckeditor5-image/tests/image/imagetypecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/image/insertimagecommand.js
+++ b/packages/ckeditor5-image/tests/image/insertimagecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/image/replaceimagesourcecommand.js
+++ b/packages/ckeditor5-image/tests/image/replaceimagesourcecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/image/ui/utils.js
+++ b/packages/ckeditor5-image/tests/image/ui/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/image/utils.js
+++ b/packages/ckeditor5-image/tests/image/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageblock.js
+++ b/packages/ckeditor5-image/tests/imageblock.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagecaption.js
+++ b/packages/ckeditor5-image/tests/imagecaption.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagecaption/imagecaption-integration.js
+++ b/packages/ckeditor5-image/tests/imagecaption/imagecaption-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagecaption/imagecaptionediting.js
+++ b/packages/ckeditor5-image/tests/imagecaption/imagecaptionediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagecaption/imagecaptionui.js
+++ b/packages/ckeditor5-image/tests/imagecaption/imagecaptionui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagecaption/toggleimagecaptioncommand.js
+++ b/packages/ckeditor5-image/tests/imagecaption/toggleimagecaptioncommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagecaption/utils.js
+++ b/packages/ckeditor5-image/tests/imagecaption/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageinline.js
+++ b/packages/ckeditor5-image/tests/imageinline.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageinsert.js
+++ b/packages/ckeditor5-image/tests/imageinsert.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageinsert/imageinsertui.js
+++ b/packages/ckeditor5-image/tests/imageinsert/imageinsertui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageinsert/imageinsertviaurlui.js
+++ b/packages/ckeditor5-image/tests/imageinsert/imageinsertviaurlui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageinsert/ui/imageinsertformview.js
+++ b/packages/ckeditor5-image/tests/imageinsert/ui/imageinsertformview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageinsert/ui/imageinserturlview.js
+++ b/packages/ckeditor5-image/tests/imageinsert/ui/imageinserturlview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageinsertviaurl.js
+++ b/packages/ckeditor5-image/tests/imageinsertviaurl.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageresize/_utils/utils.js
+++ b/packages/ckeditor5-image/tests/imageresize/_utils/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageresize/imagecustomresizeui.js
+++ b/packages/ckeditor5-image/tests/imageresize/imagecustomresizeui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageresize/imageresize.js
+++ b/packages/ckeditor5-image/tests/imageresize/imageresize.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageresize/imageresizebuttons.js
+++ b/packages/ckeditor5-image/tests/imageresize/imageresizebuttons.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageresize/imageresizeediting.js
+++ b/packages/ckeditor5-image/tests/imageresize/imageresizeediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageresize/imageresizehandles.js
+++ b/packages/ckeditor5-image/tests/imageresize/imageresizehandles.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageresize/resizeimagecommand.js
+++ b/packages/ckeditor5-image/tests/imageresize/resizeimagecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageresize/ui/imagecustomresizeformview.js
+++ b/packages/ckeditor5-image/tests/imageresize/ui/imagecustomresizeformview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageresize/utils/getselectedimagepossibleresizerange.js
+++ b/packages/ckeditor5-image/tests/imageresize/utils/getselectedimagepossibleresizerange.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageresize/utils/getselectedimagewidthinunits.js
+++ b/packages/ckeditor5-image/tests/imageresize/utils/getselectedimagewidthinunits.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageresize/utils/tryparsedimensionwithunit.js
+++ b/packages/ckeditor5-image/tests/imageresize/utils/tryparsedimensionwithunit.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagesizeattributes.js
+++ b/packages/ckeditor5-image/tests/imagesizeattributes.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagestyle.js
+++ b/packages/ckeditor5-image/tests/imagestyle.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagestyle/imagestyle-integration.js
+++ b/packages/ckeditor5-image/tests/imagestyle/imagestyle-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagestyle/imagestylecommand.js
+++ b/packages/ckeditor5-image/tests/imagestyle/imagestylecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagestyle/imagestyleediting.js
+++ b/packages/ckeditor5-image/tests/imagestyle/imagestyleediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagestyle/imagestyleui.js
+++ b/packages/ckeditor5-image/tests/imagestyle/imagestyleui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagestyle/utils.js
+++ b/packages/ckeditor5-image/tests/imagestyle/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagetextalternative.js
+++ b/packages/ckeditor5-image/tests/imagetextalternative.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagetextalternative/imagetextalternativecommand.js
+++ b/packages/ckeditor5-image/tests/imagetextalternative/imagetextalternativecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagetextalternative/imagetextalternativeediting.js
+++ b/packages/ckeditor5-image/tests/imagetextalternative/imagetextalternativeediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagetextalternative/imagetextalternativeui.js
+++ b/packages/ckeditor5-image/tests/imagetextalternative/imagetextalternativeui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagetextalternative/ui/textalternativeformview.js
+++ b/packages/ckeditor5-image/tests/imagetextalternative/ui/textalternativeformview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imagetoolbar.js
+++ b/packages/ckeditor5-image/tests/imagetoolbar.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageupload.js
+++ b/packages/ckeditor5-image/tests/imageupload.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadprogress.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadprogress.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadui.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageupload/uploadimagecommand.js
+++ b/packages/ckeditor5-image/tests/imageupload/uploadimagecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageupload/utils.js
+++ b/packages/ckeditor5-image/tests/imageupload/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/imageutils.js
+++ b/packages/ckeditor5-image/tests/imageutils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/integration.js
+++ b/packages/ckeditor5-image/tests/integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/caption.js
+++ b/packages/ckeditor5-image/tests/manual/caption.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/image.js
+++ b/packages/ckeditor5-image/tests/manual/image.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/imageblock.js
+++ b/packages/ckeditor5-image/tests/manual/imageblock.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/imageinline.js
+++ b/packages/ckeditor5-image/tests/manual/imageinline.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/imageinsert.js
+++ b/packages/ckeditor5-image/tests/manual/imageinsert.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/imageinsertviaurl.js
+++ b/packages/ckeditor5-image/tests/manual/imageinsertviaurl.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/imageplaceholder.js
+++ b/packages/ckeditor5-image/tests/manual/imageplaceholder.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/imageresize.js
+++ b/packages/ckeditor5-image/tests/manual/imageresize.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/imageresizebuttons.js
+++ b/packages/ckeditor5-image/tests/manual/imageresizebuttons.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/imageresizepx.js
+++ b/packages/ckeditor5-image/tests/manual/imageresizepx.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/imagesizeattributes.js
+++ b/packages/ckeditor5-image/tests/manual/imagesizeattributes.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/imagesizeattributesallcases.js
+++ b/packages/ckeditor5-image/tests/manual/imagesizeattributesallcases.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/imagesizeattributesghs.js
+++ b/packages/ckeditor5-image/tests/manual/imagesizeattributesghs.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/imagestyle.js
+++ b/packages/ckeditor5-image/tests/manual/imagestyle.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/imagetypetoggle.js
+++ b/packages/ckeditor5-image/tests/manual/imagetypetoggle.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/imageupload.js
+++ b/packages/ckeditor5-image/tests/manual/imageupload.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/picture.js
+++ b/packages/ckeditor5-image/tests/manual/picture.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/resizing-images-in-tables.js
+++ b/packages/ckeditor5-image/tests/manual/resizing-images-in-tables.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/simple-image.ts
+++ b/packages/ckeditor5-image/tests/manual/simple-image.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/textalternative.js
+++ b/packages/ckeditor5-image/tests/manual/textalternative.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/tickets/106/1.js
+++ b/packages/ckeditor5-image/tests/manual/tickets/106/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/tickets/110/1.js
+++ b/packages/ckeditor5-image/tests/manual/tickets/110/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/tickets/127/1.js
+++ b/packages/ckeditor5-image/tests/manual/tickets/127/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/tickets/142/1.js
+++ b/packages/ckeditor5-image/tests/manual/tickets/142/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/manual/tickets/8433/1.js
+++ b/packages/ckeditor5-image/tests/manual/tickets/8433/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/tests/pictureediting.js
+++ b/packages/ckeditor5-image/tests/pictureediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/theme/image.css
+++ b/packages/ckeditor5-image/theme/image.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/theme/imagecaption.css
+++ b/packages/ckeditor5-image/theme/imagecaption.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/theme/imagecustomresizeform.css
+++ b/packages/ckeditor5-image/theme/imagecustomresizeform.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/theme/imageinsert.css
+++ b/packages/ckeditor5-image/theme/imageinsert.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/theme/imageplaceholder.css
+++ b/packages/ckeditor5-image/theme/imageplaceholder.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/theme/imageresize.css
+++ b/packages/ckeditor5-image/theme/imageresize.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/theme/imagestyle.css
+++ b/packages/ckeditor5-image/theme/imagestyle.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/theme/imageuploadicon.css
+++ b/packages/ckeditor5-image/theme/imageuploadicon.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/theme/imageuploadloader.css
+++ b/packages/ckeditor5-image/theme/imageuploadloader.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/theme/imageuploadprogress.css
+++ b/packages/ckeditor5-image/theme/imageuploadprogress.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/theme/textalternativeform.css
+++ b/packages/ckeditor5-image/theme/textalternativeform.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-image/webpack.config.js
+++ b/packages/ckeditor5-image/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/LICENSE.md
+++ b/packages/ckeditor5-indent/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Block indentation feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-indent/docs/_snippets/features/build-indent-source.js
+++ b/packages/ckeditor5-indent/docs/_snippets/features/build-indent-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/docs/_snippets/features/custom-indent-block-classes.js
+++ b/packages/ckeditor5-indent/docs/_snippets/features/custom-indent-block-classes.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/docs/_snippets/features/indent.js
+++ b/packages/ckeditor5-indent/docs/_snippets/features/indent.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/lang/translations/af.po
+++ b/packages/ckeditor5-indent/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/ar.po
+++ b/packages/ckeditor5-indent/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/ast.po
+++ b/packages/ckeditor5-indent/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/az.po
+++ b/packages/ckeditor5-indent/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/bg.po
+++ b/packages/ckeditor5-indent/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/bn.po
+++ b/packages/ckeditor5-indent/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/bs.po
+++ b/packages/ckeditor5-indent/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/ca.po
+++ b/packages/ckeditor5-indent/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/cs.po
+++ b/packages/ckeditor5-indent/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/da.po
+++ b/packages/ckeditor5-indent/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/de-ch.po
+++ b/packages/ckeditor5-indent/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/de.po
+++ b/packages/ckeditor5-indent/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/el.po
+++ b/packages/ckeditor5-indent/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/en-au.po
+++ b/packages/ckeditor5-indent/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/en-gb.po
+++ b/packages/ckeditor5-indent/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/en.po
+++ b/packages/ckeditor5-indent/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/eo.po
+++ b/packages/ckeditor5-indent/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/es-co.po
+++ b/packages/ckeditor5-indent/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/es.po
+++ b/packages/ckeditor5-indent/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/et.po
+++ b/packages/ckeditor5-indent/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/eu.po
+++ b/packages/ckeditor5-indent/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/fa.po
+++ b/packages/ckeditor5-indent/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/fi.po
+++ b/packages/ckeditor5-indent/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/fr.po
+++ b/packages/ckeditor5-indent/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/gl.po
+++ b/packages/ckeditor5-indent/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/gu.po
+++ b/packages/ckeditor5-indent/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/he.po
+++ b/packages/ckeditor5-indent/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/hi.po
+++ b/packages/ckeditor5-indent/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/hr.po
+++ b/packages/ckeditor5-indent/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/hu.po
+++ b/packages/ckeditor5-indent/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/hy.po
+++ b/packages/ckeditor5-indent/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/id.po
+++ b/packages/ckeditor5-indent/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/it.po
+++ b/packages/ckeditor5-indent/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/ja.po
+++ b/packages/ckeditor5-indent/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/jv.po
+++ b/packages/ckeditor5-indent/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/kk.po
+++ b/packages/ckeditor5-indent/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/km.po
+++ b/packages/ckeditor5-indent/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/kn.po
+++ b/packages/ckeditor5-indent/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/ko.po
+++ b/packages/ckeditor5-indent/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/ku.po
+++ b/packages/ckeditor5-indent/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/lt.po
+++ b/packages/ckeditor5-indent/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/lv.po
+++ b/packages/ckeditor5-indent/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/ms.po
+++ b/packages/ckeditor5-indent/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/nb.po
+++ b/packages/ckeditor5-indent/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/ne.po
+++ b/packages/ckeditor5-indent/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/nl.po
+++ b/packages/ckeditor5-indent/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/no.po
+++ b/packages/ckeditor5-indent/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/oc.po
+++ b/packages/ckeditor5-indent/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/pl.po
+++ b/packages/ckeditor5-indent/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/pt-br.po
+++ b/packages/ckeditor5-indent/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/pt.po
+++ b/packages/ckeditor5-indent/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/ro.po
+++ b/packages/ckeditor5-indent/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/ru.po
+++ b/packages/ckeditor5-indent/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/si.po
+++ b/packages/ckeditor5-indent/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/sk.po
+++ b/packages/ckeditor5-indent/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/sl.po
+++ b/packages/ckeditor5-indent/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/sq.po
+++ b/packages/ckeditor5-indent/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-indent/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/sr.po
+++ b/packages/ckeditor5-indent/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/sv.po
+++ b/packages/ckeditor5-indent/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/th.po
+++ b/packages/ckeditor5-indent/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/ti.po
+++ b/packages/ckeditor5-indent/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/tk.po
+++ b/packages/ckeditor5-indent/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/tr.po
+++ b/packages/ckeditor5-indent/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/tt.po
+++ b/packages/ckeditor5-indent/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/ug.po
+++ b/packages/ckeditor5-indent/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/uk.po
+++ b/packages/ckeditor5-indent/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/ur.po
+++ b/packages/ckeditor5-indent/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/uz.po
+++ b/packages/ckeditor5-indent/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/vi.po
+++ b/packages/ckeditor5-indent/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-indent/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/lang/translations/zh.po
+++ b/packages/ckeditor5-indent/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-indent/src/augmentation.ts
+++ b/packages/ckeditor5-indent/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/src/indent.ts
+++ b/packages/ckeditor5-indent/src/indent.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/src/indentblock.ts
+++ b/packages/ckeditor5-indent/src/indentblock.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/src/indentblockcommand.ts
+++ b/packages/ckeditor5-indent/src/indentblockcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/src/indentcommandbehavior/indentbehavior.ts
+++ b/packages/ckeditor5-indent/src/indentcommandbehavior/indentbehavior.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/src/indentcommandbehavior/indentusingclasses.ts
+++ b/packages/ckeditor5-indent/src/indentcommandbehavior/indentusingclasses.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/src/indentcommandbehavior/indentusingoffset.ts
+++ b/packages/ckeditor5-indent/src/indentcommandbehavior/indentusingoffset.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/src/indentconfig.ts
+++ b/packages/ckeditor5-indent/src/indentconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/src/indentediting.ts
+++ b/packages/ckeditor5-indent/src/indentediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/src/indentui.ts
+++ b/packages/ckeditor5-indent/src/indentui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/src/index.ts
+++ b/packages/ckeditor5-indent/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/tests/indent.js
+++ b/packages/ckeditor5-indent/tests/indent.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/tests/indentblock-integration.js
+++ b/packages/ckeditor5-indent/tests/indentblock-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/tests/indentblock.js
+++ b/packages/ckeditor5-indent/tests/indentblock.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/tests/indentblockcommand.js
+++ b/packages/ckeditor5-indent/tests/indentblockcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/tests/indentediting.js
+++ b/packages/ckeditor5-indent/tests/indentediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/tests/indentui.js
+++ b/packages/ckeditor5-indent/tests/indentui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/tests/manual/indent-block-classes.js
+++ b/packages/ckeditor5-indent/tests/manual/indent-block-classes.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/tests/manual/indent-block.js
+++ b/packages/ckeditor5-indent/tests/manual/indent-block.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/tests/manual/rtl.js
+++ b/packages/ckeditor5-indent/tests/manual/rtl.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-indent/webpack.config.js
+++ b/packages/ckeditor5-indent/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-language/LICENSE.md
+++ b/packages/ckeditor5-language/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Text part language feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-language/docs/_snippets/features/textpartlanguage.js
+++ b/packages/ckeditor5-language/docs/_snippets/features/textpartlanguage.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-language/lang/translations/af.po
+++ b/packages/ckeditor5-language/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/ar.po
+++ b/packages/ckeditor5-language/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/ast.po
+++ b/packages/ckeditor5-language/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/az.po
+++ b/packages/ckeditor5-language/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/bg.po
+++ b/packages/ckeditor5-language/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/bn.po
+++ b/packages/ckeditor5-language/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/bs.po
+++ b/packages/ckeditor5-language/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/ca.po
+++ b/packages/ckeditor5-language/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/cs.po
+++ b/packages/ckeditor5-language/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/da.po
+++ b/packages/ckeditor5-language/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/de-ch.po
+++ b/packages/ckeditor5-language/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/de.po
+++ b/packages/ckeditor5-language/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/el.po
+++ b/packages/ckeditor5-language/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/en-au.po
+++ b/packages/ckeditor5-language/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/en-gb.po
+++ b/packages/ckeditor5-language/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/en.po
+++ b/packages/ckeditor5-language/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/eo.po
+++ b/packages/ckeditor5-language/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/es-co.po
+++ b/packages/ckeditor5-language/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/es.po
+++ b/packages/ckeditor5-language/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/et.po
+++ b/packages/ckeditor5-language/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/eu.po
+++ b/packages/ckeditor5-language/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/fa.po
+++ b/packages/ckeditor5-language/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/fi.po
+++ b/packages/ckeditor5-language/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/fr.po
+++ b/packages/ckeditor5-language/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/gl.po
+++ b/packages/ckeditor5-language/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/gu.po
+++ b/packages/ckeditor5-language/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/he.po
+++ b/packages/ckeditor5-language/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/hi.po
+++ b/packages/ckeditor5-language/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/hr.po
+++ b/packages/ckeditor5-language/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/hu.po
+++ b/packages/ckeditor5-language/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/hy.po
+++ b/packages/ckeditor5-language/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/id.po
+++ b/packages/ckeditor5-language/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/it.po
+++ b/packages/ckeditor5-language/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/ja.po
+++ b/packages/ckeditor5-language/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/jv.po
+++ b/packages/ckeditor5-language/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/kk.po
+++ b/packages/ckeditor5-language/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/km.po
+++ b/packages/ckeditor5-language/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/kn.po
+++ b/packages/ckeditor5-language/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/ko.po
+++ b/packages/ckeditor5-language/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/ku.po
+++ b/packages/ckeditor5-language/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/lt.po
+++ b/packages/ckeditor5-language/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/lv.po
+++ b/packages/ckeditor5-language/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/ms.po
+++ b/packages/ckeditor5-language/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/nb.po
+++ b/packages/ckeditor5-language/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/ne.po
+++ b/packages/ckeditor5-language/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/nl.po
+++ b/packages/ckeditor5-language/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/no.po
+++ b/packages/ckeditor5-language/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/oc.po
+++ b/packages/ckeditor5-language/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/pl.po
+++ b/packages/ckeditor5-language/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/pt-br.po
+++ b/packages/ckeditor5-language/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/pt.po
+++ b/packages/ckeditor5-language/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/ro.po
+++ b/packages/ckeditor5-language/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/ru.po
+++ b/packages/ckeditor5-language/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/si.po
+++ b/packages/ckeditor5-language/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/sk.po
+++ b/packages/ckeditor5-language/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/sl.po
+++ b/packages/ckeditor5-language/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/sq.po
+++ b/packages/ckeditor5-language/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-language/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/sr.po
+++ b/packages/ckeditor5-language/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/sv.po
+++ b/packages/ckeditor5-language/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/th.po
+++ b/packages/ckeditor5-language/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/ti.po
+++ b/packages/ckeditor5-language/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/tk.po
+++ b/packages/ckeditor5-language/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/tr.po
+++ b/packages/ckeditor5-language/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/tt.po
+++ b/packages/ckeditor5-language/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/ug.po
+++ b/packages/ckeditor5-language/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/uk.po
+++ b/packages/ckeditor5-language/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/ur.po
+++ b/packages/ckeditor5-language/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/uz.po
+++ b/packages/ckeditor5-language/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/vi.po
+++ b/packages/ckeditor5-language/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-language/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/lang/translations/zh.po
+++ b/packages/ckeditor5-language/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-language/src/augmentation.ts
+++ b/packages/ckeditor5-language/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-language/src/index.ts
+++ b/packages/ckeditor5-language/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-language/src/textpartlanguage.ts
+++ b/packages/ckeditor5-language/src/textpartlanguage.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-language/src/textpartlanguagecommand.ts
+++ b/packages/ckeditor5-language/src/textpartlanguagecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-language/src/textpartlanguageconfig.ts
+++ b/packages/ckeditor5-language/src/textpartlanguageconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-language/src/textpartlanguageediting.ts
+++ b/packages/ckeditor5-language/src/textpartlanguageediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-language/src/textpartlanguageui.ts
+++ b/packages/ckeditor5-language/src/textpartlanguageui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-language/src/utils.ts
+++ b/packages/ckeditor5-language/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-language/tests/manual/textpartlanguage-italic.js
+++ b/packages/ckeditor5-language/tests/manual/textpartlanguage-italic.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-language/tests/manual/textpartlanguage.js
+++ b/packages/ckeditor5-language/tests/manual/textpartlanguage.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-language/tests/textpartlanguage.js
+++ b/packages/ckeditor5-language/tests/textpartlanguage.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-language/tests/textpartlanguagecommand.js
+++ b/packages/ckeditor5-language/tests/textpartlanguagecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-language/tests/textpartlanguageediting.js
+++ b/packages/ckeditor5-language/tests/textpartlanguageediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-language/tests/textpartlanguageui.js
+++ b/packages/ckeditor5-language/tests/textpartlanguageui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-language/webpack.config.js
+++ b/packages/ckeditor5-language/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/LICENSE.md
+++ b/packages/ckeditor5-link/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Link feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-link/docs/_snippets/features/autolink.js
+++ b/packages/ckeditor5-link/docs/_snippets/features/autolink.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/docs/_snippets/features/build-link-source.js
+++ b/packages/ckeditor5-link/docs/_snippets/features/build-link-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/docs/_snippets/features/link.js
+++ b/packages/ckeditor5-link/docs/_snippets/features/link.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/docs/_snippets/features/linkdecorators.js
+++ b/packages/ckeditor5-link/docs/_snippets/features/linkdecorators.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/lang/translations/af.po
+++ b/packages/ckeditor5-link/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/ar.po
+++ b/packages/ckeditor5-link/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/ast.po
+++ b/packages/ckeditor5-link/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/az.po
+++ b/packages/ckeditor5-link/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/bg.po
+++ b/packages/ckeditor5-link/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/bn.po
+++ b/packages/ckeditor5-link/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/bs.po
+++ b/packages/ckeditor5-link/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/ca.po
+++ b/packages/ckeditor5-link/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/cs.po
+++ b/packages/ckeditor5-link/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/da.po
+++ b/packages/ckeditor5-link/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/de-ch.po
+++ b/packages/ckeditor5-link/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/de.po
+++ b/packages/ckeditor5-link/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/el.po
+++ b/packages/ckeditor5-link/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/en-au.po
+++ b/packages/ckeditor5-link/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/en-gb.po
+++ b/packages/ckeditor5-link/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/en.po
+++ b/packages/ckeditor5-link/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/eo.po
+++ b/packages/ckeditor5-link/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/es-co.po
+++ b/packages/ckeditor5-link/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/es.po
+++ b/packages/ckeditor5-link/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/et.po
+++ b/packages/ckeditor5-link/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/eu.po
+++ b/packages/ckeditor5-link/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/fa.po
+++ b/packages/ckeditor5-link/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/fi.po
+++ b/packages/ckeditor5-link/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/fr.po
+++ b/packages/ckeditor5-link/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/gl.po
+++ b/packages/ckeditor5-link/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/gu.po
+++ b/packages/ckeditor5-link/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/he.po
+++ b/packages/ckeditor5-link/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/hi.po
+++ b/packages/ckeditor5-link/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/hr.po
+++ b/packages/ckeditor5-link/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/hu.po
+++ b/packages/ckeditor5-link/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/hy.po
+++ b/packages/ckeditor5-link/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/id.po
+++ b/packages/ckeditor5-link/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/it.po
+++ b/packages/ckeditor5-link/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/ja.po
+++ b/packages/ckeditor5-link/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/jv.po
+++ b/packages/ckeditor5-link/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/kk.po
+++ b/packages/ckeditor5-link/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/km.po
+++ b/packages/ckeditor5-link/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/kn.po
+++ b/packages/ckeditor5-link/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/ko.po
+++ b/packages/ckeditor5-link/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/ku.po
+++ b/packages/ckeditor5-link/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/lt.po
+++ b/packages/ckeditor5-link/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/lv.po
+++ b/packages/ckeditor5-link/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/ms.po
+++ b/packages/ckeditor5-link/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/nb.po
+++ b/packages/ckeditor5-link/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/ne.po
+++ b/packages/ckeditor5-link/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/nl.po
+++ b/packages/ckeditor5-link/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/no.po
+++ b/packages/ckeditor5-link/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/oc.po
+++ b/packages/ckeditor5-link/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/pl.po
+++ b/packages/ckeditor5-link/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/pt-br.po
+++ b/packages/ckeditor5-link/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/pt.po
+++ b/packages/ckeditor5-link/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/ro.po
+++ b/packages/ckeditor5-link/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/ru.po
+++ b/packages/ckeditor5-link/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/si.po
+++ b/packages/ckeditor5-link/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/sk.po
+++ b/packages/ckeditor5-link/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/sl.po
+++ b/packages/ckeditor5-link/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/sq.po
+++ b/packages/ckeditor5-link/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-link/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/sr.po
+++ b/packages/ckeditor5-link/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/sv.po
+++ b/packages/ckeditor5-link/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/th.po
+++ b/packages/ckeditor5-link/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/ti.po
+++ b/packages/ckeditor5-link/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/tk.po
+++ b/packages/ckeditor5-link/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/tr.po
+++ b/packages/ckeditor5-link/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/tt.po
+++ b/packages/ckeditor5-link/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/ug.po
+++ b/packages/ckeditor5-link/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/uk.po
+++ b/packages/ckeditor5-link/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/ur.po
+++ b/packages/ckeditor5-link/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/uz.po
+++ b/packages/ckeditor5-link/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/vi.po
+++ b/packages/ckeditor5-link/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-link/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/lang/translations/zh.po
+++ b/packages/ckeditor5-link/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-link/src/augmentation.ts
+++ b/packages/ckeditor5-link/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/src/index.ts
+++ b/packages/ckeditor5-link/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/src/link.ts
+++ b/packages/ckeditor5-link/src/link.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/src/linkcommand.ts
+++ b/packages/ckeditor5-link/src/linkcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/src/linkconfig.ts
+++ b/packages/ckeditor5-link/src/linkconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/src/linkediting.ts
+++ b/packages/ckeditor5-link/src/linkediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/src/linkimage.ts
+++ b/packages/ckeditor5-link/src/linkimage.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/src/linkimageediting.ts
+++ b/packages/ckeditor5-link/src/linkimageediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/src/linkimageui.ts
+++ b/packages/ckeditor5-link/src/linkimageui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/src/ui/linkactionsview.ts
+++ b/packages/ckeditor5-link/src/ui/linkactionsview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/src/ui/linkformview.ts
+++ b/packages/ckeditor5-link/src/ui/linkformview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/src/unlinkcommand.ts
+++ b/packages/ckeditor5-link/src/unlinkcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/src/utils.ts
+++ b/packages/ckeditor5-link/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/src/utils/automaticdecorators.ts
+++ b/packages/ckeditor5-link/src/utils/automaticdecorators.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/src/utils/manualdecorator.ts
+++ b/packages/ckeditor5-link/src/utils/manualdecorator.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/integrations/clipboard.js
+++ b/packages/ckeditor5-link/tests/integrations/clipboard.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/link.js
+++ b/packages/ckeditor5-link/tests/link.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/linkcommand.js
+++ b/packages/ckeditor5-link/tests/linkcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/linkediting.js
+++ b/packages/ckeditor5-link/tests/linkediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/linkimage-integration.js
+++ b/packages/ckeditor5-link/tests/linkimage-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/linkimage.js
+++ b/packages/ckeditor5-link/tests/linkimage.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/linkimageediting.js
+++ b/packages/ckeditor5-link/tests/linkimageediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/linkimageui.js
+++ b/packages/ckeditor5-link/tests/linkimageui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/manual/autolink.js
+++ b/packages/ckeditor5-link/tests/manual/autolink.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/manual/link.js
+++ b/packages/ckeditor5-link/tests/manual/link.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/manual/linkdecorator.js
+++ b/packages/ckeditor5-link/tests/manual/linkdecorator.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/manual/linkhighlight.js
+++ b/packages/ckeditor5-link/tests/manual/linkhighlight.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/manual/linkimage.js
+++ b/packages/ckeditor5-link/tests/manual/linkimage.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/manual/protocol.js
+++ b/packages/ckeditor5-link/tests/manual/protocol.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/manual/tickets/113/1.js
+++ b/packages/ckeditor5-link/tests/manual/tickets/113/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/manual/tickets/6053/1.js
+++ b/packages/ckeditor5-link/tests/manual/tickets/6053/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/ui/linkactionsview.js
+++ b/packages/ckeditor5-link/tests/ui/linkactionsview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/ui/linkformview.js
+++ b/packages/ckeditor5-link/tests/ui/linkformview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/unlinkcommand.js
+++ b/packages/ckeditor5-link/tests/unlinkcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/utils.js
+++ b/packages/ckeditor5-link/tests/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/utils/automaticdecorators.js
+++ b/packages/ckeditor5-link/tests/utils/automaticdecorators.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/tests/utils/manualdecorator.js
+++ b/packages/ckeditor5-link/tests/utils/manualdecorator.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/theme/link.css
+++ b/packages/ckeditor5-link/theme/link.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/theme/linkactions.css
+++ b/packages/ckeditor5-link/theme/linkactions.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/theme/linkform.css
+++ b/packages/ckeditor5-link/theme/linkform.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/theme/linkimage.css
+++ b/packages/ckeditor5-link/theme/linkimage.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-link/webpack.config.js
+++ b/packages/ckeditor5-link/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/LICENSE.md
+++ b/packages/ckeditor5-list/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 List feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-list/docs/_snippets/features/lists-basic.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/lists-basic.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/docs/_snippets/features/lists-document.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/lists-document.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/docs/_snippets/features/lists-index.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/lists-index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/docs/_snippets/features/lists-reversed.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/lists-reversed.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/docs/_snippets/features/lists-source.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/lists-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/docs/_snippets/features/lists-style.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/lists-style.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/docs/_snippets/features/todo-list.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/todo-list.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/lang/translations/af.po
+++ b/packages/ckeditor5-list/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/ar.po
+++ b/packages/ckeditor5-list/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/ast.po
+++ b/packages/ckeditor5-list/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/az.po
+++ b/packages/ckeditor5-list/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/bg.po
+++ b/packages/ckeditor5-list/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/bn.po
+++ b/packages/ckeditor5-list/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/bs.po
+++ b/packages/ckeditor5-list/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/ca.po
+++ b/packages/ckeditor5-list/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/cs.po
+++ b/packages/ckeditor5-list/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/da.po
+++ b/packages/ckeditor5-list/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/de-ch.po
+++ b/packages/ckeditor5-list/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/de.po
+++ b/packages/ckeditor5-list/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/el.po
+++ b/packages/ckeditor5-list/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/en-au.po
+++ b/packages/ckeditor5-list/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/en-gb.po
+++ b/packages/ckeditor5-list/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/en.po
+++ b/packages/ckeditor5-list/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/eo.po
+++ b/packages/ckeditor5-list/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/es-co.po
+++ b/packages/ckeditor5-list/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/es.po
+++ b/packages/ckeditor5-list/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/et.po
+++ b/packages/ckeditor5-list/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/eu.po
+++ b/packages/ckeditor5-list/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/fa.po
+++ b/packages/ckeditor5-list/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/fi.po
+++ b/packages/ckeditor5-list/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/fr.po
+++ b/packages/ckeditor5-list/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/gl.po
+++ b/packages/ckeditor5-list/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/gu.po
+++ b/packages/ckeditor5-list/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/he.po
+++ b/packages/ckeditor5-list/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/hi.po
+++ b/packages/ckeditor5-list/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/hr.po
+++ b/packages/ckeditor5-list/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/hu.po
+++ b/packages/ckeditor5-list/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/hy.po
+++ b/packages/ckeditor5-list/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/id.po
+++ b/packages/ckeditor5-list/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/it.po
+++ b/packages/ckeditor5-list/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/ja.po
+++ b/packages/ckeditor5-list/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/jv.po
+++ b/packages/ckeditor5-list/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/kk.po
+++ b/packages/ckeditor5-list/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/km.po
+++ b/packages/ckeditor5-list/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/kn.po
+++ b/packages/ckeditor5-list/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/ko.po
+++ b/packages/ckeditor5-list/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/ku.po
+++ b/packages/ckeditor5-list/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/lt.po
+++ b/packages/ckeditor5-list/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/lv.po
+++ b/packages/ckeditor5-list/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/ms.po
+++ b/packages/ckeditor5-list/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/nb.po
+++ b/packages/ckeditor5-list/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/ne.po
+++ b/packages/ckeditor5-list/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/nl.po
+++ b/packages/ckeditor5-list/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/no.po
+++ b/packages/ckeditor5-list/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/oc.po
+++ b/packages/ckeditor5-list/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/pl.po
+++ b/packages/ckeditor5-list/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/pt-br.po
+++ b/packages/ckeditor5-list/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/pt.po
+++ b/packages/ckeditor5-list/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/ro.po
+++ b/packages/ckeditor5-list/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/ru.po
+++ b/packages/ckeditor5-list/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/si.po
+++ b/packages/ckeditor5-list/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/sk.po
+++ b/packages/ckeditor5-list/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/sl.po
+++ b/packages/ckeditor5-list/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/sq.po
+++ b/packages/ckeditor5-list/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-list/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/sr.po
+++ b/packages/ckeditor5-list/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/sv.po
+++ b/packages/ckeditor5-list/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/th.po
+++ b/packages/ckeditor5-list/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/ti.po
+++ b/packages/ckeditor5-list/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/tk.po
+++ b/packages/ckeditor5-list/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/tr.po
+++ b/packages/ckeditor5-list/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/tt.po
+++ b/packages/ckeditor5-list/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/ug.po
+++ b/packages/ckeditor5-list/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/uk.po
+++ b/packages/ckeditor5-list/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/ur.po
+++ b/packages/ckeditor5-list/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/uz.po
+++ b/packages/ckeditor5-list/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/vi.po
+++ b/packages/ckeditor5-list/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-list/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/lang/translations/zh.po
+++ b/packages/ckeditor5-list/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-list/src/augmentation.ts
+++ b/packages/ckeditor5-list/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/documentlist.ts
+++ b/packages/ckeditor5-list/src/documentlist.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/documentlistproperties.ts
+++ b/packages/ckeditor5-list/src/documentlistproperties.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/index.ts
+++ b/packages/ckeditor5-list/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/legacylist.ts
+++ b/packages/ckeditor5-list/src/legacylist.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/legacylist/legacyconverters.ts
+++ b/packages/ckeditor5-list/src/legacylist/legacyconverters.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/legacylist/legacyindentcommand.ts
+++ b/packages/ckeditor5-list/src/legacylist/legacyindentcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/legacylist/legacylistcommand.ts
+++ b/packages/ckeditor5-list/src/legacylist/legacylistcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/legacylist/legacylistediting.ts
+++ b/packages/ckeditor5-list/src/legacylist/legacylistediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/legacylist/legacylistutils.ts
+++ b/packages/ckeditor5-list/src/legacylist/legacylistutils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/legacylist/legacyutils.ts
+++ b/packages/ckeditor5-list/src/legacylist/legacyutils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/legacylistproperties.ts
+++ b/packages/ckeditor5-list/src/legacylistproperties.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/legacylistproperties/legacylistpropertiesediting.ts
+++ b/packages/ckeditor5-list/src/legacylistproperties/legacylistpropertiesediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/legacylistproperties/legacylistreversedcommand.ts
+++ b/packages/ckeditor5-list/src/legacylistproperties/legacylistreversedcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/legacylistproperties/legacyliststartcommand.ts
+++ b/packages/ckeditor5-list/src/legacylistproperties/legacyliststartcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/legacylistproperties/legacyliststylecommand.ts
+++ b/packages/ckeditor5-list/src/legacylistproperties/legacyliststylecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/legacytodolist.ts
+++ b/packages/ckeditor5-list/src/legacytodolist.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/legacytodolist/legacychecktodolistcommand.ts
+++ b/packages/ckeditor5-list/src/legacytodolist/legacychecktodolistcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/legacytodolist/legacytodolistconverters.ts
+++ b/packages/ckeditor5-list/src/legacytodolist/legacytodolistconverters.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/legacytodolist/legacytodolistediting.ts
+++ b/packages/ckeditor5-list/src/legacytodolist/legacytodolistediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/list.ts
+++ b/packages/ckeditor5-list/src/list.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/list/adjacentlistssupport.ts
+++ b/packages/ckeditor5-list/src/list/adjacentlistssupport.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/list/converters.ts
+++ b/packages/ckeditor5-list/src/list/converters.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/list/listcommand.ts
+++ b/packages/ckeditor5-list/src/list/listcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/list/listediting.ts
+++ b/packages/ckeditor5-list/src/list/listediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/list/listindentcommand.ts
+++ b/packages/ckeditor5-list/src/list/listindentcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/list/listmergecommand.ts
+++ b/packages/ckeditor5-list/src/list/listmergecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/list/listsplitcommand.ts
+++ b/packages/ckeditor5-list/src/list/listsplitcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/list/listui.ts
+++ b/packages/ckeditor5-list/src/list/listui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/list/listutils.ts
+++ b/packages/ckeditor5-list/src/list/listutils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/list/utils.ts
+++ b/packages/ckeditor5-list/src/list/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/list/utils/listwalker.ts
+++ b/packages/ckeditor5-list/src/list/utils/listwalker.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/list/utils/model.ts
+++ b/packages/ckeditor5-list/src/list/utils/model.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/list/utils/postfixers.ts
+++ b/packages/ckeditor5-list/src/list/utils/postfixers.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/list/utils/view.ts
+++ b/packages/ckeditor5-list/src/list/utils/view.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/listconfig.ts
+++ b/packages/ckeditor5-list/src/listconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/listproperties.ts
+++ b/packages/ckeditor5-list/src/listproperties.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/listproperties/converters.ts
+++ b/packages/ckeditor5-list/src/listproperties/converters.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesutils.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesutils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/listproperties/listreversedcommand.ts
+++ b/packages/ckeditor5-list/src/listproperties/listreversedcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/listproperties/liststartcommand.ts
+++ b/packages/ckeditor5-list/src/listproperties/liststartcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/listproperties/liststylecommand.ts
+++ b/packages/ckeditor5-list/src/listproperties/liststylecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/listproperties/ui/listpropertiesview.ts
+++ b/packages/ckeditor5-list/src/listproperties/ui/listpropertiesview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/listproperties/utils/config.ts
+++ b/packages/ckeditor5-list/src/listproperties/utils/config.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/listproperties/utils/style.ts
+++ b/packages/ckeditor5-list/src/listproperties/utils/style.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/tododocumentlist.ts
+++ b/packages/ckeditor5-list/src/tododocumentlist.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/todolist.ts
+++ b/packages/ckeditor5-list/src/todolist.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/todolist/checktodolistcommand.ts
+++ b/packages/ckeditor5-list/src/todolist/checktodolistcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/todolist/todocheckboxchangeobserver.ts
+++ b/packages/ckeditor5-list/src/todolist/todocheckboxchangeobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/todolist/todolistediting.ts
+++ b/packages/ckeditor5-list/src/todolist/todolistediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/src/todolist/todolistui.ts
+++ b/packages/ckeditor5-list/src/todolist/todolistui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/documentlist.js
+++ b/packages/ckeditor5-list/tests/documentlist.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/documentlistproperties.js
+++ b/packages/ckeditor5-list/tests/documentlistproperties.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/legacylist.js
+++ b/packages/ckeditor5-list/tests/legacylist.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/legacylist/legacyindentcommand.js
+++ b/packages/ckeditor5-list/tests/legacylist/legacyindentcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/legacylist/legacylistcommand.js
+++ b/packages/ckeditor5-list/tests/legacylist/legacylistcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/legacylist/legacylistediting.js
+++ b/packages/ckeditor5-list/tests/legacylist/legacylistediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/legacylist/legacylistutils.js
+++ b/packages/ckeditor5-list/tests/legacylist/legacylistutils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/legacylist/legacyutils.js
+++ b/packages/ckeditor5-list/tests/legacylist/legacyutils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/legacylistproperties.js
+++ b/packages/ckeditor5-list/tests/legacylistproperties.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/legacylistproperties/legacylistpropertiesediting.js
+++ b/packages/ckeditor5-list/tests/legacylistproperties/legacylistpropertiesediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/legacylistproperties/legacylistreversedcommand.js
+++ b/packages/ckeditor5-list/tests/legacylistproperties/legacylistreversedcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/legacylistproperties/legacyliststartcommand.js
+++ b/packages/ckeditor5-list/tests/legacylistproperties/legacyliststartcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/legacylistproperties/legacyliststylecommand.js
+++ b/packages/ckeditor5-list/tests/legacylistproperties/legacyliststylecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/legacytodolist.js
+++ b/packages/ckeditor5-list/tests/legacytodolist.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/legacytodolist/legacychecktodolistcommand.js
+++ b/packages/ckeditor5-list/tests/legacytodolist/legacychecktodolistcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/legacytodolist/legacytodolistediting.js
+++ b/packages/ckeditor5-list/tests/legacytodolist/legacytodolistediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list.js
+++ b/packages/ckeditor5-list/tests/list.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/_utils-tests/uid.js
+++ b/packages/ckeditor5-list/tests/list/_utils-tests/uid.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/_utils-tests/utils.js
+++ b/packages/ckeditor5-list/tests/list/_utils-tests/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/_utils/uid.js
+++ b/packages/ckeditor5-list/tests/list/_utils/uid.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/_utils/utils.js
+++ b/packages/ckeditor5-list/tests/list/_utils/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/adjacentlistssupport.js
+++ b/packages/ckeditor5-list/tests/list/adjacentlistssupport.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/converters-changes.js
+++ b/packages/ckeditor5-list/tests/list/converters-changes.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/converters-data-single-block.js
+++ b/packages/ckeditor5-list/tests/list/converters-data-single-block.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/converters-data.js
+++ b/packages/ckeditor5-list/tests/list/converters-data.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/converters-marker-changes.js
+++ b/packages/ckeditor5-list/tests/list/converters-marker-changes.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/converters.js
+++ b/packages/ckeditor5-list/tests/list/converters.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/integrations/clipboard-single-block.js
+++ b/packages/ckeditor5-list/tests/list/integrations/clipboard-single-block.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/integrations/clipboard.js
+++ b/packages/ckeditor5-list/tests/list/integrations/clipboard.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/integrations/delete-single-block.js
+++ b/packages/ckeditor5-list/tests/list/integrations/delete-single-block.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/integrations/delete.js
+++ b/packages/ckeditor5-list/tests/list/integrations/delete.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/integrations/enter.js
+++ b/packages/ckeditor5-list/tests/list/integrations/enter.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/integrations/image.js
+++ b/packages/ckeditor5-list/tests/list/integrations/image.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/integrations/indentmulticommand.js
+++ b/packages/ckeditor5-list/tests/list/integrations/indentmulticommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/integrations/insertcontent.js
+++ b/packages/ckeditor5-list/tests/list/integrations/insertcontent.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/integrations/markers.js
+++ b/packages/ckeditor5-list/tests/list/integrations/markers.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/integrations/tabobservers.js
+++ b/packages/ckeditor5-list/tests/list/integrations/tabobservers.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/listcommand-single-block.js
+++ b/packages/ckeditor5-list/tests/list/listcommand-single-block.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/listcommand.js
+++ b/packages/ckeditor5-list/tests/list/listcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/listediting-single-block.js
+++ b/packages/ckeditor5-list/tests/list/listediting-single-block.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/listediting.js
+++ b/packages/ckeditor5-list/tests/list/listediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/listindentcommand-single-block.js
+++ b/packages/ckeditor5-list/tests/list/listindentcommand-single-block.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/listindentcommand.js
+++ b/packages/ckeditor5-list/tests/list/listindentcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/listmergecommand.js
+++ b/packages/ckeditor5-list/tests/list/listmergecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/listsplitcommand.js
+++ b/packages/ckeditor5-list/tests/list/listsplitcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/listui.js
+++ b/packages/ckeditor5-list/tests/list/listui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/listutils.js
+++ b/packages/ckeditor5-list/tests/list/listutils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/utils/listwalker.js
+++ b/packages/ckeditor5-list/tests/list/utils/listwalker.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/utils/model.js
+++ b/packages/ckeditor5-list/tests/list/utils/model.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/utils/postfixers.js
+++ b/packages/ckeditor5-list/tests/list/utils/postfixers.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/list/utils/view.js
+++ b/packages/ckeditor5-list/tests/list/utils/view.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/listproperties.js
+++ b/packages/ckeditor5-list/tests/listproperties.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/listproperties/converters.js
+++ b/packages/ckeditor5-list/tests/listproperties/converters.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/listproperties/listpropertiesediting.js
+++ b/packages/ckeditor5-list/tests/listproperties/listpropertiesediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/listproperties/listpropertiesui.js
+++ b/packages/ckeditor5-list/tests/listproperties/listpropertiesui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/listproperties/listpropertiesutils.js
+++ b/packages/ckeditor5-list/tests/listproperties/listpropertiesutils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/listproperties/listreversedcommand.js
+++ b/packages/ckeditor5-list/tests/listproperties/listreversedcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/listproperties/liststartcommand.js
+++ b/packages/ckeditor5-list/tests/listproperties/liststartcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/listproperties/liststylecommand.js
+++ b/packages/ckeditor5-list/tests/listproperties/liststylecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/listproperties/ui/listpropertiesview.js
+++ b/packages/ckeditor5-list/tests/listproperties/ui/listpropertiesview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/listproperties/utils/config.js
+++ b/packages/ckeditor5-list/tests/listproperties/utils/config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/listproperties/utils/style.js
+++ b/packages/ckeditor5-list/tests/listproperties/utils/style.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/manual/documentlist-properties-all.js
+++ b/packages/ckeditor5-list/tests/manual/documentlist-properties-all.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/manual/documentlist-properties.js
+++ b/packages/ckeditor5-list/tests/manual/documentlist-properties.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/manual/documentlist-separator.js
+++ b/packages/ckeditor5-list/tests/manual/documentlist-separator.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/manual/documentlist-simple.js
+++ b/packages/ckeditor5-list/tests/manual/documentlist-simple.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/manual/documentlist.js
+++ b/packages/ckeditor5-list/tests/manual/documentlist.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/manual/list-properties.js
+++ b/packages/ckeditor5-list/tests/manual/list-properties.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/manual/list-style.js
+++ b/packages/ckeditor5-list/tests/manual/list-style.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/manual/list.js
+++ b/packages/ckeditor5-list/tests/manual/list.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/manual/listmocking.js
+++ b/packages/ckeditor5-list/tests/manual/listmocking.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/manual/nestedlists.js
+++ b/packages/ckeditor5-list/tests/manual/nestedlists.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/manual/todo-documentlist-rtl.js
+++ b/packages/ckeditor5-list/tests/manual/todo-documentlist-rtl.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/manual/todo-documentlist-simple.js
+++ b/packages/ckeditor5-list/tests/manual/todo-documentlist-simple.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/manual/todo-documentlist.js
+++ b/packages/ckeditor5-list/tests/manual/todo-documentlist.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/manual/todo-list-rtl.js
+++ b/packages/ckeditor5-list/tests/manual/todo-list-rtl.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/manual/todo-list.js
+++ b/packages/ckeditor5-list/tests/manual/todo-list.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/tododocumentlist.js
+++ b/packages/ckeditor5-list/tests/tododocumentlist.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/todolist.js
+++ b/packages/ckeditor5-list/tests/todolist.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/todolist/checktodolistcommand.js
+++ b/packages/ckeditor5-list/tests/todolist/checktodolistcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/todolist/todocheckboxchangeobserver.js
+++ b/packages/ckeditor5-list/tests/todolist/todocheckboxchangeobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/todolist/todolistediting-conversion-changes.js
+++ b/packages/ckeditor5-list/tests/todolist/todolistediting-conversion-changes.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/todolist/todolistediting-single-block.js
+++ b/packages/ckeditor5-list/tests/todolist/todolistediting-single-block.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/todolist/todolistediting.js
+++ b/packages/ckeditor5-list/tests/todolist/todolistediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/tests/todolist/todolistui.js
+++ b/packages/ckeditor5-list/tests/todolist/todolistui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/theme/documentlist.css
+++ b/packages/ckeditor5-list/theme/documentlist.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/theme/list.css
+++ b/packages/ckeditor5-list/theme/list.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/theme/listproperties.css
+++ b/packages/ckeditor5-list/theme/listproperties.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/theme/liststyles.css
+++ b/packages/ckeditor5-list/theme/liststyles.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/theme/todolist.css
+++ b/packages/ckeditor5-list/theme/todolist.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-list/webpack.config.js
+++ b/packages/ckeditor5-list/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/LICENSE.md
+++ b/packages/ckeditor5-markdown-gfm/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 GitHub Flavored Markdown support** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.js
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/paste-from-markdown.js
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/paste-from-markdown.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/src/augmentation.ts
+++ b/packages/ckeditor5-markdown-gfm/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/src/gfmdataprocessor.ts
+++ b/packages/ckeditor5-markdown-gfm/src/gfmdataprocessor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/src/html2markdown/html2markdown.ts
+++ b/packages/ckeditor5-markdown-gfm/src/html2markdown/html2markdown.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/src/index.ts
+++ b/packages/ckeditor5-markdown-gfm/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/src/markdown.ts
+++ b/packages/ckeditor5-markdown-gfm/src/markdown.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/src/markdown2html/markdown2html.ts
+++ b/packages/ckeditor5-markdown-gfm/src/markdown2html/markdown2html.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/src/pastefrommarkdownexperimental.ts
+++ b/packages/ckeditor5-markdown-gfm/src/pastefrommarkdownexperimental.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/_utils/utils.js
+++ b/packages/ckeditor5-markdown-gfm/tests/_utils/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/blockquotes.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/blockquotes.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/code.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/code.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/escaping.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/escaping.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/gfmdataprocessor.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/gfmdataprocessor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/headers.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/headers.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/horizontal-rules.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/horizontal-rules.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/html.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/html.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/images.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/images.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/links.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/links.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/lists.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/lists.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/paragraphs.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/paragraphs.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/strikethrough.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/strikethrough.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/strong-emphasis.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/strong-emphasis.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/tables.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/tables.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/tabs.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/tabs.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/text.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/text.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/manual/gfmdataprocessor/gfmdataprocessor.js
+++ b/packages/ckeditor5-markdown-gfm/tests/manual/gfmdataprocessor/gfmdataprocessor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/manual/markdown.js
+++ b/packages/ckeditor5-markdown-gfm/tests/manual/markdown.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/manual/pastefrommarkdown/pastefrommarkdown.js
+++ b/packages/ckeditor5-markdown-gfm/tests/manual/pastefrommarkdown/pastefrommarkdown.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/markdown.js
+++ b/packages/ckeditor5-markdown-gfm/tests/markdown.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/tests/pastefrommarkdownexperimental.js
+++ b/packages/ckeditor5-markdown-gfm/tests/pastefrommarkdownexperimental.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-markdown-gfm/webpack.config.js
+++ b/packages/ckeditor5-markdown-gfm/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/LICENSE.md
+++ b/packages/ckeditor5-media-embed/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Media embed feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-media-embed/docs/_snippets/features/build-media-source.js
+++ b/packages/ckeditor5-media-embed/docs/_snippets/features/build-media-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed-preview.js
+++ b/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed-preview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed.js
+++ b/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/lang/translations/af.po
+++ b/packages/ckeditor5-media-embed/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/ar.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/ast.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/az.po
+++ b/packages/ckeditor5-media-embed/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/bg.po
+++ b/packages/ckeditor5-media-embed/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/bn.po
+++ b/packages/ckeditor5-media-embed/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/bs.po
+++ b/packages/ckeditor5-media-embed/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/ca.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/cs.po
+++ b/packages/ckeditor5-media-embed/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/da.po
+++ b/packages/ckeditor5-media-embed/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/de-ch.po
+++ b/packages/ckeditor5-media-embed/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/de.po
+++ b/packages/ckeditor5-media-embed/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/el.po
+++ b/packages/ckeditor5-media-embed/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/en-au.po
+++ b/packages/ckeditor5-media-embed/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/en-gb.po
+++ b/packages/ckeditor5-media-embed/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/en.po
+++ b/packages/ckeditor5-media-embed/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/eo.po
+++ b/packages/ckeditor5-media-embed/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/es-co.po
+++ b/packages/ckeditor5-media-embed/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/es.po
+++ b/packages/ckeditor5-media-embed/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/et.po
+++ b/packages/ckeditor5-media-embed/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/eu.po
+++ b/packages/ckeditor5-media-embed/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/fa.po
+++ b/packages/ckeditor5-media-embed/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/fi.po
+++ b/packages/ckeditor5-media-embed/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/fr.po
+++ b/packages/ckeditor5-media-embed/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/gl.po
+++ b/packages/ckeditor5-media-embed/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/gu.po
+++ b/packages/ckeditor5-media-embed/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/he.po
+++ b/packages/ckeditor5-media-embed/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/hi.po
+++ b/packages/ckeditor5-media-embed/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/hr.po
+++ b/packages/ckeditor5-media-embed/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/hu.po
+++ b/packages/ckeditor5-media-embed/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/hy.po
+++ b/packages/ckeditor5-media-embed/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/id.po
+++ b/packages/ckeditor5-media-embed/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/it.po
+++ b/packages/ckeditor5-media-embed/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/ja.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/jv.po
+++ b/packages/ckeditor5-media-embed/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/kk.po
+++ b/packages/ckeditor5-media-embed/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/km.po
+++ b/packages/ckeditor5-media-embed/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/kn.po
+++ b/packages/ckeditor5-media-embed/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/ko.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/ku.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/lt.po
+++ b/packages/ckeditor5-media-embed/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/lv.po
+++ b/packages/ckeditor5-media-embed/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/ms.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/nb.po
+++ b/packages/ckeditor5-media-embed/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/ne.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/nl.po
+++ b/packages/ckeditor5-media-embed/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/no.po
+++ b/packages/ckeditor5-media-embed/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/oc.po
+++ b/packages/ckeditor5-media-embed/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/pl.po
+++ b/packages/ckeditor5-media-embed/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/pt-br.po
+++ b/packages/ckeditor5-media-embed/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/pt.po
+++ b/packages/ckeditor5-media-embed/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/ro.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/ru.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/si.po
+++ b/packages/ckeditor5-media-embed/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/sk.po
+++ b/packages/ckeditor5-media-embed/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/sl.po
+++ b/packages/ckeditor5-media-embed/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/sq.po
+++ b/packages/ckeditor5-media-embed/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-media-embed/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/sr.po
+++ b/packages/ckeditor5-media-embed/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/sv.po
+++ b/packages/ckeditor5-media-embed/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/th.po
+++ b/packages/ckeditor5-media-embed/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/ti.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/tk.po
+++ b/packages/ckeditor5-media-embed/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/tr.po
+++ b/packages/ckeditor5-media-embed/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/tt.po
+++ b/packages/ckeditor5-media-embed/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/ug.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/uk.po
+++ b/packages/ckeditor5-media-embed/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/ur.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/uz.po
+++ b/packages/ckeditor5-media-embed/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/vi.po
+++ b/packages/ckeditor5-media-embed/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-media-embed/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/lang/translations/zh.po
+++ b/packages/ckeditor5-media-embed/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-media-embed/src/augmentation.ts
+++ b/packages/ckeditor5-media-embed/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/src/automediaembed.ts
+++ b/packages/ckeditor5-media-embed/src/automediaembed.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/src/converters.ts
+++ b/packages/ckeditor5-media-embed/src/converters.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/src/index.ts
+++ b/packages/ckeditor5-media-embed/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/src/mediaembed.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembed.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/src/mediaembedcommand.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/src/mediaembedconfig.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/src/mediaembedediting.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/src/mediaembedtoolbar.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedtoolbar.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/src/mediaembedui.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/src/mediaregistry.ts
+++ b/packages/ckeditor5-media-embed/src/mediaregistry.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/src/ui/mediaformview.ts
+++ b/packages/ckeditor5-media-embed/src/ui/mediaformview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/src/utils.ts
+++ b/packages/ckeditor5-media-embed/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/tests/automediaembed.js
+++ b/packages/ckeditor5-media-embed/tests/automediaembed.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/tests/insertmediacommand.js
+++ b/packages/ckeditor5-media-embed/tests/insertmediacommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/tests/integration.js
+++ b/packages/ckeditor5-media-embed/tests/integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/tests/manual/mediaembed.js
+++ b/packages/ckeditor5-media-embed/tests/manual/mediaembed.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/tests/manual/semanticmediaembed.js
+++ b/packages/ckeditor5-media-embed/tests/manual/semanticmediaembed.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/tests/mediaembed.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembed.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/tests/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/tests/mediaembedtoolbar.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedtoolbar.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/tests/mediaembedui.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/tests/mediaregistry.js
+++ b/packages/ckeditor5-media-embed/tests/mediaregistry.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/tests/ui/mediaformview.js
+++ b/packages/ckeditor5-media-embed/tests/ui/mediaformview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/theme/mediaembed.css
+++ b/packages/ckeditor5-media-embed/theme/mediaembed.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/theme/mediaembedediting.css
+++ b/packages/ckeditor5-media-embed/theme/mediaembedediting.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/theme/mediaform.css
+++ b/packages/ckeditor5-media-embed/theme/mediaform.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-media-embed/webpack.config.js
+++ b/packages/ckeditor5-media-embed/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/LICENSE.md
+++ b/packages/ckeditor5-mention/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Mention feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-mention/docs/_snippets/examples/chat-with-mentions.js
+++ b/packages/ckeditor5-mention/docs/_snippets/examples/chat-with-mentions.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/docs/_snippets/features/build-mention-source.js
+++ b/packages/ckeditor5-mention/docs/_snippets/features/build-mention-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/docs/_snippets/features/custom-mention-colors-variables.js
+++ b/packages/ckeditor5-mention/docs/_snippets/features/custom-mention-colors-variables.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/docs/_snippets/features/mention-customization.js
+++ b/packages/ckeditor5-mention/docs/_snippets/features/mention-customization.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/docs/_snippets/features/mention.js
+++ b/packages/ckeditor5-mention/docs/_snippets/features/mention.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/src/augmentation.ts
+++ b/packages/ckeditor5-mention/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/src/index.ts
+++ b/packages/ckeditor5-mention/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/src/mention.ts
+++ b/packages/ckeditor5-mention/src/mention.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/src/mentioncommand.ts
+++ b/packages/ckeditor5-mention/src/mentioncommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/src/mentionconfig.ts
+++ b/packages/ckeditor5-mention/src/mentionconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/src/mentionediting.ts
+++ b/packages/ckeditor5-mention/src/mentionediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/src/mentionui.ts
+++ b/packages/ckeditor5-mention/src/mentionui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/src/ui/domwrapperview.ts
+++ b/packages/ckeditor5-mention/src/ui/domwrapperview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/src/ui/mentionlistitemview.ts
+++ b/packages/ckeditor5-mention/src/ui/mentionlistitemview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/src/ui/mentionsview.ts
+++ b/packages/ckeditor5-mention/src/ui/mentionsview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/tests/_utils/asyncserver/index.js
+++ b/packages/ckeditor5-mention/tests/_utils/asyncserver/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/tests/manual/mention-asynchronous.js
+++ b/packages/ckeditor5-mention/tests/manual/mention-asynchronous.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/tests/manual/mention-custom-commitkeys.js
+++ b/packages/ckeditor5-mention/tests/manual/mention-custom-commitkeys.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/tests/manual/mention-custom-dropdownlimit.js
+++ b/packages/ckeditor5-mention/tests/manual/mention-custom-dropdownlimit.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/tests/manual/mention-custom-renderer.js
+++ b/packages/ckeditor5-mention/tests/manual/mention-custom-renderer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/tests/manual/mention-custom-view.js
+++ b/packages/ckeditor5-mention/tests/manual/mention-custom-view.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/tests/manual/mention.js
+++ b/packages/ckeditor5-mention/tests/manual/mention.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/tests/manual/tickets/11400.js
+++ b/packages/ckeditor5-mention/tests/manual/tickets/11400.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/tests/mention-integration.js
+++ b/packages/ckeditor5-mention/tests/mention-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/tests/mention.js
+++ b/packages/ckeditor5-mention/tests/mention.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/tests/mentioncommand.js
+++ b/packages/ckeditor5-mention/tests/mentioncommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/tests/mentionediting.js
+++ b/packages/ckeditor5-mention/tests/mentionediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/tests/mentionui.js
+++ b/packages/ckeditor5-mention/tests/mentionui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/tests/ui/domwrapperview.js
+++ b/packages/ckeditor5-mention/tests/ui/domwrapperview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/theme/mention.css
+++ b/packages/ckeditor5-mention/theme/mention.css
@@ -1,4 +1,4 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */

--- a/packages/ckeditor5-mention/theme/mentionui.css
+++ b/packages/ckeditor5-mention/theme/mentionui.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-mention/webpack.config.js
+++ b/packages/ckeditor5-mention/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-minimap/LICENSE.md
+++ b/packages/ckeditor5-minimap/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Minimap feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-minimap/docs/_snippets/features/minimap.js
+++ b/packages/ckeditor5-minimap/docs/_snippets/features/minimap.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-minimap/src/augmentation.ts
+++ b/packages/ckeditor5-minimap/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-minimap/src/index.ts
+++ b/packages/ckeditor5-minimap/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-minimap/src/minimap.ts
+++ b/packages/ckeditor5-minimap/src/minimap.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-minimap/src/minimapconfig.ts
+++ b/packages/ckeditor5-minimap/src/minimapconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-minimap/src/minimapiframeview.ts
+++ b/packages/ckeditor5-minimap/src/minimapiframeview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-minimap/src/minimappositiontrackerview.ts
+++ b/packages/ckeditor5-minimap/src/minimappositiontrackerview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-minimap/src/minimapview.ts
+++ b/packages/ckeditor5-minimap/src/minimapview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-minimap/src/utils.ts
+++ b/packages/ckeditor5-minimap/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-minimap/tests/fixtures.js
+++ b/packages/ckeditor5-minimap/tests/fixtures.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-minimap/tests/manual/minimap-in-body.js
+++ b/packages/ckeditor5-minimap/tests/manual/minimap-in-body.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-minimap/tests/manual/minimap.js
+++ b/packages/ckeditor5-minimap/tests/manual/minimap.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-minimap/tests/mock-test-for-ci-to-not-fail.js
+++ b/packages/ckeditor5-minimap/tests/mock-test-for-ci-to-not-fail.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-minimap/theme/minimap.css
+++ b/packages/ckeditor5-minimap/theme/minimap.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-minimap/webpack.config.js
+++ b/packages/ckeditor5-minimap/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-page-break/LICENSE.md
+++ b/packages/ckeditor5-page-break/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Page break feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-page-break/docs/_snippets/features/page-break.js
+++ b/packages/ckeditor5-page-break/docs/_snippets/features/page-break.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-page-break/lang/translations/af.po
+++ b/packages/ckeditor5-page-break/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/ar.po
+++ b/packages/ckeditor5-page-break/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/ast.po
+++ b/packages/ckeditor5-page-break/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/az.po
+++ b/packages/ckeditor5-page-break/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/bg.po
+++ b/packages/ckeditor5-page-break/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/bn.po
+++ b/packages/ckeditor5-page-break/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/bs.po
+++ b/packages/ckeditor5-page-break/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/ca.po
+++ b/packages/ckeditor5-page-break/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/cs.po
+++ b/packages/ckeditor5-page-break/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/da.po
+++ b/packages/ckeditor5-page-break/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/de-ch.po
+++ b/packages/ckeditor5-page-break/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/de.po
+++ b/packages/ckeditor5-page-break/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/el.po
+++ b/packages/ckeditor5-page-break/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/en-au.po
+++ b/packages/ckeditor5-page-break/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/en-gb.po
+++ b/packages/ckeditor5-page-break/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/en.po
+++ b/packages/ckeditor5-page-break/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/eo.po
+++ b/packages/ckeditor5-page-break/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/es-co.po
+++ b/packages/ckeditor5-page-break/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/es.po
+++ b/packages/ckeditor5-page-break/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/et.po
+++ b/packages/ckeditor5-page-break/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/eu.po
+++ b/packages/ckeditor5-page-break/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/fa.po
+++ b/packages/ckeditor5-page-break/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/fi.po
+++ b/packages/ckeditor5-page-break/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/fr.po
+++ b/packages/ckeditor5-page-break/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/gl.po
+++ b/packages/ckeditor5-page-break/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/gu.po
+++ b/packages/ckeditor5-page-break/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/he.po
+++ b/packages/ckeditor5-page-break/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/hi.po
+++ b/packages/ckeditor5-page-break/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/hr.po
+++ b/packages/ckeditor5-page-break/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/hu.po
+++ b/packages/ckeditor5-page-break/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/hy.po
+++ b/packages/ckeditor5-page-break/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/id.po
+++ b/packages/ckeditor5-page-break/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/it.po
+++ b/packages/ckeditor5-page-break/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/ja.po
+++ b/packages/ckeditor5-page-break/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/jv.po
+++ b/packages/ckeditor5-page-break/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/kk.po
+++ b/packages/ckeditor5-page-break/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/km.po
+++ b/packages/ckeditor5-page-break/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/kn.po
+++ b/packages/ckeditor5-page-break/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/ko.po
+++ b/packages/ckeditor5-page-break/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/ku.po
+++ b/packages/ckeditor5-page-break/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/lt.po
+++ b/packages/ckeditor5-page-break/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/lv.po
+++ b/packages/ckeditor5-page-break/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/ms.po
+++ b/packages/ckeditor5-page-break/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/nb.po
+++ b/packages/ckeditor5-page-break/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/ne.po
+++ b/packages/ckeditor5-page-break/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/nl.po
+++ b/packages/ckeditor5-page-break/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/no.po
+++ b/packages/ckeditor5-page-break/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/oc.po
+++ b/packages/ckeditor5-page-break/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/pl.po
+++ b/packages/ckeditor5-page-break/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/pt-br.po
+++ b/packages/ckeditor5-page-break/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/pt.po
+++ b/packages/ckeditor5-page-break/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/ro.po
+++ b/packages/ckeditor5-page-break/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/ru.po
+++ b/packages/ckeditor5-page-break/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/si.po
+++ b/packages/ckeditor5-page-break/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/sk.po
+++ b/packages/ckeditor5-page-break/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/sl.po
+++ b/packages/ckeditor5-page-break/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/sq.po
+++ b/packages/ckeditor5-page-break/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-page-break/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/sr.po
+++ b/packages/ckeditor5-page-break/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/sv.po
+++ b/packages/ckeditor5-page-break/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/th.po
+++ b/packages/ckeditor5-page-break/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/ti.po
+++ b/packages/ckeditor5-page-break/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/tk.po
+++ b/packages/ckeditor5-page-break/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/tr.po
+++ b/packages/ckeditor5-page-break/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/tt.po
+++ b/packages/ckeditor5-page-break/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/ug.po
+++ b/packages/ckeditor5-page-break/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/uk.po
+++ b/packages/ckeditor5-page-break/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/ur.po
+++ b/packages/ckeditor5-page-break/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/uz.po
+++ b/packages/ckeditor5-page-break/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/vi.po
+++ b/packages/ckeditor5-page-break/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-page-break/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/lang/translations/zh.po
+++ b/packages/ckeditor5-page-break/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-page-break/src/augmentation.ts
+++ b/packages/ckeditor5-page-break/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-page-break/src/index.ts
+++ b/packages/ckeditor5-page-break/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-page-break/src/pagebreak.ts
+++ b/packages/ckeditor5-page-break/src/pagebreak.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-page-break/src/pagebreakcommand.ts
+++ b/packages/ckeditor5-page-break/src/pagebreakcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-page-break/src/pagebreakediting.ts
+++ b/packages/ckeditor5-page-break/src/pagebreakediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-page-break/src/pagebreakui.ts
+++ b/packages/ckeditor5-page-break/src/pagebreakui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-page-break/tests/manual/pagebreak.js
+++ b/packages/ckeditor5-page-break/tests/manual/pagebreak.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-page-break/tests/pagebreak.js
+++ b/packages/ckeditor5-page-break/tests/pagebreak.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-page-break/tests/pagebreakcommand.js
+++ b/packages/ckeditor5-page-break/tests/pagebreakcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-page-break/tests/pagebreakediting.js
+++ b/packages/ckeditor5-page-break/tests/pagebreakediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-page-break/tests/pagebreakui.js
+++ b/packages/ckeditor5-page-break/tests/pagebreakui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-page-break/theme/pagebreak.css
+++ b/packages/ckeditor5-page-break/theme/pagebreak.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-page-break/webpack.config.js
+++ b/packages/ckeditor5-page-break/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paragraph/LICENSE.md
+++ b/packages/ckeditor5-paragraph/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Paragraph feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-paragraph/src/augmentation.ts
+++ b/packages/ckeditor5-paragraph/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paragraph/src/index.ts
+++ b/packages/ckeditor5-paragraph/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
+++ b/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paragraph/src/paragraph.ts
+++ b/packages/ckeditor5-paragraph/src/paragraph.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paragraph/src/paragraphbuttonui.ts
+++ b/packages/ckeditor5-paragraph/src/paragraphbuttonui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paragraph/src/paragraphcommand.ts
+++ b/packages/ckeditor5-paragraph/src/paragraphcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paragraph/tests/insertparagraphcommand.js
+++ b/packages/ckeditor5-paragraph/tests/insertparagraphcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paragraph/tests/manual/clipboard-integration.js
+++ b/packages/ckeditor5-paragraph/tests/manual/clipboard-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paragraph/tests/paragraph-intergration.js
+++ b/packages/ckeditor5-paragraph/tests/paragraph-intergration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paragraph/tests/paragraph.js
+++ b/packages/ckeditor5-paragraph/tests/paragraph.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paragraph/tests/paragraphbuttonui.js
+++ b/packages/ckeditor5-paragraph/tests/paragraphbuttonui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paragraph/tests/paragraphcommand.js
+++ b/packages/ckeditor5-paragraph/tests/paragraphcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/LICENSE.md
+++ b/packages/ckeditor5-paste-from-office/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Paste from Office feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-paste-from-office/docs/_snippets/features/build-paste-from-office-source.js
+++ b/packages/ckeditor5-paste-from-office/docs/_snippets/features/build-paste-from-office-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/docs/_snippets/features/paste-from-office.js
+++ b/packages/ckeditor5-paste-from-office/docs/_snippets/features/paste-from-office.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/augmentation.ts
+++ b/packages/ckeditor5-paste-from-office/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/filters/bookmark.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/bookmark.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/filters/br.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/br.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/filters/image.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/image.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/filters/list.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/list.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/filters/parse.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/parse.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/filters/removeboldwrapper.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/removeboldwrapper.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/filters/removegooglesheetstag.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/removegooglesheetstag.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/filters/removeinvalidtablewidth.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/removeinvalidtablewidth.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/filters/removemsattributes.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/removemsattributes.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/filters/removestyleblock.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/removestyleblock.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/filters/removexmlns.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/removexmlns.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/filters/space.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/space.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/filters/utils.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/index.ts
+++ b/packages/ckeditor5-paste-from-office/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/normalizer.ts
+++ b/packages/ckeditor5-paste-from-office/src/normalizer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/normalizers/googledocsnormalizer.ts
+++ b/packages/ckeditor5-paste-from-office/src/normalizers/googledocsnormalizer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/normalizers/googlesheetsnormalizer.ts
+++ b/packages/ckeditor5-paste-from-office/src/normalizers/googlesheetsnormalizer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/normalizers/mswordnormalizer.ts
+++ b/packages/ckeditor5-paste-from-office/src/normalizers/mswordnormalizer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/src/pastefromoffice.ts
+++ b/packages/ckeditor5-paste-from-office/src/pastefromoffice.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/basic-styles/index.js
+++ b/packages/ckeditor5-paste-from-office/tests/_data/basic-styles/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/bookmark/index.js
+++ b/packages/ckeditor5-paste-from-office/tests/_data/bookmark/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/font-without-table-properties/index.js
+++ b/packages/ckeditor5-paste-from-office/tests/_data/font-without-table-properties/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/image/index.js
+++ b/packages/ckeditor5-paste-from-office/tests/_data/image/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/link/index.js
+++ b/packages/ckeditor5-paste-from-office/tests/_data/link/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/list/index.js
+++ b/packages/ckeditor5-paste-from-office/tests/_data/list/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/other/index.js
+++ b/packages/ckeditor5-paste-from-office/tests/_data/other/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/page-break/index.js
+++ b/packages/ckeditor5-paste-from-office/tests/_data/page-break/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/paste-from-google-docs/bold-wrapper/index.js
+++ b/packages/ckeditor5-paste-from-office/tests/_data/paste-from-google-docs/bold-wrapper/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/paste-from-google-docs/br-paragraph/index.js
+++ b/packages/ckeditor5-paste-from-office/tests/_data/paste-from-google-docs/br-paragraph/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/paste-from-google-docs/lists/index.js
+++ b/packages/ckeditor5-paste-from-office/tests/_data/paste-from-google-docs/lists/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/spacing/index.js
+++ b/packages/ckeditor5-paste-from-office/tests/_data/spacing/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/table/index.js
+++ b/packages/ckeditor5-paste-from-office/tests/_data/table/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/_utils/fixtures.js
+++ b/packages/ckeditor5-paste-from-office/tests/_utils/fixtures.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/_utils/utils.js
+++ b/packages/ckeditor5-paste-from-office/tests/_utils/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/data/integration.js
+++ b/packages/ckeditor5-paste-from-office/tests/data/integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/data/normalization.js
+++ b/packages/ckeditor5-paste-from-office/tests/data/normalization.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/filters/bookmark.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/bookmark.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/filters/br.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/br.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/filters/image.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/image.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/filters/list.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/list.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/filters/parse.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/parse.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/filters/removeboldwrapper.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/removeboldwrapper.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/filters/removegooglesheetstag.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/removegooglesheetstag.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/filters/removeinvalidtablewidth.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/removeinvalidtablewidth.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/filters/removemsattributes.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/removemsattributes.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/filters/removestyleblock.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/removestyleblock.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/filters/removexmlns.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/removexmlns.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/filters/space.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/space.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/filters/utils.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/manual/integration.js
+++ b/packages/ckeditor5-paste-from-office/tests/manual/integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/manual/tickets/12361/1.js
+++ b/packages/ckeditor5-paste-from-office/tests/manual/tickets/12361/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/manual/tickets/7957/1.js
+++ b/packages/ckeditor5-paste-from-office/tests/manual/tickets/7957/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/normalizers/googledocsnormalizer.js
+++ b/packages/ckeditor5-paste-from-office/tests/normalizers/googledocsnormalizer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/normalizers/googlesheetsnormalizer.js
+++ b/packages/ckeditor5-paste-from-office/tests/normalizers/googlesheetsnormalizer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/normalizers/mswordnormalizer.js
+++ b/packages/ckeditor5-paste-from-office/tests/normalizers/mswordnormalizer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
+++ b/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-paste-from-office/webpack.config.js
+++ b/packages/ckeditor5-paste-from-office/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-remove-format/LICENSE.md
+++ b/packages/ckeditor5-remove-format/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Remove format feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-remove-format/docs/_snippets/features/build-remove-format-source.js
+++ b/packages/ckeditor5-remove-format/docs/_snippets/features/build-remove-format-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-remove-format/docs/_snippets/features/remove-format.js
+++ b/packages/ckeditor5-remove-format/docs/_snippets/features/remove-format.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-remove-format/lang/translations/af.po
+++ b/packages/ckeditor5-remove-format/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/ar.po
+++ b/packages/ckeditor5-remove-format/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/ast.po
+++ b/packages/ckeditor5-remove-format/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/az.po
+++ b/packages/ckeditor5-remove-format/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/bg.po
+++ b/packages/ckeditor5-remove-format/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/bn.po
+++ b/packages/ckeditor5-remove-format/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/bs.po
+++ b/packages/ckeditor5-remove-format/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/ca.po
+++ b/packages/ckeditor5-remove-format/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/cs.po
+++ b/packages/ckeditor5-remove-format/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/da.po
+++ b/packages/ckeditor5-remove-format/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/de-ch.po
+++ b/packages/ckeditor5-remove-format/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/de.po
+++ b/packages/ckeditor5-remove-format/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/el.po
+++ b/packages/ckeditor5-remove-format/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/en-au.po
+++ b/packages/ckeditor5-remove-format/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/en-gb.po
+++ b/packages/ckeditor5-remove-format/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/en.po
+++ b/packages/ckeditor5-remove-format/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/eo.po
+++ b/packages/ckeditor5-remove-format/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/es-co.po
+++ b/packages/ckeditor5-remove-format/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/es.po
+++ b/packages/ckeditor5-remove-format/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/et.po
+++ b/packages/ckeditor5-remove-format/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/eu.po
+++ b/packages/ckeditor5-remove-format/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/fa.po
+++ b/packages/ckeditor5-remove-format/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/fi.po
+++ b/packages/ckeditor5-remove-format/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/fr.po
+++ b/packages/ckeditor5-remove-format/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/gl.po
+++ b/packages/ckeditor5-remove-format/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/gu.po
+++ b/packages/ckeditor5-remove-format/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/he.po
+++ b/packages/ckeditor5-remove-format/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/hi.po
+++ b/packages/ckeditor5-remove-format/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/hr.po
+++ b/packages/ckeditor5-remove-format/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/hu.po
+++ b/packages/ckeditor5-remove-format/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/hy.po
+++ b/packages/ckeditor5-remove-format/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/id.po
+++ b/packages/ckeditor5-remove-format/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/it.po
+++ b/packages/ckeditor5-remove-format/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/ja.po
+++ b/packages/ckeditor5-remove-format/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/jv.po
+++ b/packages/ckeditor5-remove-format/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/kk.po
+++ b/packages/ckeditor5-remove-format/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/km.po
+++ b/packages/ckeditor5-remove-format/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/kn.po
+++ b/packages/ckeditor5-remove-format/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/ko.po
+++ b/packages/ckeditor5-remove-format/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/ku.po
+++ b/packages/ckeditor5-remove-format/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/lt.po
+++ b/packages/ckeditor5-remove-format/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/lv.po
+++ b/packages/ckeditor5-remove-format/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/ms.po
+++ b/packages/ckeditor5-remove-format/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/nb.po
+++ b/packages/ckeditor5-remove-format/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/ne.po
+++ b/packages/ckeditor5-remove-format/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/nl.po
+++ b/packages/ckeditor5-remove-format/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/no.po
+++ b/packages/ckeditor5-remove-format/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/oc.po
+++ b/packages/ckeditor5-remove-format/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/pl.po
+++ b/packages/ckeditor5-remove-format/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/pt-br.po
+++ b/packages/ckeditor5-remove-format/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/pt.po
+++ b/packages/ckeditor5-remove-format/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/ro.po
+++ b/packages/ckeditor5-remove-format/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/ru.po
+++ b/packages/ckeditor5-remove-format/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/si.po
+++ b/packages/ckeditor5-remove-format/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/sk.po
+++ b/packages/ckeditor5-remove-format/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/sl.po
+++ b/packages/ckeditor5-remove-format/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/sq.po
+++ b/packages/ckeditor5-remove-format/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-remove-format/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/sr.po
+++ b/packages/ckeditor5-remove-format/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/sv.po
+++ b/packages/ckeditor5-remove-format/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/th.po
+++ b/packages/ckeditor5-remove-format/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/ti.po
+++ b/packages/ckeditor5-remove-format/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/tk.po
+++ b/packages/ckeditor5-remove-format/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/tr.po
+++ b/packages/ckeditor5-remove-format/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/tt.po
+++ b/packages/ckeditor5-remove-format/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/ug.po
+++ b/packages/ckeditor5-remove-format/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/uk.po
+++ b/packages/ckeditor5-remove-format/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/ur.po
+++ b/packages/ckeditor5-remove-format/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/uz.po
+++ b/packages/ckeditor5-remove-format/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/vi.po
+++ b/packages/ckeditor5-remove-format/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-remove-format/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/lang/translations/zh.po
+++ b/packages/ckeditor5-remove-format/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-remove-format/src/augmentation.ts
+++ b/packages/ckeditor5-remove-format/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-remove-format/src/index.ts
+++ b/packages/ckeditor5-remove-format/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-remove-format/src/removeformat.ts
+++ b/packages/ckeditor5-remove-format/src/removeformat.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-remove-format/src/removeformatcommand.ts
+++ b/packages/ckeditor5-remove-format/src/removeformatcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-remove-format/src/removeformatediting.ts
+++ b/packages/ckeditor5-remove-format/src/removeformatediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-remove-format/src/removeformatui.ts
+++ b/packages/ckeditor5-remove-format/src/removeformatui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-remove-format/tests/integration.js
+++ b/packages/ckeditor5-remove-format/tests/integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-remove-format/tests/manual/removeformat.js
+++ b/packages/ckeditor5-remove-format/tests/manual/removeformat.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-remove-format/tests/removeformat.js
+++ b/packages/ckeditor5-remove-format/tests/removeformat.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-remove-format/tests/removeformatcommand.js
+++ b/packages/ckeditor5-remove-format/tests/removeformatcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-remove-format/tests/removeformatediting.js
+++ b/packages/ckeditor5-remove-format/tests/removeformatediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-remove-format/tests/removeformatui.js
+++ b/packages/ckeditor5-remove-format/tests/removeformatui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-remove-format/webpack.config.js
+++ b/packages/ckeditor5-remove-format/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/LICENSE.md
+++ b/packages/ckeditor5-restricted-editing/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Restricted editing feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-restricted-editing/docs/_snippets/features/restricted-editing.js
+++ b/packages/ckeditor5-restricted-editing/docs/_snippets/features/restricted-editing.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/lang/translations/af.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/ar.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/ast.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/az.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/bg.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/bn.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/bs.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/ca.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/cs.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/da.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/de-ch.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/de.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/el.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/en-au.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/en-gb.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/en.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/eo.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/es-co.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/es.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/et.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/eu.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/fa.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/fi.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/fr.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/gl.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/gu.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/he.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/hi.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/hr.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/hu.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/hy.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/id.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/it.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/ja.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/jv.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/kk.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/km.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/kn.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/ko.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/ku.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/lt.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/lv.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/ms.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/nb.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/ne.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/nl.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/no.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/oc.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/pl.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/pt-br.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/pt.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/ro.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/ru.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/si.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/sk.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/sl.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/sq.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/sr.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/sv.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/th.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/ti.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/tk.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/tr.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/tt.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/ug.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/uk.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/ur.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/uz.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/vi.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/lang/translations/zh.po
+++ b/packages/ckeditor5-restricted-editing/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-restricted-editing/src/augmentation.ts
+++ b/packages/ckeditor5-restricted-editing/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/src/index.ts
+++ b/packages/ckeditor5-restricted-editing/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingconfig.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingexceptioncommand.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingexceptioncommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmode.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmode.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmode/converters.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmode/converters.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmode/utils.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmode/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmodeediting.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmodeediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmodenavigationcommand.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmodenavigationcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/src/standardeditingmode.ts
+++ b/packages/ckeditor5-restricted-editing/src/standardeditingmode.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/src/standardeditingmodeediting.ts
+++ b/packages/ckeditor5-restricted-editing/src/standardeditingmodeediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/src/standardeditingmodeui.ts
+++ b/packages/ckeditor5-restricted-editing/src/standardeditingmodeui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/tests/manual/restrictedediting-focus.js
+++ b/packages/ckeditor5-restricted-editing/tests/manual/restrictedediting-focus.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/tests/manual/restrictedediting.js
+++ b/packages/ckeditor5-restricted-editing/tests/manual/restrictedediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/tests/restrictededitingexceptioncommand.js
+++ b/packages/ckeditor5-restricted-editing/tests/restrictededitingexceptioncommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/tests/restrictededitingmode.js
+++ b/packages/ckeditor5-restricted-editing/tests/restrictededitingmode.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeediting-commands.js
+++ b/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeediting-commands.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeediting.js
+++ b/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/tests/restrictededitingmodenavigationcommand.js
+++ b/packages/ckeditor5-restricted-editing/tests/restrictededitingmodenavigationcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeui.js
+++ b/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/tests/standardeditingmode.js
+++ b/packages/ckeditor5-restricted-editing/tests/standardeditingmode.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/tests/standardeditingmodeediting.js
+++ b/packages/ckeditor5-restricted-editing/tests/standardeditingmodeediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/tests/standardeditingmodeui.js
+++ b/packages/ckeditor5-restricted-editing/tests/standardeditingmodeui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/theme/restrictedediting.css
+++ b/packages/ckeditor5-restricted-editing/theme/restrictedediting.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-restricted-editing/webpack.config.js
+++ b/packages/ckeditor5-restricted-editing/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-select-all/LICENSE.md
+++ b/packages/ckeditor5-select-all/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Select all feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-select-all/docs/_snippets/features/select-all.js
+++ b/packages/ckeditor5-select-all/docs/_snippets/features/select-all.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-select-all/lang/translations/af.po
+++ b/packages/ckeditor5-select-all/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/ar.po
+++ b/packages/ckeditor5-select-all/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/ast.po
+++ b/packages/ckeditor5-select-all/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/az.po
+++ b/packages/ckeditor5-select-all/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/bg.po
+++ b/packages/ckeditor5-select-all/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/bn.po
+++ b/packages/ckeditor5-select-all/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/bs.po
+++ b/packages/ckeditor5-select-all/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/ca.po
+++ b/packages/ckeditor5-select-all/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/cs.po
+++ b/packages/ckeditor5-select-all/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/da.po
+++ b/packages/ckeditor5-select-all/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/de-ch.po
+++ b/packages/ckeditor5-select-all/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/de.po
+++ b/packages/ckeditor5-select-all/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/el.po
+++ b/packages/ckeditor5-select-all/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/en-au.po
+++ b/packages/ckeditor5-select-all/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/en-gb.po
+++ b/packages/ckeditor5-select-all/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/en.po
+++ b/packages/ckeditor5-select-all/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/eo.po
+++ b/packages/ckeditor5-select-all/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/es-co.po
+++ b/packages/ckeditor5-select-all/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/es.po
+++ b/packages/ckeditor5-select-all/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/et.po
+++ b/packages/ckeditor5-select-all/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/eu.po
+++ b/packages/ckeditor5-select-all/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/fa.po
+++ b/packages/ckeditor5-select-all/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/fi.po
+++ b/packages/ckeditor5-select-all/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/fr.po
+++ b/packages/ckeditor5-select-all/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/gl.po
+++ b/packages/ckeditor5-select-all/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/gu.po
+++ b/packages/ckeditor5-select-all/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/he.po
+++ b/packages/ckeditor5-select-all/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/hi.po
+++ b/packages/ckeditor5-select-all/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/hr.po
+++ b/packages/ckeditor5-select-all/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/hu.po
+++ b/packages/ckeditor5-select-all/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/hy.po
+++ b/packages/ckeditor5-select-all/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/id.po
+++ b/packages/ckeditor5-select-all/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/it.po
+++ b/packages/ckeditor5-select-all/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/ja.po
+++ b/packages/ckeditor5-select-all/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/jv.po
+++ b/packages/ckeditor5-select-all/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/kk.po
+++ b/packages/ckeditor5-select-all/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/km.po
+++ b/packages/ckeditor5-select-all/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/kn.po
+++ b/packages/ckeditor5-select-all/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/ko.po
+++ b/packages/ckeditor5-select-all/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/ku.po
+++ b/packages/ckeditor5-select-all/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/lt.po
+++ b/packages/ckeditor5-select-all/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/lv.po
+++ b/packages/ckeditor5-select-all/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/ms.po
+++ b/packages/ckeditor5-select-all/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/nb.po
+++ b/packages/ckeditor5-select-all/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/ne.po
+++ b/packages/ckeditor5-select-all/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/nl.po
+++ b/packages/ckeditor5-select-all/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/no.po
+++ b/packages/ckeditor5-select-all/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/oc.po
+++ b/packages/ckeditor5-select-all/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/pl.po
+++ b/packages/ckeditor5-select-all/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/pt-br.po
+++ b/packages/ckeditor5-select-all/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/pt.po
+++ b/packages/ckeditor5-select-all/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/ro.po
+++ b/packages/ckeditor5-select-all/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/ru.po
+++ b/packages/ckeditor5-select-all/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/si.po
+++ b/packages/ckeditor5-select-all/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/sk.po
+++ b/packages/ckeditor5-select-all/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/sl.po
+++ b/packages/ckeditor5-select-all/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/sq.po
+++ b/packages/ckeditor5-select-all/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-select-all/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/sr.po
+++ b/packages/ckeditor5-select-all/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/sv.po
+++ b/packages/ckeditor5-select-all/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/th.po
+++ b/packages/ckeditor5-select-all/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/ti.po
+++ b/packages/ckeditor5-select-all/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/tk.po
+++ b/packages/ckeditor5-select-all/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/tr.po
+++ b/packages/ckeditor5-select-all/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/tt.po
+++ b/packages/ckeditor5-select-all/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/ug.po
+++ b/packages/ckeditor5-select-all/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/uk.po
+++ b/packages/ckeditor5-select-all/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/ur.po
+++ b/packages/ckeditor5-select-all/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/uz.po
+++ b/packages/ckeditor5-select-all/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/vi.po
+++ b/packages/ckeditor5-select-all/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-select-all/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/lang/translations/zh.po
+++ b/packages/ckeditor5-select-all/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-select-all/src/augmentation.ts
+++ b/packages/ckeditor5-select-all/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-select-all/src/index.ts
+++ b/packages/ckeditor5-select-all/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-select-all/src/selectall.ts
+++ b/packages/ckeditor5-select-all/src/selectall.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-select-all/src/selectallcommand.ts
+++ b/packages/ckeditor5-select-all/src/selectallcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-select-all/src/selectallediting.ts
+++ b/packages/ckeditor5-select-all/src/selectallediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-select-all/src/selectallui.ts
+++ b/packages/ckeditor5-select-all/src/selectallui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-select-all/tests/manual/selectall.js
+++ b/packages/ckeditor5-select-all/tests/manual/selectall.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-select-all/tests/selectall.js
+++ b/packages/ckeditor5-select-all/tests/selectall.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-select-all/tests/selectallcommand.js
+++ b/packages/ckeditor5-select-all/tests/selectallcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-select-all/tests/selectallediting.js
+++ b/packages/ckeditor5-select-all/tests/selectallediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-select-all/tests/selectallui.js
+++ b/packages/ckeditor5-select-all/tests/selectallui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/LICENSE.md
+++ b/packages/ckeditor5-show-blocks/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Show blocks feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-show-blocks/docs/_snippets/features/show-blocks.js
+++ b/packages/ckeditor5-show-blocks/docs/_snippets/features/show-blocks.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/lang/translations/af.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/ar.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/ast.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/az.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/bg.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/bn.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/bs.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/ca.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/cs.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/da.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/de-ch.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/de.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/el.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/en-au.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/en-gb.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/en.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/eo.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/es-co.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/es.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/et.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/eu.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/fa.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/fi.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/fr.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/gl.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/gu.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/he.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/hi.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/hr.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/hu.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/hy.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/id.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/it.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/ja.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/jv.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/kk.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/km.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/kn.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/ko.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/ku.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/lt.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/lv.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/ms.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/nb.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/ne.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/nl.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/no.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/oc.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/pl.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/pt-br.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/pt.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/ro.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/ru.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/si.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/sk.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/sl.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/sq.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/sr.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/sv.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/th.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/ti.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/tk.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/tr.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/tt.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/ug.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/uk.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/ur.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/uz.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/vi.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/lang/translations/zh.po
+++ b/packages/ckeditor5-show-blocks/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-show-blocks/src/augmentation.ts
+++ b/packages/ckeditor5-show-blocks/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/src/index.ts
+++ b/packages/ckeditor5-show-blocks/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/src/showblocks.ts
+++ b/packages/ckeditor5-show-blocks/src/showblocks.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/src/showblockscommand.ts
+++ b/packages/ckeditor5-show-blocks/src/showblockscommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/src/showblocksediting.ts
+++ b/packages/ckeditor5-show-blocks/src/showblocksediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/src/showblocksui.ts
+++ b/packages/ckeditor5-show-blocks/src/showblocksui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/tests/index.js
+++ b/packages/ckeditor5-show-blocks/tests/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/tests/manual/showblocks-in-multirooteditor.js
+++ b/packages/ckeditor5-show-blocks/tests/manual/showblocks-in-multirooteditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/tests/manual/showblocks.js
+++ b/packages/ckeditor5-show-blocks/tests/manual/showblocks.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/tests/manual/showblockseditortypes.js
+++ b/packages/ckeditor5-show-blocks/tests/manual/showblockseditortypes.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/tests/showblocks.js
+++ b/packages/ckeditor5-show-blocks/tests/showblocks.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/tests/showblockscommand.js
+++ b/packages/ckeditor5-show-blocks/tests/showblockscommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/tests/showblocksediting.js
+++ b/packages/ckeditor5-show-blocks/tests/showblocksediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/tests/showblocksui.js
+++ b/packages/ckeditor5-show-blocks/tests/showblocksui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/theme/showblocks.css
+++ b/packages/ckeditor5-show-blocks/theme/showblocks.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-show-blocks/webpack.config.js
+++ b/packages/ckeditor5-show-blocks/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-source-editing/LICENSE.md
+++ b/packages/ckeditor5-source-editing/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Source editing feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing-imports.js
+++ b/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing-imports.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing-with-markdown.js
+++ b/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing-with-markdown.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing.css
+++ b/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing.js
+++ b/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-source-editing/lang/translations/af.po
+++ b/packages/ckeditor5-source-editing/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/ar.po
+++ b/packages/ckeditor5-source-editing/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/ast.po
+++ b/packages/ckeditor5-source-editing/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/az.po
+++ b/packages/ckeditor5-source-editing/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/bg.po
+++ b/packages/ckeditor5-source-editing/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/bn.po
+++ b/packages/ckeditor5-source-editing/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/bs.po
+++ b/packages/ckeditor5-source-editing/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/ca.po
+++ b/packages/ckeditor5-source-editing/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/cs.po
+++ b/packages/ckeditor5-source-editing/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/da.po
+++ b/packages/ckeditor5-source-editing/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/de-ch.po
+++ b/packages/ckeditor5-source-editing/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/de.po
+++ b/packages/ckeditor5-source-editing/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/el.po
+++ b/packages/ckeditor5-source-editing/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/en-au.po
+++ b/packages/ckeditor5-source-editing/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/en-gb.po
+++ b/packages/ckeditor5-source-editing/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/en.po
+++ b/packages/ckeditor5-source-editing/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/eo.po
+++ b/packages/ckeditor5-source-editing/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/es-co.po
+++ b/packages/ckeditor5-source-editing/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/es.po
+++ b/packages/ckeditor5-source-editing/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/et.po
+++ b/packages/ckeditor5-source-editing/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/eu.po
+++ b/packages/ckeditor5-source-editing/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/fa.po
+++ b/packages/ckeditor5-source-editing/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/fi.po
+++ b/packages/ckeditor5-source-editing/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/fr.po
+++ b/packages/ckeditor5-source-editing/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/gl.po
+++ b/packages/ckeditor5-source-editing/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/gu.po
+++ b/packages/ckeditor5-source-editing/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/he.po
+++ b/packages/ckeditor5-source-editing/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/hi.po
+++ b/packages/ckeditor5-source-editing/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/hr.po
+++ b/packages/ckeditor5-source-editing/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/hu.po
+++ b/packages/ckeditor5-source-editing/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/hy.po
+++ b/packages/ckeditor5-source-editing/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/id.po
+++ b/packages/ckeditor5-source-editing/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/it.po
+++ b/packages/ckeditor5-source-editing/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/ja.po
+++ b/packages/ckeditor5-source-editing/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/jv.po
+++ b/packages/ckeditor5-source-editing/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/kk.po
+++ b/packages/ckeditor5-source-editing/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/km.po
+++ b/packages/ckeditor5-source-editing/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/kn.po
+++ b/packages/ckeditor5-source-editing/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/ko.po
+++ b/packages/ckeditor5-source-editing/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/ku.po
+++ b/packages/ckeditor5-source-editing/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/lt.po
+++ b/packages/ckeditor5-source-editing/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/lv.po
+++ b/packages/ckeditor5-source-editing/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/ms.po
+++ b/packages/ckeditor5-source-editing/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/nb.po
+++ b/packages/ckeditor5-source-editing/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/ne.po
+++ b/packages/ckeditor5-source-editing/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/nl.po
+++ b/packages/ckeditor5-source-editing/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/no.po
+++ b/packages/ckeditor5-source-editing/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/oc.po
+++ b/packages/ckeditor5-source-editing/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/pl.po
+++ b/packages/ckeditor5-source-editing/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/pt-br.po
+++ b/packages/ckeditor5-source-editing/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/pt.po
+++ b/packages/ckeditor5-source-editing/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/ro.po
+++ b/packages/ckeditor5-source-editing/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/ru.po
+++ b/packages/ckeditor5-source-editing/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/si.po
+++ b/packages/ckeditor5-source-editing/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/sk.po
+++ b/packages/ckeditor5-source-editing/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/sl.po
+++ b/packages/ckeditor5-source-editing/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/sq.po
+++ b/packages/ckeditor5-source-editing/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-source-editing/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/sr.po
+++ b/packages/ckeditor5-source-editing/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/sv.po
+++ b/packages/ckeditor5-source-editing/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/th.po
+++ b/packages/ckeditor5-source-editing/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/ti.po
+++ b/packages/ckeditor5-source-editing/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/tk.po
+++ b/packages/ckeditor5-source-editing/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/tr.po
+++ b/packages/ckeditor5-source-editing/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/tt.po
+++ b/packages/ckeditor5-source-editing/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/ug.po
+++ b/packages/ckeditor5-source-editing/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/uk.po
+++ b/packages/ckeditor5-source-editing/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/ur.po
+++ b/packages/ckeditor5-source-editing/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/uz.po
+++ b/packages/ckeditor5-source-editing/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/vi.po
+++ b/packages/ckeditor5-source-editing/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-source-editing/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/lang/translations/zh.po
+++ b/packages/ckeditor5-source-editing/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-source-editing/src/augmentation.ts
+++ b/packages/ckeditor5-source-editing/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-source-editing/src/index.ts
+++ b/packages/ckeditor5-source-editing/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-source-editing/src/sourceediting.ts
+++ b/packages/ckeditor5-source-editing/src/sourceediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-source-editing/src/sourceeditingconfig.ts
+++ b/packages/ckeditor5-source-editing/src/sourceeditingconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-source-editing/src/utils/formathtml.ts
+++ b/packages/ckeditor5-source-editing/src/utils/formathtml.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-source-editing/tests/manual/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/manual/sourceediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-source-editing/tests/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/sourceediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-source-editing/tests/utils/formathtml.js
+++ b/packages/ckeditor5-source-editing/tests/utils/formathtml.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-source-editing/theme/sourceediting.css
+++ b/packages/ckeditor5-source-editing/theme/sourceediting.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-source-editing/webpack.config.js
+++ b/packages/ckeditor5-source-editing/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/LICENSE.md
+++ b/packages/ckeditor5-special-characters/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Special characters feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-extended-category.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-extended-category.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-limited-categories.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-limited-categories.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-new-category.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-new-category.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-source.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/lang/translations/af.po
+++ b/packages/ckeditor5-special-characters/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/ar.po
+++ b/packages/ckeditor5-special-characters/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/ast.po
+++ b/packages/ckeditor5-special-characters/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/az.po
+++ b/packages/ckeditor5-special-characters/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/bg.po
+++ b/packages/ckeditor5-special-characters/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/bn.po
+++ b/packages/ckeditor5-special-characters/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/bs.po
+++ b/packages/ckeditor5-special-characters/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/ca.po
+++ b/packages/ckeditor5-special-characters/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/cs.po
+++ b/packages/ckeditor5-special-characters/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/da.po
+++ b/packages/ckeditor5-special-characters/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/de-ch.po
+++ b/packages/ckeditor5-special-characters/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/de.po
+++ b/packages/ckeditor5-special-characters/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/el.po
+++ b/packages/ckeditor5-special-characters/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/en-au.po
+++ b/packages/ckeditor5-special-characters/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/en-gb.po
+++ b/packages/ckeditor5-special-characters/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/en.po
+++ b/packages/ckeditor5-special-characters/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/eo.po
+++ b/packages/ckeditor5-special-characters/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/es-co.po
+++ b/packages/ckeditor5-special-characters/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/es.po
+++ b/packages/ckeditor5-special-characters/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/et.po
+++ b/packages/ckeditor5-special-characters/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/eu.po
+++ b/packages/ckeditor5-special-characters/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/fa.po
+++ b/packages/ckeditor5-special-characters/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/fi.po
+++ b/packages/ckeditor5-special-characters/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/fr.po
+++ b/packages/ckeditor5-special-characters/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/gl.po
+++ b/packages/ckeditor5-special-characters/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/gu.po
+++ b/packages/ckeditor5-special-characters/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/he.po
+++ b/packages/ckeditor5-special-characters/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/hi.po
+++ b/packages/ckeditor5-special-characters/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/hr.po
+++ b/packages/ckeditor5-special-characters/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/hu.po
+++ b/packages/ckeditor5-special-characters/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/hy.po
+++ b/packages/ckeditor5-special-characters/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/id.po
+++ b/packages/ckeditor5-special-characters/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/it.po
+++ b/packages/ckeditor5-special-characters/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/ja.po
+++ b/packages/ckeditor5-special-characters/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/jv.po
+++ b/packages/ckeditor5-special-characters/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/kk.po
+++ b/packages/ckeditor5-special-characters/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/km.po
+++ b/packages/ckeditor5-special-characters/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/kn.po
+++ b/packages/ckeditor5-special-characters/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/ko.po
+++ b/packages/ckeditor5-special-characters/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/ku.po
+++ b/packages/ckeditor5-special-characters/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/lt.po
+++ b/packages/ckeditor5-special-characters/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/lv.po
+++ b/packages/ckeditor5-special-characters/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/ms.po
+++ b/packages/ckeditor5-special-characters/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/nb.po
+++ b/packages/ckeditor5-special-characters/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/ne.po
+++ b/packages/ckeditor5-special-characters/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/nl.po
+++ b/packages/ckeditor5-special-characters/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/no.po
+++ b/packages/ckeditor5-special-characters/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/oc.po
+++ b/packages/ckeditor5-special-characters/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/pl.po
+++ b/packages/ckeditor5-special-characters/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/pt-br.po
+++ b/packages/ckeditor5-special-characters/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/pt.po
+++ b/packages/ckeditor5-special-characters/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/ro.po
+++ b/packages/ckeditor5-special-characters/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/ru.po
+++ b/packages/ckeditor5-special-characters/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/si.po
+++ b/packages/ckeditor5-special-characters/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/sk.po
+++ b/packages/ckeditor5-special-characters/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/sl.po
+++ b/packages/ckeditor5-special-characters/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/sq.po
+++ b/packages/ckeditor5-special-characters/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-special-characters/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/sr.po
+++ b/packages/ckeditor5-special-characters/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/sv.po
+++ b/packages/ckeditor5-special-characters/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/th.po
+++ b/packages/ckeditor5-special-characters/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/ti.po
+++ b/packages/ckeditor5-special-characters/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/tk.po
+++ b/packages/ckeditor5-special-characters/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/tr.po
+++ b/packages/ckeditor5-special-characters/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/tt.po
+++ b/packages/ckeditor5-special-characters/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/ug.po
+++ b/packages/ckeditor5-special-characters/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/uk.po
+++ b/packages/ckeditor5-special-characters/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/ur.po
+++ b/packages/ckeditor5-special-characters/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/uz.po
+++ b/packages/ckeditor5-special-characters/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/vi.po
+++ b/packages/ckeditor5-special-characters/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-special-characters/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/lang/translations/zh.po
+++ b/packages/ckeditor5-special-characters/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-special-characters/src/augmentation.ts
+++ b/packages/ckeditor5-special-characters/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/src/index.ts
+++ b/packages/ckeditor5-special-characters/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/src/specialcharacters.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharacters.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/src/specialcharactersarrows.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharactersarrows.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/src/specialcharactersconfig.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharactersconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/src/specialcharacterscurrency.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharacterscurrency.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/src/specialcharactersessentials.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharactersessentials.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/src/specialcharacterslatin.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharacterslatin.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/src/specialcharactersmathematical.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharactersmathematical.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/src/specialcharacterstext.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharacterstext.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/src/ui/charactergridview.ts
+++ b/packages/ckeditor5-special-characters/src/ui/charactergridview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/src/ui/characterinfoview.ts
+++ b/packages/ckeditor5-special-characters/src/ui/characterinfoview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/src/ui/specialcharacterscategoriesview.ts
+++ b/packages/ckeditor5-special-characters/src/ui/specialcharacterscategoriesview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/src/ui/specialcharactersview.ts
+++ b/packages/ckeditor5-special-characters/src/ui/specialcharactersview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/tests/manual/specialcharacters.js
+++ b/packages/ckeditor5-special-characters/tests/manual/specialcharacters.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/tests/specialcharacters.js
+++ b/packages/ckeditor5-special-characters/tests/specialcharacters.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/tests/specialcharactersarrows.js
+++ b/packages/ckeditor5-special-characters/tests/specialcharactersarrows.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/tests/specialcharacterscurrency.js
+++ b/packages/ckeditor5-special-characters/tests/specialcharacterscurrency.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/tests/specialcharactersessentials.js
+++ b/packages/ckeditor5-special-characters/tests/specialcharactersessentials.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/tests/specialcharacterslatin.js
+++ b/packages/ckeditor5-special-characters/tests/specialcharacterslatin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/tests/specialcharactersmathematical.js
+++ b/packages/ckeditor5-special-characters/tests/specialcharactersmathematical.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/tests/specialcharacterstext.js
+++ b/packages/ckeditor5-special-characters/tests/specialcharacterstext.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/tests/ui/charactergridview.js
+++ b/packages/ckeditor5-special-characters/tests/ui/charactergridview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/tests/ui/characterinfoview.js
+++ b/packages/ckeditor5-special-characters/tests/ui/characterinfoview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/tests/ui/specialcharacterscategoriesview.js
+++ b/packages/ckeditor5-special-characters/tests/ui/specialcharacterscategoriesview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/tests/ui/specialcharactersview.js
+++ b/packages/ckeditor5-special-characters/tests/ui/specialcharactersview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/theme/charactergrid.css
+++ b/packages/ckeditor5-special-characters/theme/charactergrid.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/theme/characterinfo.css
+++ b/packages/ckeditor5-special-characters/theme/characterinfo.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/theme/specialcharacters.css
+++ b/packages/ckeditor5-special-characters/theme/specialcharacters.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-special-characters/webpack.config.js
+++ b/packages/ckeditor5-special-characters/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/LICENSE.md
+++ b/packages/ckeditor5-style/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Style feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.js
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/lang/translations/af.po
+++ b/packages/ckeditor5-style/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/ar.po
+++ b/packages/ckeditor5-style/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/ast.po
+++ b/packages/ckeditor5-style/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/az.po
+++ b/packages/ckeditor5-style/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/bg.po
+++ b/packages/ckeditor5-style/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/bn.po
+++ b/packages/ckeditor5-style/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/bs.po
+++ b/packages/ckeditor5-style/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/ca.po
+++ b/packages/ckeditor5-style/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/cs.po
+++ b/packages/ckeditor5-style/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/da.po
+++ b/packages/ckeditor5-style/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/de-ch.po
+++ b/packages/ckeditor5-style/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/de.po
+++ b/packages/ckeditor5-style/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/el.po
+++ b/packages/ckeditor5-style/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/en-au.po
+++ b/packages/ckeditor5-style/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/en-gb.po
+++ b/packages/ckeditor5-style/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/en.po
+++ b/packages/ckeditor5-style/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/eo.po
+++ b/packages/ckeditor5-style/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/es-co.po
+++ b/packages/ckeditor5-style/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/es.po
+++ b/packages/ckeditor5-style/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/et.po
+++ b/packages/ckeditor5-style/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/eu.po
+++ b/packages/ckeditor5-style/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/fa.po
+++ b/packages/ckeditor5-style/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/fi.po
+++ b/packages/ckeditor5-style/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/fr.po
+++ b/packages/ckeditor5-style/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/gl.po
+++ b/packages/ckeditor5-style/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/gu.po
+++ b/packages/ckeditor5-style/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/he.po
+++ b/packages/ckeditor5-style/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/hi.po
+++ b/packages/ckeditor5-style/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/hr.po
+++ b/packages/ckeditor5-style/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/hu.po
+++ b/packages/ckeditor5-style/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/hy.po
+++ b/packages/ckeditor5-style/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/id.po
+++ b/packages/ckeditor5-style/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/it.po
+++ b/packages/ckeditor5-style/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/ja.po
+++ b/packages/ckeditor5-style/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/jv.po
+++ b/packages/ckeditor5-style/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/kk.po
+++ b/packages/ckeditor5-style/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/km.po
+++ b/packages/ckeditor5-style/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/kn.po
+++ b/packages/ckeditor5-style/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/ko.po
+++ b/packages/ckeditor5-style/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/ku.po
+++ b/packages/ckeditor5-style/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/lt.po
+++ b/packages/ckeditor5-style/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/lv.po
+++ b/packages/ckeditor5-style/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/ms.po
+++ b/packages/ckeditor5-style/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/nb.po
+++ b/packages/ckeditor5-style/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/ne.po
+++ b/packages/ckeditor5-style/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/nl.po
+++ b/packages/ckeditor5-style/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/no.po
+++ b/packages/ckeditor5-style/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/oc.po
+++ b/packages/ckeditor5-style/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/pl.po
+++ b/packages/ckeditor5-style/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/pt-br.po
+++ b/packages/ckeditor5-style/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/pt.po
+++ b/packages/ckeditor5-style/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/ro.po
+++ b/packages/ckeditor5-style/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/ru.po
+++ b/packages/ckeditor5-style/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/si.po
+++ b/packages/ckeditor5-style/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/sk.po
+++ b/packages/ckeditor5-style/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/sl.po
+++ b/packages/ckeditor5-style/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/sq.po
+++ b/packages/ckeditor5-style/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-style/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/sr.po
+++ b/packages/ckeditor5-style/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/sv.po
+++ b/packages/ckeditor5-style/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/th.po
+++ b/packages/ckeditor5-style/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/ti.po
+++ b/packages/ckeditor5-style/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/tk.po
+++ b/packages/ckeditor5-style/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/tr.po
+++ b/packages/ckeditor5-style/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/tt.po
+++ b/packages/ckeditor5-style/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/ug.po
+++ b/packages/ckeditor5-style/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/uk.po
+++ b/packages/ckeditor5-style/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/ur.po
+++ b/packages/ckeditor5-style/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/uz.po
+++ b/packages/ckeditor5-style/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/vi.po
+++ b/packages/ckeditor5-style/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-style/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/lang/translations/zh.po
+++ b/packages/ckeditor5-style/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-style/src/augmentation.ts
+++ b/packages/ckeditor5-style/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/src/index.ts
+++ b/packages/ckeditor5-style/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/src/integrations/link.ts
+++ b/packages/ckeditor5-style/src/integrations/link.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/src/integrations/list.ts
+++ b/packages/ckeditor5-style/src/integrations/list.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/src/integrations/table.ts
+++ b/packages/ckeditor5-style/src/integrations/table.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/src/style.ts
+++ b/packages/ckeditor5-style/src/style.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/src/stylecommand.ts
+++ b/packages/ckeditor5-style/src/stylecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/src/styleconfig.ts
+++ b/packages/ckeditor5-style/src/styleconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/src/styleediting.ts
+++ b/packages/ckeditor5-style/src/styleediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/src/styleui.ts
+++ b/packages/ckeditor5-style/src/styleui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/src/styleutils.ts
+++ b/packages/ckeditor5-style/src/styleutils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/src/ui/stylegridbuttonview.ts
+++ b/packages/ckeditor5-style/src/ui/stylegridbuttonview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/src/ui/stylegridview.ts
+++ b/packages/ckeditor5-style/src/ui/stylegridview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/src/ui/stylegroupview.ts
+++ b/packages/ckeditor5-style/src/ui/stylegroupview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/src/ui/stylepanelview.ts
+++ b/packages/ckeditor5-style/src/ui/stylepanelview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/tests/integrations/link.js
+++ b/packages/ckeditor5-style/tests/integrations/link.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/tests/integrations/list.js
+++ b/packages/ckeditor5-style/tests/integrations/list.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/tests/integrations/table.js
+++ b/packages/ckeditor5-style/tests/integrations/table.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/tests/manual/styledropdown.js
+++ b/packages/ckeditor5-style/tests/manual/styledropdown.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/tests/style.js
+++ b/packages/ckeditor5-style/tests/style.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/tests/stylecommand.js
+++ b/packages/ckeditor5-style/tests/stylecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/tests/styleediting.js
+++ b/packages/ckeditor5-style/tests/styleediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/tests/styleui.js
+++ b/packages/ckeditor5-style/tests/styleui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/tests/styleutils.js
+++ b/packages/ckeditor5-style/tests/styleutils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/tests/tickets/11580.js
+++ b/packages/ckeditor5-style/tests/tickets/11580.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/tests/ui/stylegridbuttonview.js
+++ b/packages/ckeditor5-style/tests/ui/stylegridbuttonview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/tests/ui/stylegridview.js
+++ b/packages/ckeditor5-style/tests/ui/stylegridview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/tests/ui/stylegroupview.js
+++ b/packages/ckeditor5-style/tests/ui/stylegroupview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/tests/ui/stylepanelview.js
+++ b/packages/ckeditor5-style/tests/ui/stylepanelview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/theme/style.css
+++ b/packages/ckeditor5-style/theme/style.css
@@ -1,4 +1,4 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */

--- a/packages/ckeditor5-style/theme/stylegrid.css
+++ b/packages/ckeditor5-style/theme/stylegrid.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/theme/stylegroup.css
+++ b/packages/ckeditor5-style/theme/stylegroup.css
@@ -1,4 +1,4 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */

--- a/packages/ckeditor5-style/theme/stylepanel.css
+++ b/packages/ckeditor5-style/theme/stylepanel.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-style/webpack.config.js
+++ b/packages/ckeditor5-style/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/LICENSE.md
+++ b/packages/ckeditor5-table/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Table feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-table/docs/_snippets/features/build-table-source.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/build-table-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/docs/_snippets/features/table-caption.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/table-caption.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/docs/_snippets/features/table-column-resize.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/table-column-resize.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/docs/_snippets/features/table-default-headings.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/table-default-headings.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/docs/_snippets/features/table-default-properties.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/table-default-properties.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/docs/_snippets/features/table-nesting.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/table-nesting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/docs/_snippets/features/table-styling-colors.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/table-styling-colors.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/docs/_snippets/features/table-styling.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/table-styling.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/docs/_snippets/features/tables.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/tables.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/lang/translations/af.po
+++ b/packages/ckeditor5-table/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/ar.po
+++ b/packages/ckeditor5-table/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/ast.po
+++ b/packages/ckeditor5-table/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/az.po
+++ b/packages/ckeditor5-table/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/bg.po
+++ b/packages/ckeditor5-table/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/bn.po
+++ b/packages/ckeditor5-table/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/bs.po
+++ b/packages/ckeditor5-table/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/ca.po
+++ b/packages/ckeditor5-table/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/cs.po
+++ b/packages/ckeditor5-table/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/da.po
+++ b/packages/ckeditor5-table/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/de-ch.po
+++ b/packages/ckeditor5-table/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/de.po
+++ b/packages/ckeditor5-table/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/el.po
+++ b/packages/ckeditor5-table/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/en-au.po
+++ b/packages/ckeditor5-table/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/en-gb.po
+++ b/packages/ckeditor5-table/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/en.po
+++ b/packages/ckeditor5-table/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/eo.po
+++ b/packages/ckeditor5-table/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/es-co.po
+++ b/packages/ckeditor5-table/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/es.po
+++ b/packages/ckeditor5-table/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/et.po
+++ b/packages/ckeditor5-table/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/eu.po
+++ b/packages/ckeditor5-table/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/fa.po
+++ b/packages/ckeditor5-table/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/fi.po
+++ b/packages/ckeditor5-table/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/fr.po
+++ b/packages/ckeditor5-table/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/gl.po
+++ b/packages/ckeditor5-table/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/gu.po
+++ b/packages/ckeditor5-table/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/he.po
+++ b/packages/ckeditor5-table/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/hi.po
+++ b/packages/ckeditor5-table/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/hr.po
+++ b/packages/ckeditor5-table/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/hu.po
+++ b/packages/ckeditor5-table/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/hy.po
+++ b/packages/ckeditor5-table/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/id.po
+++ b/packages/ckeditor5-table/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/it.po
+++ b/packages/ckeditor5-table/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/ja.po
+++ b/packages/ckeditor5-table/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/jv.po
+++ b/packages/ckeditor5-table/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/kk.po
+++ b/packages/ckeditor5-table/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/km.po
+++ b/packages/ckeditor5-table/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/kn.po
+++ b/packages/ckeditor5-table/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/ko.po
+++ b/packages/ckeditor5-table/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/ku.po
+++ b/packages/ckeditor5-table/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/lt.po
+++ b/packages/ckeditor5-table/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/lv.po
+++ b/packages/ckeditor5-table/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/ms.po
+++ b/packages/ckeditor5-table/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/nb.po
+++ b/packages/ckeditor5-table/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/ne.po
+++ b/packages/ckeditor5-table/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/nl.po
+++ b/packages/ckeditor5-table/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/no.po
+++ b/packages/ckeditor5-table/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/oc.po
+++ b/packages/ckeditor5-table/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/pl.po
+++ b/packages/ckeditor5-table/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/pt-br.po
+++ b/packages/ckeditor5-table/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/pt.po
+++ b/packages/ckeditor5-table/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/ro.po
+++ b/packages/ckeditor5-table/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/ru.po
+++ b/packages/ckeditor5-table/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/si.po
+++ b/packages/ckeditor5-table/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/sk.po
+++ b/packages/ckeditor5-table/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/sl.po
+++ b/packages/ckeditor5-table/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/sq.po
+++ b/packages/ckeditor5-table/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-table/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/sr.po
+++ b/packages/ckeditor5-table/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/sv.po
+++ b/packages/ckeditor5-table/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/th.po
+++ b/packages/ckeditor5-table/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/ti.po
+++ b/packages/ckeditor5-table/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/tk.po
+++ b/packages/ckeditor5-table/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/tr.po
+++ b/packages/ckeditor5-table/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/tt.po
+++ b/packages/ckeditor5-table/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/ug.po
+++ b/packages/ckeditor5-table/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/uk.po
+++ b/packages/ckeditor5-table/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/ur.po
+++ b/packages/ckeditor5-table/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/uz.po
+++ b/packages/ckeditor5-table/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/vi.po
+++ b/packages/ckeditor5-table/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-table/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/lang/translations/zh.po
+++ b/packages/ckeditor5-table/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-table/src/augmentation.ts
+++ b/packages/ckeditor5-table/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/commands/insertcolumncommand.ts
+++ b/packages/ckeditor5-table/src/commands/insertcolumncommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/commands/insertrowcommand.ts
+++ b/packages/ckeditor5-table/src/commands/insertrowcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/commands/inserttablecommand.ts
+++ b/packages/ckeditor5-table/src/commands/inserttablecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/commands/mergecellcommand.ts
+++ b/packages/ckeditor5-table/src/commands/mergecellcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/commands/mergecellscommand.ts
+++ b/packages/ckeditor5-table/src/commands/mergecellscommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/commands/removecolumncommand.ts
+++ b/packages/ckeditor5-table/src/commands/removecolumncommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/commands/removerowcommand.ts
+++ b/packages/ckeditor5-table/src/commands/removerowcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/commands/selectcolumncommand.ts
+++ b/packages/ckeditor5-table/src/commands/selectcolumncommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/commands/selectrowcommand.ts
+++ b/packages/ckeditor5-table/src/commands/selectrowcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/commands/setheadercolumncommand.ts
+++ b/packages/ckeditor5-table/src/commands/setheadercolumncommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/commands/setheaderrowcommand.ts
+++ b/packages/ckeditor5-table/src/commands/setheaderrowcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/commands/splitcellcommand.ts
+++ b/packages/ckeditor5-table/src/commands/splitcellcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/converters/downcast.ts
+++ b/packages/ckeditor5-table/src/converters/downcast.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/converters/table-caption-post-fixer.ts
+++ b/packages/ckeditor5-table/src/converters/table-caption-post-fixer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/converters/table-cell-paragraph-post-fixer.ts
+++ b/packages/ckeditor5-table/src/converters/table-cell-paragraph-post-fixer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/converters/table-cell-refresh-handler.ts
+++ b/packages/ckeditor5-table/src/converters/table-cell-refresh-handler.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/converters/table-headings-refresh-handler.ts
+++ b/packages/ckeditor5-table/src/converters/table-headings-refresh-handler.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/converters/table-layout-post-fixer.ts
+++ b/packages/ckeditor5-table/src/converters/table-layout-post-fixer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/converters/tableproperties.ts
+++ b/packages/ckeditor5-table/src/converters/tableproperties.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/converters/upcasttable.ts
+++ b/packages/ckeditor5-table/src/converters/upcasttable.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/index.ts
+++ b/packages/ckeditor5-table/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/plaintableoutput.ts
+++ b/packages/ckeditor5-table/src/plaintableoutput.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/table.ts
+++ b/packages/ckeditor5-table/src/table.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecaption.ts
+++ b/packages/ckeditor5-table/src/tablecaption.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecaption/tablecaptionediting.ts
+++ b/packages/ckeditor5-table/src/tablecaption/tablecaptionediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecaption/tablecaptionui.ts
+++ b/packages/ckeditor5-table/src/tablecaption/tablecaptionui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecaption/toggletablecaptioncommand.ts
+++ b/packages/ckeditor5-table/src/tablecaption/toggletablecaptioncommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecaption/utils.ts
+++ b/packages/ckeditor5-table/src/tablecaption/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecellproperties.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellbackgroundcolorcommand.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellbackgroundcolorcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellbordercolorcommand.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellbordercolorcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellborderstylecommand.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellborderstylecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellborderwidthcommand.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellborderwidthcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellheightcommand.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellheightcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellhorizontalalignmentcommand.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellhorizontalalignmentcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellpaddingcommand.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellpaddingcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellpropertycommand.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellpropertycommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellverticalalignmentcommand.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellverticalalignmentcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesui.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecellproperties/ui/tablecellpropertiesview.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/ui/tablecellpropertiesview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecellwidth/commands/tablecellwidthcommand.ts
+++ b/packages/ckeditor5-table/src/tablecellwidth/commands/tablecellwidthcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecellwidth/tablecellwidthediting.ts
+++ b/packages/ckeditor5-table/src/tablecellwidth/tablecellwidthediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableclipboard.ts
+++ b/packages/ckeditor5-table/src/tableclipboard.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecolumnresize.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecolumnresize/constants.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize/constants.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecolumnresize/converters.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize/converters.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablewidthscommand.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablewidthscommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablecolumnresize/utils.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableconfig.ts
+++ b/packages/ckeditor5-table/src/tableconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableediting.ts
+++ b/packages/ckeditor5-table/src/tableediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablekeyboard.ts
+++ b/packages/ckeditor5-table/src/tablekeyboard.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablemouse.ts
+++ b/packages/ckeditor5-table/src/tablemouse.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablemouse/mouseeventsobserver.ts
+++ b/packages/ckeditor5-table/src/tablemouse/mouseeventsobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableproperties.ts
+++ b/packages/ckeditor5-table/src/tableproperties.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableproperties/commands/tablealignmentcommand.ts
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tablealignmentcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableproperties/commands/tablebackgroundcolorcommand.ts
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tablebackgroundcolorcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableproperties/commands/tablebordercolorcommand.ts
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tablebordercolorcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableproperties/commands/tableborderstylecommand.ts
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tableborderstylecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableproperties/commands/tableborderwidthcommand.ts
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tableborderwidthcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableproperties/commands/tableheightcommand.ts
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tableheightcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableproperties/commands/tablepropertycommand.ts
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tablepropertycommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableproperties/commands/tablewidthcommand.ts
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tablewidthcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesui.ts
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.ts
+++ b/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableselection.ts
+++ b/packages/ckeditor5-table/src/tableselection.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tabletoolbar.ts
+++ b/packages/ckeditor5-table/src/tabletoolbar.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableui.ts
+++ b/packages/ckeditor5-table/src/tableui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tableutils.ts
+++ b/packages/ckeditor5-table/src/tableutils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/tablewalker.ts
+++ b/packages/ckeditor5-table/src/tablewalker.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/ui/colorinputview.ts
+++ b/packages/ckeditor5-table/src/ui/colorinputview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/ui/formrowview.ts
+++ b/packages/ckeditor5-table/src/ui/formrowview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/ui/inserttableview.ts
+++ b/packages/ckeditor5-table/src/ui/inserttableview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/utils/common.ts
+++ b/packages/ckeditor5-table/src/utils/common.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/utils/structure.ts
+++ b/packages/ckeditor5-table/src/utils/structure.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/utils/table-properties.ts
+++ b/packages/ckeditor5-table/src/utils/table-properties.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/utils/ui/contextualballoon.ts
+++ b/packages/ckeditor5-table/src/utils/ui/contextualballoon.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/utils/ui/table-properties.ts
+++ b/packages/ckeditor5-table/src/utils/ui/table-properties.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/src/utils/ui/widget.ts
+++ b/packages/ckeditor5-table/src/utils/ui/widget.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/_utils-tests/table-ascii-art.js
+++ b/packages/ckeditor5-table/tests/_utils-tests/table-ascii-art.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/_utils/utils.js
+++ b/packages/ckeditor5-table/tests/_utils/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/commands/insertcolumncommand.js
+++ b/packages/ckeditor5-table/tests/commands/insertcolumncommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/commands/insertrowcommand.js
+++ b/packages/ckeditor5-table/tests/commands/insertrowcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/commands/inserttablecommand.js
+++ b/packages/ckeditor5-table/tests/commands/inserttablecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/commands/mergecellcommand.js
+++ b/packages/ckeditor5-table/tests/commands/mergecellcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/commands/mergecellscommand.js
+++ b/packages/ckeditor5-table/tests/commands/mergecellscommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/commands/removecolumncommand.js
+++ b/packages/ckeditor5-table/tests/commands/removecolumncommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/commands/removerowcommand.js
+++ b/packages/ckeditor5-table/tests/commands/removerowcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/commands/selectcolumncommand.js
+++ b/packages/ckeditor5-table/tests/commands/selectcolumncommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/commands/selectrowcommand.js
+++ b/packages/ckeditor5-table/tests/commands/selectrowcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/commands/setheadercolumncommand.js
+++ b/packages/ckeditor5-table/tests/commands/setheadercolumncommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/commands/setheaderrowcommand.js
+++ b/packages/ckeditor5-table/tests/commands/setheaderrowcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/commands/splitcellcommand.js
+++ b/packages/ckeditor5-table/tests/commands/splitcellcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/converters/downcast.js
+++ b/packages/ckeditor5-table/tests/converters/downcast.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/converters/table-caption-post-fixer.js
+++ b/packages/ckeditor5-table/tests/converters/table-caption-post-fixer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/converters/table-cell-paragraph-post-fixer.js
+++ b/packages/ckeditor5-table/tests/converters/table-cell-paragraph-post-fixer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/converters/table-cell-refresh-handler.js
+++ b/packages/ckeditor5-table/tests/converters/table-cell-refresh-handler.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/converters/table-layout-post-fixer.js
+++ b/packages/ckeditor5-table/tests/converters/table-layout-post-fixer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/converters/upcasttable.js
+++ b/packages/ckeditor5-table/tests/converters/upcasttable.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/integration.js
+++ b/packages/ckeditor5-table/tests/integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/manual/plaintableoutput.js
+++ b/packages/ckeditor5-table/tests/manual/plaintableoutput.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/manual/rtl.js
+++ b/packages/ckeditor5-table/tests/manual/rtl.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/manual/table.js
+++ b/packages/ckeditor5-table/tests/manual/table.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/manual/tableautoheadings.js
+++ b/packages/ckeditor5-table/tests/manual/tableautoheadings.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/manual/tableblockcontent.js
+++ b/packages/ckeditor5-table/tests/manual/tableblockcontent.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/manual/tablecaption.js
+++ b/packages/ckeditor5-table/tests/manual/tablecaption.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/manual/tableclipboard.js
+++ b/packages/ckeditor5-table/tests/manual/tableclipboard.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/manual/tablecolumnresize.js
+++ b/packages/ckeditor5-table/tests/manual/tablecolumnresize.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/manual/tablecolumnresizewithoutproperties.js
+++ b/packages/ckeditor5-table/tests/manual/tablecolumnresizewithoutproperties.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/manual/tabledefaultproperties.js
+++ b/packages/ckeditor5-table/tests/manual/tabledefaultproperties.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/manual/tablemocking.js
+++ b/packages/ckeditor5-table/tests/manual/tablemocking.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/manual/tablenonesting.js
+++ b/packages/ckeditor5-table/tests/manual/tablenonesting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/manual/tableproperties.js
+++ b/packages/ckeditor5-table/tests/manual/tableproperties.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/manual/tableselection.js
+++ b/packages/ckeditor5-table/tests/manual/tableselection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/manual/tickets/10042.js
+++ b/packages/ckeditor5-table/tests/manual/tickets/10042.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/manual/tickets/6062.js
+++ b/packages/ckeditor5-table/tests/manual/tickets/6062.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/plaintableoutput.js
+++ b/packages/ckeditor5-table/tests/plaintableoutput.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/table-integration.js
+++ b/packages/ckeditor5-table/tests/table-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/table.js
+++ b/packages/ckeditor5-table/tests/table.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecaption/tablecaption.js
+++ b/packages/ckeditor5-table/tests/tablecaption/tablecaption.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecaption/tablecaptionediting.js
+++ b/packages/ckeditor5-table/tests/tablecaption/tablecaptionediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecaption/tablecaptionui.js
+++ b/packages/ckeditor5-table/tests/tablecaption/tablecaptionui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecaption/toggletablecaptioncommand.js
+++ b/packages/ckeditor5-table/tests/tablecaption/toggletablecaptioncommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecaption/utils.js
+++ b/packages/ckeditor5-table/tests/tablecaption/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecellproperties.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellbackgroundcolorcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellbackgroundcolorcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellborderstylecommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellborderstylecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellheightcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellheightcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellpaddingcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellpaddingcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesui.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/ui/tablecellpropertiesview.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/ui/tablecellpropertiesview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecellwidth/commands/tablecellwidthcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellwidth/commands/tablecellwidthcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecellwidth/tablecellwidthediting.js
+++ b/packages/ckeditor5-table/tests/tablecellwidth/tablecellwidthediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableclipboard-copy-cut.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-copy-cut.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableclipboard.js
+++ b/packages/ckeditor5-table/tests/tableclipboard.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecolumnresize/_utils/utils.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/_utils/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresize.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresize.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablewidthscommand.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablewidthscommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableediting.js
+++ b/packages/ckeditor5-table/tests/tableediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablekeyboard.js
+++ b/packages/ckeditor5-table/tests/tablekeyboard.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablemouse.js
+++ b/packages/ckeditor5-table/tests/tablemouse.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableproperties.js
+++ b/packages/ckeditor5-table/tests/tableproperties.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tablealignmentcommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tablealignmentcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tablebackgroundcolorcommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tablebackgroundcolorcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tablebordercolorcommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tablebordercolorcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tableborderstylecommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tableborderstylecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tableborderwidthcommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tableborderwidthcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tableheightcommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tableheightcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tablewidthcommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tablewidthcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting-integration.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableproperties/ui/tablepropertiesview.js
+++ b/packages/ckeditor5-table/tests/tableproperties/ui/tablepropertiesview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableselection-integration.js
+++ b/packages/ckeditor5-table/tests/tableselection-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableselection.js
+++ b/packages/ckeditor5-table/tests/tableselection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableselection/mouseeventsobserver.js
+++ b/packages/ckeditor5-table/tests/tableselection/mouseeventsobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tabletoolbar.js
+++ b/packages/ckeditor5-table/tests/tabletoolbar.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableui.js
+++ b/packages/ckeditor5-table/tests/tableui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tableutils.js
+++ b/packages/ckeditor5-table/tests/tableutils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/tablewalker.js
+++ b/packages/ckeditor5-table/tests/tablewalker.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/ui/colorinputview.js
+++ b/packages/ckeditor5-table/tests/ui/colorinputview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/ui/formrowview.js
+++ b/packages/ckeditor5-table/tests/ui/formrowview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/ui/inserttableview.js
+++ b/packages/ckeditor5-table/tests/ui/inserttableview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/utils/common.js
+++ b/packages/ckeditor5-table/tests/utils/common.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/utils/structure.js
+++ b/packages/ckeditor5-table/tests/utils/structure.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/utils/table-properties.js
+++ b/packages/ckeditor5-table/tests/utils/table-properties.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/utils/ui/contextualballoon.js
+++ b/packages/ckeditor5-table/tests/utils/ui/contextualballoon.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/utils/ui/table-properties.js
+++ b/packages/ckeditor5-table/tests/utils/ui/table-properties.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/tests/utils/ui/widget.js
+++ b/packages/ckeditor5-table/tests/utils/ui/widget.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/theme/colorinput.css
+++ b/packages/ckeditor5-table/theme/colorinput.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/theme/form.css
+++ b/packages/ckeditor5-table/theme/form.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/theme/formrow.css
+++ b/packages/ckeditor5-table/theme/formrow.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/theme/inserttable.css
+++ b/packages/ckeditor5-table/theme/inserttable.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/theme/tablecaption.css
+++ b/packages/ckeditor5-table/theme/tablecaption.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/theme/tablecellproperties.css
+++ b/packages/ckeditor5-table/theme/tablecellproperties.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/theme/tableediting.css
+++ b/packages/ckeditor5-table/theme/tableediting.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/theme/tableform.css
+++ b/packages/ckeditor5-table/theme/tableform.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/theme/tableproperties.css
+++ b/packages/ckeditor5-table/theme/tableproperties.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/theme/tableselection.css
+++ b/packages/ckeditor5-table/theme/tableselection.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-table/webpack.config.js
+++ b/packages/ckeditor5-table/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/LICENSE.md
+++ b/packages/ckeditor5-theme-lark/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Lark theme** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-theme-lark/docs/_snippets/examples/custom.css
+++ b/packages/ckeditor5-theme-lark/docs/_snippets/examples/custom.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/docs/_snippets/examples/theme-lark.js
+++ b/packages/ckeditor5-theme-lark/docs/_snippets/examples/theme-lark.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/tests/42.js
+++ b/packages/ckeditor5-theme-lark/tests/42.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/tests/manual/iconset.js
+++ b/packages/ckeditor5-theme-lark/tests/manual/iconset.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/tests/manual/inverted.js
+++ b/packages/ckeditor5-theme-lark/tests/manual/inverted.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/tests/manual/reset.js
+++ b/packages/ckeditor5-theme-lark/tests/manual/reset.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/tests/manual/theme.js
+++ b/packages/ckeditor5-theme-lark/tests/manual/theme.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/tests/manual/tickets/113/1.js
+++ b/packages/ckeditor5-theme-lark/tests/manual/tickets/113/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/tests/manual/tickets/189/1.js
+++ b/packages/ckeditor5-theme-lark/tests/manual/tickets/189/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/tests/manual/tickets/189/assets/iframe-content.js
+++ b/packages/ckeditor5-theme-lark/tests/manual/tickets/189/assets/iframe-content.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-bookmark/bookmark.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-bookmark/bookmark.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-clipboard/clipboard.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-clipboard/clipboard.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-code-block/codeblock.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-code-block/codeblock.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-editor-classic/classiceditor.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-editor-classic/classiceditor.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-engine/placeholder.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-engine/placeholder.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-find-and-replace/findandreplaceform.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-find-and-replace/findandreplaceform.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-heading/heading.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-heading/heading.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-horizontal-line/horizontalline.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-horizontal-line/horizontalline.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-html-embed/htmlembed.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-html-embed/htmlembed.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageinsert.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageinsert.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageupload.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageupload.css
@@ -1,4 +1,4 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageuploadicon.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageuploadicon.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageuploadloader.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageuploadloader.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageuploadprogress.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageuploadprogress.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-link/link.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-link/link.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkactions.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkactions.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkform.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkform.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkimage.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkimage.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-list/listproperties.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-list/listproperties.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-list/liststyles.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-list/liststyles.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-media-embed/mediaembedediting.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-media-embed/mediaembedediting.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-mention/mention.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-mention/mention.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-restricted-editing/restrictedediting.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-restricted-editing/restrictedediting.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-special-characters/charactergrid.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-special-characters/charactergrid.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-special-characters/characterinfo.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-special-characters/characterinfo.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-special-characters/specialcharacters.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-special-characters/specialcharacters.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-style/style.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-style/style.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-style/stylegrid.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-style/stylegrid.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-style/stylegroup.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-style/stylegroup.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-style/stylepanel.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-style/stylepanel.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/colorinput.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/colorinput.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/form.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/form.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/formrow.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/formrow.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/inserttable.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/inserttable.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablecellproperties.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablecellproperties.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableediting.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableediting.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableform.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableform.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableproperties.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableproperties.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableselection.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableselection.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/autocomplete/autocomplete.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/autocomplete/autocomplete.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/button.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/button.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/listitembutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/listitembutton.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/switchbutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/switchbutton.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/collapsible/collapsible.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/collapsible/collapsible.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/colorgrid/colorgrid.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/colorgrid/colorgrid.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/colorselector/colorselector.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/colorselector/colorselector.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dialog/dialog.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dialog/dialog.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dialog/dialogactions.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dialog/dialogactions.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/dropdown.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/dropdown.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/listdropdown.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/listdropdown.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenubutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenubutton.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenulistitem.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenulistitem.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenulistitembutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenulistitembutton.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenupanel.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenupanel.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/splitbutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/splitbutton.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/toolbardropdown.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/toolbardropdown.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/editorui/accessibilityhelp.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/editorui/accessibilityhelp.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/editorui/editorui.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/editorui/editorui.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/formheader/formheader.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/formheader/formheader.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/icon/icon.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/icon/icon.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/input/input.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/input/input.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/label/label.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/label/label.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/labeledfield/labeledfieldview.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/labeledfield/labeledfieldview.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/labeledinput/labeledinput.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/labeledinput/labeledinput.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/list/list.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/list/list.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubar.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubar.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenu.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenu.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenubutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenubutton.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenulistitem.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenulistitem.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenulistitembutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenulistitembutton.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenupanel.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenupanel.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/panel/balloonpanel.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/panel/balloonpanel.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/panel/balloonrotator.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/panel/balloonrotator.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/panel/fakepanel.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/panel/fakepanel.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/panel/stickypanel.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/panel/stickypanel.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/responsive-form/responsiveform.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/responsive-form/responsiveform.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/search/search.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/search/search.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/spinner/spinner.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/spinner/spinner.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/textarea/textarea.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/textarea/textarea.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/toolbar/blocktoolbar.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/toolbar/blocktoolbar.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/toolbar/toolbar.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/toolbar/toolbar.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/tooltip/tooltip.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/tooltip/tooltip.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_colors.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_colors.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_disabled.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_disabled.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_focus.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_focus.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_fonts.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_fonts.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_reset.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_reset.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_rounded.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_rounded.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_shadow.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_shadow.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_spacing.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_spacing.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/globals.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/globals.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/mixins/_button.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/mixins/_button.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widget.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widget.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgetresize.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgetresize.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/index.css
+++ b/packages/ckeditor5-theme-lark/theme/index.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/mixins/_disabled.css
+++ b/packages/ckeditor5-theme-lark/theme/mixins/_disabled.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/mixins/_focus.css
+++ b/packages/ckeditor5-theme-lark/theme/mixins/_focus.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/mixins/_rounded.css
+++ b/packages/ckeditor5-theme-lark/theme/mixins/_rounded.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/mixins/_shadow.css
+++ b/packages/ckeditor5-theme-lark/theme/mixins/_shadow.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-theme-lark/theme/theme.css
+++ b/packages/ckeditor5-theme-lark/theme/theme.css
@@ -1,4 +1,4 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */

--- a/packages/ckeditor5-typing/LICENSE.md
+++ b/packages/ckeditor5-typing/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Typing feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-typing/docs/_snippets/features/build-text-transformation-source.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/build-text-transformation-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation-extended.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation-extended.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/augmentation.ts
+++ b/packages/ckeditor5-typing/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/delete.ts
+++ b/packages/ckeditor5-typing/src/delete.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/deletecommand.ts
+++ b/packages/ckeditor5-typing/src/deletecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/deleteobserver.ts
+++ b/packages/ckeditor5-typing/src/deleteobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/index.ts
+++ b/packages/ckeditor5-typing/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/input.ts
+++ b/packages/ckeditor5-typing/src/input.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/inserttextcommand.ts
+++ b/packages/ckeditor5-typing/src/inserttextcommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/inserttextobserver.ts
+++ b/packages/ckeditor5-typing/src/inserttextobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/texttransformation.ts
+++ b/packages/ckeditor5-typing/src/texttransformation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/textwatcher.ts
+++ b/packages/ckeditor5-typing/src/textwatcher.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/twostepcaretmovement.ts
+++ b/packages/ckeditor5-typing/src/twostepcaretmovement.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/typing.ts
+++ b/packages/ckeditor5-typing/src/typing.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/typingconfig.ts
+++ b/packages/ckeditor5-typing/src/typingconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/utils/changebuffer.ts
+++ b/packages/ckeditor5-typing/src/utils/changebuffer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/utils/findattributerange.ts
+++ b/packages/ckeditor5-typing/src/utils/findattributerange.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/utils/getlasttextline.ts
+++ b/packages/ckeditor5-typing/src/utils/getlasttextline.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/src/utils/inlinehighlight.ts
+++ b/packages/ckeditor5-typing/src/utils/inlinehighlight.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/_utils/utils.js
+++ b/packages/ckeditor5-typing/tests/_utils/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/delete-integration.js
+++ b/packages/ckeditor5-typing/tests/delete-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/delete.js
+++ b/packages/ckeditor5-typing/tests/delete.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/deletecommand.js
+++ b/packages/ckeditor5-typing/tests/deletecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/deleteobserver.js
+++ b/packages/ckeditor5-typing/tests/deleteobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/input-integration.js
+++ b/packages/ckeditor5-typing/tests/input-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/input.js
+++ b/packages/ckeditor5-typing/tests/input.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/inserttextcommand.js
+++ b/packages/ckeditor5-typing/tests/inserttextcommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/inserttextobserver.js
+++ b/packages/ckeditor5-typing/tests/inserttextobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/1301/1.js
+++ b/packages/ckeditor5-typing/tests/manual/1301/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/20/1.js
+++ b/packages/ckeditor5-typing/tests/manual/20/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/21/1.js
+++ b/packages/ckeditor5-typing/tests/manual/21/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/40/1.js
+++ b/packages/ckeditor5-typing/tests/manual/40/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/52/1.js
+++ b/packages/ckeditor5-typing/tests/manual/52/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/59/1.js
+++ b/packages/ckeditor5-typing/tests/manual/59/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/82/1.js
+++ b/packages/ckeditor5-typing/tests/manual/82/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/86/1.js
+++ b/packages/ckeditor5-typing/tests/manual/86/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/beforeinput-contenteditable.js
+++ b/packages/ckeditor5-typing/tests/manual/beforeinput-contenteditable.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/beforeinput.js
+++ b/packages/ckeditor5-typing/tests/manual/beforeinput.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/delete.js
+++ b/packages/ckeditor5-typing/tests/manual/delete.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/input.js
+++ b/packages/ckeditor5-typing/tests/manual/input.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/nbsp.js
+++ b/packages/ckeditor5-typing/tests/manual/nbsp.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/rtl.js
+++ b/packages/ckeditor5-typing/tests/manual/rtl.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/selection.js
+++ b/packages/ckeditor5-typing/tests/manual/selection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/spellchecking.js
+++ b/packages/ckeditor5-typing/tests/manual/spellchecking.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/texttransformation.js
+++ b/packages/ckeditor5-typing/tests/manual/texttransformation.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/two-step-caret.js
+++ b/packages/ckeditor5-typing/tests/manual/two-step-caret.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/manual/unicode.js
+++ b/packages/ckeditor5-typing/tests/manual/unicode.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/texttransformation-integration.js
+++ b/packages/ckeditor5-typing/tests/texttransformation-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/texttransformation.js
+++ b/packages/ckeditor5-typing/tests/texttransformation.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/textwatcher.js
+++ b/packages/ckeditor5-typing/tests/textwatcher.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/tickets/11904.js
+++ b/packages/ckeditor5-typing/tests/tickets/11904.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/tickets/59.js
+++ b/packages/ckeditor5-typing/tests/tickets/59.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/twostepcaretmovement.js
+++ b/packages/ckeditor5-typing/tests/twostepcaretmovement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/typing.js
+++ b/packages/ckeditor5-typing/tests/typing.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/utils/changebuffer.js
+++ b/packages/ckeditor5-typing/tests/utils/changebuffer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/utils/findattributerange.js
+++ b/packages/ckeditor5-typing/tests/utils/findattributerange.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/utils/getlasttextline.js
+++ b/packages/ckeditor5-typing/tests/utils/getlasttextline.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-typing/tests/utils/inlinehighlight.js
+++ b/packages/ckeditor5-typing/tests/utils/inlinehighlight.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/LICENSE.md
+++ b/packages/ckeditor5-ui/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 UI framework** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-ui/docs/_snippets/examples/bootstrap-ui-inner.js
+++ b/packages/ckeditor5-ui/docs/_snippets/examples/bootstrap-ui-inner.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/docs/_snippets/examples/bootstrap-ui.js
+++ b/packages/ckeditor5-ui/docs/_snippets/examples/bootstrap-ui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/lang/translations/af.po
+++ b/packages/ckeditor5-ui/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/ar.po
+++ b/packages/ckeditor5-ui/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/ast.po
+++ b/packages/ckeditor5-ui/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/az.po
+++ b/packages/ckeditor5-ui/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/bg.po
+++ b/packages/ckeditor5-ui/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/bn.po
+++ b/packages/ckeditor5-ui/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/bs.po
+++ b/packages/ckeditor5-ui/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/ca.po
+++ b/packages/ckeditor5-ui/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/cs.po
+++ b/packages/ckeditor5-ui/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/da.po
+++ b/packages/ckeditor5-ui/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/de-ch.po
+++ b/packages/ckeditor5-ui/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/de.po
+++ b/packages/ckeditor5-ui/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/el.po
+++ b/packages/ckeditor5-ui/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/en-au.po
+++ b/packages/ckeditor5-ui/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/en-gb.po
+++ b/packages/ckeditor5-ui/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/en.po
+++ b/packages/ckeditor5-ui/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/eo.po
+++ b/packages/ckeditor5-ui/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/es-co.po
+++ b/packages/ckeditor5-ui/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/es.po
+++ b/packages/ckeditor5-ui/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/et.po
+++ b/packages/ckeditor5-ui/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/eu.po
+++ b/packages/ckeditor5-ui/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/fa.po
+++ b/packages/ckeditor5-ui/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/fi.po
+++ b/packages/ckeditor5-ui/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/fr.po
+++ b/packages/ckeditor5-ui/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/gl.po
+++ b/packages/ckeditor5-ui/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/gu.po
+++ b/packages/ckeditor5-ui/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/he.po
+++ b/packages/ckeditor5-ui/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/hi.po
+++ b/packages/ckeditor5-ui/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/hr.po
+++ b/packages/ckeditor5-ui/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/hu.po
+++ b/packages/ckeditor5-ui/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/hy.po
+++ b/packages/ckeditor5-ui/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/id.po
+++ b/packages/ckeditor5-ui/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/it.po
+++ b/packages/ckeditor5-ui/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/ja.po
+++ b/packages/ckeditor5-ui/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/jv.po
+++ b/packages/ckeditor5-ui/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/kk.po
+++ b/packages/ckeditor5-ui/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/km.po
+++ b/packages/ckeditor5-ui/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/kn.po
+++ b/packages/ckeditor5-ui/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/ko.po
+++ b/packages/ckeditor5-ui/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/ku.po
+++ b/packages/ckeditor5-ui/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/lt.po
+++ b/packages/ckeditor5-ui/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/lv.po
+++ b/packages/ckeditor5-ui/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/ms.po
+++ b/packages/ckeditor5-ui/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/nb.po
+++ b/packages/ckeditor5-ui/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/ne.po
+++ b/packages/ckeditor5-ui/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/nl.po
+++ b/packages/ckeditor5-ui/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/no.po
+++ b/packages/ckeditor5-ui/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/oc.po
+++ b/packages/ckeditor5-ui/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/pl.po
+++ b/packages/ckeditor5-ui/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/pt-br.po
+++ b/packages/ckeditor5-ui/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/pt.po
+++ b/packages/ckeditor5-ui/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/ro.po
+++ b/packages/ckeditor5-ui/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/ru.po
+++ b/packages/ckeditor5-ui/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/si.po
+++ b/packages/ckeditor5-ui/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/sk.po
+++ b/packages/ckeditor5-ui/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/sl.po
+++ b/packages/ckeditor5-ui/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/sq.po
+++ b/packages/ckeditor5-ui/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-ui/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/sr.po
+++ b/packages/ckeditor5-ui/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/sv.po
+++ b/packages/ckeditor5-ui/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/th.po
+++ b/packages/ckeditor5-ui/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/ti.po
+++ b/packages/ckeditor5-ui/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/tk.po
+++ b/packages/ckeditor5-ui/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/tr.po
+++ b/packages/ckeditor5-ui/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/tt.po
+++ b/packages/ckeditor5-ui/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/ug.po
+++ b/packages/ckeditor5-ui/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/uk.po
+++ b/packages/ckeditor5-ui/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/ur.po
+++ b/packages/ckeditor5-ui/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/uz.po
+++ b/packages/ckeditor5-ui/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/vi.po
+++ b/packages/ckeditor5-ui/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-ui/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/lang/translations/zh.po
+++ b/packages/ckeditor5-ui/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-ui/src/arialiveannouncer.ts
+++ b/packages/ckeditor5-ui/src/arialiveannouncer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/augmentation.ts
+++ b/packages/ckeditor5-ui/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/autocomplete/autocompleteview.ts
+++ b/packages/ckeditor5-ui/src/autocomplete/autocompleteview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/badge/badge.ts
+++ b/packages/ckeditor5-ui/src/badge/badge.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/bindings/addkeyboardhandlingforgrid.ts
+++ b/packages/ckeditor5-ui/src/bindings/addkeyboardhandlingforgrid.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/bindings/clickoutsidehandler.ts
+++ b/packages/ckeditor5-ui/src/bindings/clickoutsidehandler.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/bindings/csstransitiondisablermixin.ts
+++ b/packages/ckeditor5-ui/src/bindings/csstransitiondisablermixin.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/bindings/draggableviewmixin.ts
+++ b/packages/ckeditor5-ui/src/bindings/draggableviewmixin.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/bindings/injectcsstransitiondisabler.ts
+++ b/packages/ckeditor5-ui/src/bindings/injectcsstransitiondisabler.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/bindings/preventdefault.ts
+++ b/packages/ckeditor5-ui/src/bindings/preventdefault.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/bindings/submithandler.ts
+++ b/packages/ckeditor5-ui/src/bindings/submithandler.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/button/button.ts
+++ b/packages/ckeditor5-ui/src/button/button.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/button/buttonlabel.ts
+++ b/packages/ckeditor5-ui/src/button/buttonlabel.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/button/buttonlabelview.ts
+++ b/packages/ckeditor5-ui/src/button/buttonlabelview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/button/buttonview.ts
+++ b/packages/ckeditor5-ui/src/button/buttonview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/button/filedialogbuttonview.ts
+++ b/packages/ckeditor5-ui/src/button/filedialogbuttonview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/button/listitembuttonview.ts
+++ b/packages/ckeditor5-ui/src/button/listitembuttonview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/button/switchbuttonview.ts
+++ b/packages/ckeditor5-ui/src/button/switchbuttonview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/collapsible/collapsibleview.ts
+++ b/packages/ckeditor5-ui/src/collapsible/collapsibleview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/colorgrid/colorgridview.ts
+++ b/packages/ckeditor5-ui/src/colorgrid/colorgridview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/colorgrid/colortileview.ts
+++ b/packages/ckeditor5-ui/src/colorgrid/colortileview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/colorgrid/utils.ts
+++ b/packages/ckeditor5-ui/src/colorgrid/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/colorpicker/utils.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/colorselector/colorgridsfragmentview.ts
+++ b/packages/ckeditor5-ui/src/colorselector/colorgridsfragmentview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/colorselector/colorpickerfragmentview.ts
+++ b/packages/ckeditor5-ui/src/colorselector/colorpickerfragmentview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/colorselector/colorselectorview.ts
+++ b/packages/ckeditor5-ui/src/colorselector/colorselectorview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/colorselector/documentcolorcollection.ts
+++ b/packages/ckeditor5-ui/src/colorselector/documentcolorcollection.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/componentfactory.ts
+++ b/packages/ckeditor5-ui/src/componentfactory.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dialog/dialog.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialog.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dialog/dialogactionsview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogactionsview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dialog/dialogcontentview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogcontentview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dialog/dialogview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dropdown/button/dropdownbutton.ts
+++ b/packages/ckeditor5-ui/src/dropdown/button/dropdownbutton.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dropdown/button/dropdownbuttonview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/button/dropdownbuttonview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dropdown/button/splitbuttonview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/button/splitbuttonview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dropdown/dropdownpanelfocusable.ts
+++ b/packages/ckeditor5-ui/src/dropdown/dropdownpanelfocusable.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dropdown/dropdownpanelview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/dropdownpanelview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dropdown/dropdownview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/dropdownview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenubehaviors.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenubehaviors.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenubuttonview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenubuttonview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenulistitembuttonview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenulistitembuttonview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenulistitemview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenulistitemview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenulistview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenulistview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenunestedmenupanelview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenunestedmenupanelview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenunestedmenuview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenunestedmenuview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenurootlistview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenurootlistview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dropdown/menu/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/editableui/editableuiview.ts
+++ b/packages/ckeditor5-ui/src/editableui/editableuiview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/editableui/inline/inlineeditableuiview.ts
+++ b/packages/ckeditor5-ui/src/editableui/inline/inlineeditableuiview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/editorui/accessibilityhelp/accessibilityhelp.ts
+++ b/packages/ckeditor5-ui/src/editorui/accessibilityhelp/accessibilityhelp.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/editorui/accessibilityhelp/accessibilityhelpcontentview.ts
+++ b/packages/ckeditor5-ui/src/editorui/accessibilityhelp/accessibilityhelpcontentview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/editorui/bodycollection.ts
+++ b/packages/ckeditor5-ui/src/editorui/bodycollection.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/editorui/boxed/boxededitoruiview.ts
+++ b/packages/ckeditor5-ui/src/editorui/boxed/boxededitoruiview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/editorui/editorui.ts
+++ b/packages/ckeditor5-ui/src/editorui/editorui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/editorui/editoruiview.ts
+++ b/packages/ckeditor5-ui/src/editorui/editoruiview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/editorui/evaluationbadge.ts
+++ b/packages/ckeditor5-ui/src/editorui/evaluationbadge.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/editorui/poweredby.ts
+++ b/packages/ckeditor5-ui/src/editorui/poweredby.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/focuscycler.ts
+++ b/packages/ckeditor5-ui/src/focuscycler.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/formheader/formheaderview.ts
+++ b/packages/ckeditor5-ui/src/formheader/formheaderview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/highlightedtext/buttonlabelwithhighlightview.ts
+++ b/packages/ckeditor5-ui/src/highlightedtext/buttonlabelwithhighlightview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/highlightedtext/highlightedtextview.ts
+++ b/packages/ckeditor5-ui/src/highlightedtext/highlightedtextview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/highlightedtext/labelwithhighlightview.ts
+++ b/packages/ckeditor5-ui/src/highlightedtext/labelwithhighlightview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/icon/iconview.ts
+++ b/packages/ckeditor5-ui/src/icon/iconview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/iframe/iframeview.ts
+++ b/packages/ckeditor5-ui/src/iframe/iframeview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/input/inputbase.ts
+++ b/packages/ckeditor5-ui/src/input/inputbase.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/input/inputview.ts
+++ b/packages/ckeditor5-ui/src/input/inputview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/inputnumber/inputnumberview.ts
+++ b/packages/ckeditor5-ui/src/inputnumber/inputnumberview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/inputtext/inputtextview.ts
+++ b/packages/ckeditor5-ui/src/inputtext/inputtextview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/label/labelview.ts
+++ b/packages/ckeditor5-ui/src/label/labelview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/labeledfield/labeledfieldview.ts
+++ b/packages/ckeditor5-ui/src/labeledfield/labeledfieldview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/labeledfield/utils.ts
+++ b/packages/ckeditor5-ui/src/labeledfield/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/labeledinput/labeledinputview.ts
+++ b/packages/ckeditor5-ui/src/labeledinput/labeledinputview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/list/listitemgroupview.ts
+++ b/packages/ckeditor5-ui/src/list/listitemgroupview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/list/listitemview.ts
+++ b/packages/ckeditor5-ui/src/list/listitemview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/list/listseparatorview.ts
+++ b/packages/ckeditor5-ui/src/list/listseparatorview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/list/listview.ts
+++ b/packages/ckeditor5-ui/src/list/listview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/menubar/menubarmenubuttonview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenubuttonview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/menubar/menubarmenulistitembuttonview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenulistitembuttonview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/menubar/menubarmenulistitemfiledialogbuttonview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenulistitemfiledialogbuttonview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/menubar/menubarmenulistitemview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenulistitemview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/menubar/menubarmenulistview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenulistview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/menubar/menubarmenupanelview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenupanelview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/menubar/menubarmenuview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenuview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/menubar/menubarview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/menubar/utils.ts
+++ b/packages/ckeditor5-ui/src/menubar/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/model.ts
+++ b/packages/ckeditor5-ui/src/model.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/notification/notification.ts
+++ b/packages/ckeditor5-ui/src/notification/notification.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/panel/balloon/contextualballoon.ts
+++ b/packages/ckeditor5-ui/src/panel/balloon/contextualballoon.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/search/filteredview.ts
+++ b/packages/ckeditor5-ui/src/search/filteredview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/search/filtergroupanditemnames.ts
+++ b/packages/ckeditor5-ui/src/search/filtergroupanditemnames.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/search/searchinfoview.ts
+++ b/packages/ckeditor5-ui/src/search/searchinfoview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/search/searchresultsview.ts
+++ b/packages/ckeditor5-ui/src/search/searchresultsview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/search/text/searchtextqueryview.ts
+++ b/packages/ckeditor5-ui/src/search/text/searchtextqueryview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/search/text/searchtextview.ts
+++ b/packages/ckeditor5-ui/src/search/text/searchtextview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/spinner/spinnerview.ts
+++ b/packages/ckeditor5-ui/src/spinner/spinnerview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/template.ts
+++ b/packages/ckeditor5-ui/src/template.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/textarea/textareaview.ts
+++ b/packages/ckeditor5-ui/src/textarea/textareaview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/toolbar/balloon/balloontoolbar.ts
+++ b/packages/ckeditor5-ui/src/toolbar/balloon/balloontoolbar.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/toolbar/block/blockbuttonview.ts
+++ b/packages/ckeditor5-ui/src/toolbar/block/blockbuttonview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.ts
+++ b/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/toolbar/normalizetoolbarconfig.ts
+++ b/packages/ckeditor5-ui/src/toolbar/normalizetoolbarconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/toolbar/toolbarlinebreakview.ts
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarlinebreakview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/toolbar/toolbarseparatorview.ts
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarseparatorview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.ts
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/tooltipmanager.ts
+++ b/packages/ckeditor5-ui/src/tooltipmanager.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/view.ts
+++ b/packages/ckeditor5-ui/src/view.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/src/viewcollection.ts
+++ b/packages/ckeditor5-ui/src/viewcollection.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/_utils-tests/testfocuscycling.ts
+++ b/packages/ckeditor5-ui/tests/_utils-tests/testfocuscycling.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/_utils-tests/utils.js
+++ b/packages/ckeditor5-ui/tests/_utils-tests/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/_utils/utils.js
+++ b/packages/ckeditor5-ui/tests/_utils/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/autocomplete/autocompleteview.js
+++ b/packages/ckeditor5-ui/tests/autocomplete/autocompleteview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/badge/badge.js
+++ b/packages/ckeditor5-ui/tests/badge/badge.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/bindings/addkeyboardhandlingforgrid.js
+++ b/packages/ckeditor5-ui/tests/bindings/addkeyboardhandlingforgrid.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/bindings/clickoutsidehandler.js
+++ b/packages/ckeditor5-ui/tests/bindings/clickoutsidehandler.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/bindings/csstransitiondisablermixin.js
+++ b/packages/ckeditor5-ui/tests/bindings/csstransitiondisablermixin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/bindings/draggableviewmixin.js
+++ b/packages/ckeditor5-ui/tests/bindings/draggableviewmixin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/bindings/injectcsstransitiondisabler.js
+++ b/packages/ckeditor5-ui/tests/bindings/injectcsstransitiondisabler.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/bindings/preventdefault.js
+++ b/packages/ckeditor5-ui/tests/bindings/preventdefault.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/bindings/submithandler.js
+++ b/packages/ckeditor5-ui/tests/bindings/submithandler.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/button/buttonlabelview.js
+++ b/packages/ckeditor5-ui/tests/button/buttonlabelview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/button/buttonview.js
+++ b/packages/ckeditor5-ui/tests/button/buttonview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/button/filedialogbuttonview.js
+++ b/packages/ckeditor5-ui/tests/button/filedialogbuttonview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/button/listitembuttonview.js
+++ b/packages/ckeditor5-ui/tests/button/listitembuttonview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/button/switchbuttonview.js
+++ b/packages/ckeditor5-ui/tests/button/switchbuttonview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/collapsible/collapsibleview.js
+++ b/packages/ckeditor5-ui/tests/collapsible/collapsibleview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/colorgrid/colorgridview.js
+++ b/packages/ckeditor5-ui/tests/colorgrid/colorgridview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/colorgrid/colortileview.js
+++ b/packages/ckeditor5-ui/tests/colorgrid/colortileview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/colorgrid/utils.js
+++ b/packages/ckeditor5-ui/tests/colorgrid/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/colorpicker/colorpickerview.js
+++ b/packages/ckeditor5-ui/tests/colorpicker/colorpickerview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/colorpicker/utils.js
+++ b/packages/ckeditor5-ui/tests/colorpicker/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/colorselector/colorselectorview.js
+++ b/packages/ckeditor5-ui/tests/colorselector/colorselectorview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/colorselector/documentcolorcollection.js
+++ b/packages/ckeditor5-ui/tests/colorselector/documentcolorcollection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/componentfactory.js
+++ b/packages/ckeditor5-ui/tests/componentfactory.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dialog/dialog.js
+++ b/packages/ckeditor5-ui/tests/dialog/dialog.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dialog/dialogactionsview.js
+++ b/packages/ckeditor5-ui/tests/dialog/dialogactionsview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dialog/dialogcontentview.js
+++ b/packages/ckeditor5-ui/tests/dialog/dialogcontentview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dialog/dialogview.js
+++ b/packages/ckeditor5-ui/tests/dialog/dialogview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dropdown/button/dropdownbuttonview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/button/dropdownbuttonview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dropdown/button/splitbuttonview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/button/splitbuttonview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dropdown/dropdownpanelview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/dropdownpanelview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dropdown/dropdownview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/dropdownview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dropdown/menu/_utils/dropdowntreemock.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/_utils/dropdowntreemock.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenubehaviors.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenubehaviors.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenubuttonview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenubuttonview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenulistitembuttonview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenulistitembuttonview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenulistitemview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenulistitemview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenulistview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenulistview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenunestedmenupanelview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenunestedmenupanelview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenunestedmenuview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenunestedmenuview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenurootlistview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenurootlistview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/dropdown/utils.js
+++ b/packages/ckeditor5-ui/tests/dropdown/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/editableui/editableuiview.js
+++ b/packages/ckeditor5-ui/tests/editableui/editableuiview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/editableui/inline/inlineeditableuiview.js
+++ b/packages/ckeditor5-ui/tests/editableui/inline/inlineeditableuiview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/editorui/accessibilityhelp/accessibilityhelp.js
+++ b/packages/ckeditor5-ui/tests/editorui/accessibilityhelp/accessibilityhelp.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/editorui/accessibilityhelp/accessibilityhelpcontentview.js
+++ b/packages/ckeditor5-ui/tests/editorui/accessibilityhelp/accessibilityhelpcontentview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/editorui/arialiveannouncer.js
+++ b/packages/ckeditor5-ui/tests/editorui/arialiveannouncer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/editorui/bodycollection.js
+++ b/packages/ckeditor5-ui/tests/editorui/bodycollection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/editorui/boxed/boxededitoruiview.js
+++ b/packages/ckeditor5-ui/tests/editorui/boxed/boxededitoruiview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/editorui/editorui.js
+++ b/packages/ckeditor5-ui/tests/editorui/editorui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/editorui/editoruiview.js
+++ b/packages/ckeditor5-ui/tests/editorui/editoruiview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/editorui/evaluationbadge.js
+++ b/packages/ckeditor5-ui/tests/editorui/evaluationbadge.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/editorui/poweredby.js
+++ b/packages/ckeditor5-ui/tests/editorui/poweredby.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/focuscycler.js
+++ b/packages/ckeditor5-ui/tests/focuscycler.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/formheader/formheaderview.js
+++ b/packages/ckeditor5-ui/tests/formheader/formheaderview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/highlightedtext/buttonlabelwithhighlightview.js
+++ b/packages/ckeditor5-ui/tests/highlightedtext/buttonlabelwithhighlightview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/highlightedtext/highlightedtextview.js
+++ b/packages/ckeditor5-ui/tests/highlightedtext/highlightedtextview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/highlightedtext/labelwithhighlightview.js
+++ b/packages/ckeditor5-ui/tests/highlightedtext/labelwithhighlightview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/icon/iconview.js
+++ b/packages/ckeditor5-ui/tests/icon/iconview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/iframe/iframeview.js
+++ b/packages/ckeditor5-ui/tests/iframe/iframeview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/input/inputbase.js
+++ b/packages/ckeditor5-ui/tests/input/inputbase.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/input/inputview.js
+++ b/packages/ckeditor5-ui/tests/input/inputview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/inputnumber/inputnumberview.js
+++ b/packages/ckeditor5-ui/tests/inputnumber/inputnumberview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/inputtext/inputtextview.js
+++ b/packages/ckeditor5-ui/tests/inputtext/inputtextview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/label/labelview.js
+++ b/packages/ckeditor5-ui/tests/label/labelview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/labeledfield/labeledfieldview.js
+++ b/packages/ckeditor5-ui/tests/labeledfield/labeledfieldview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/labeledfield/utils.js
+++ b/packages/ckeditor5-ui/tests/labeledfield/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/labeledinput/labeledinputview.js
+++ b/packages/ckeditor5-ui/tests/labeledinput/labeledinputview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/list/listitemgroupview.js
+++ b/packages/ckeditor5-ui/tests/list/listitemgroupview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/list/listitemview.js
+++ b/packages/ckeditor5-ui/tests/list/listitemview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/list/listseparatorview.js
+++ b/packages/ckeditor5-ui/tests/list/listseparatorview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/list/listview.js
+++ b/packages/ckeditor5-ui/tests/list/listview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/autocomplete/autocomplete.ts
+++ b/packages/ckeditor5-ui/tests/manual/autocomplete/autocomplete.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/balloontoolbar/balloontoolbar-multi-root.js
+++ b/packages/ckeditor5-ui/tests/manual/balloontoolbar/balloontoolbar-multi-root.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/balloontoolbar/balloontoolbar.js
+++ b/packages/ckeditor5-ui/tests/manual/balloontoolbar/balloontoolbar.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/bindings/draggableviewmixin.ts
+++ b/packages/ckeditor5-ui/tests/manual/bindings/draggableviewmixin.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/blocktoolbar/blocktoolbar.js
+++ b/packages/ckeditor5-ui/tests/manual/blocktoolbar/blocktoolbar.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/blocktoolbar/rtl.js
+++ b/packages/ckeditor5-ui/tests/manual/blocktoolbar/rtl.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/blocktoolbar/scrollable-blocktoolbar.js
+++ b/packages/ckeditor5-ui/tests/manual/blocktoolbar/scrollable-blocktoolbar.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/contextualballoon/contextualballoon.js
+++ b/packages/ckeditor5-ui/tests/manual/contextualballoon/contextualballoon.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/contextualballoon/externalchanges.js
+++ b/packages/ckeditor5-ui/tests/manual/contextualballoon/externalchanges.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/dialog/dialog-body-scroll-lock.ts
+++ b/packages/ckeditor5-ui/tests/manual/dialog/dialog-body-scroll-lock.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/dialog/dialog-esc-key-handling.ts
+++ b/packages/ckeditor5-ui/tests/manual/dialog/dialog-esc-key-handling.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/dialog/dialog.ts
+++ b/packages/ckeditor5-ui/tests/manual/dialog/dialog.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/dropdown/dropdown.js
+++ b/packages/ckeditor5-ui/tests/manual/dropdown/dropdown.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/dropdown/panelposition.js
+++ b/packages/ckeditor5-ui/tests/manual/dropdown/panelposition.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/icon/icon.js
+++ b/packages/ckeditor5-ui/tests/manual/icon/icon.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/list/list.js
+++ b/packages/ckeditor5-ui/tests/manual/list/list.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/menubar/menubar.js
+++ b/packages/ckeditor5-ui/tests/manual/menubar/menubar.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/panel/balloon/balloonpanelview.js
+++ b/packages/ckeditor5-ui/tests/manual/panel/balloon/balloonpanelview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/panel/sticky/stickypanelview.js
+++ b/packages/ckeditor5-ui/tests/manual/panel/sticky/stickypanelview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/poweredby/poweredby-customized.js
+++ b/packages/ckeditor5-ui/tests/manual/poweredby/poweredby-customized.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/poweredby/poweredby-force-visible.js
+++ b/packages/ckeditor5-ui/tests/manual/poweredby/poweredby-force-visible.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/poweredby/poweredby-with-key.js
+++ b/packages/ckeditor5-ui/tests/manual/poweredby/poweredby-with-key.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/poweredby/poweredby.js
+++ b/packages/ckeditor5-ui/tests/manual/poweredby/poweredby.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/search/search.ts
+++ b/packages/ckeditor5-ui/tests/manual/search/search.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/textarea/textareaview.ts
+++ b/packages/ckeditor5-ui/tests/manual/textarea/textareaview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/tickets/126/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/126/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/tickets/170/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/170/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/tickets/198/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/198/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/tickets/228/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/228/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/tickets/385/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/385/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/tickets/418/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/418/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/tickets/5328/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/5328/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/tickets/76/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/76/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/tickets/9412/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/9412/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/tickets/9892/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/9892/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/toolbar/grouping.js
+++ b/packages/ckeditor5-ui/tests/manual/toolbar/grouping.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/toolbar/nested.js
+++ b/packages/ckeditor5-ui/tests/manual/toolbar/nested.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/manual/tooltip/tooltip.js
+++ b/packages/ckeditor5-ui/tests/manual/tooltip/tooltip.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/menubar/_utils/utils.js
+++ b/packages/ckeditor5-ui/tests/menubar/_utils/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/menubar/menubarmenubuttonview.js
+++ b/packages/ckeditor5-ui/tests/menubar/menubarmenubuttonview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/menubar/menubarmenulistitembuttonview.js
+++ b/packages/ckeditor5-ui/tests/menubar/menubarmenulistitembuttonview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/menubar/menubarmenulistitemfiledialogbuttonview.js
+++ b/packages/ckeditor5-ui/tests/menubar/menubarmenulistitemfiledialogbuttonview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/menubar/menubarmenulistitemview.js
+++ b/packages/ckeditor5-ui/tests/menubar/menubarmenulistitemview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/menubar/menubarmenulistview.js
+++ b/packages/ckeditor5-ui/tests/menubar/menubarmenulistview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/menubar/menubarmenupanelview.js
+++ b/packages/ckeditor5-ui/tests/menubar/menubarmenupanelview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/menubar/menubarmenuview.js
+++ b/packages/ckeditor5-ui/tests/menubar/menubarmenuview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/menubar/menubarview.js
+++ b/packages/ckeditor5-ui/tests/menubar/menubarview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/menubar/utils.js
+++ b/packages/ckeditor5-ui/tests/menubar/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/model.js
+++ b/packages/ckeditor5-ui/tests/model.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/notification/notification.js
+++ b/packages/ckeditor5-ui/tests/notification/notification.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/panel/balloon/balloonpanelview.js
+++ b/packages/ckeditor5-ui/tests/panel/balloon/balloonpanelview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/panel/balloon/contextualballoon.js
+++ b/packages/ckeditor5-ui/tests/panel/balloon/contextualballoon.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/panel/sticky/stickypanelview.js
+++ b/packages/ckeditor5-ui/tests/panel/sticky/stickypanelview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/search/filtergroupanditemnames.js
+++ b/packages/ckeditor5-ui/tests/search/filtergroupanditemnames.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/search/searchinfoview.js
+++ b/packages/ckeditor5-ui/tests/search/searchinfoview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/search/searchresultsview.js
+++ b/packages/ckeditor5-ui/tests/search/searchresultsview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/search/text/searchtextqueryview.js
+++ b/packages/ckeditor5-ui/tests/search/text/searchtextqueryview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/search/text/searchtextview.js
+++ b/packages/ckeditor5-ui/tests/search/text/searchtextview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/spinner/spinner.js
+++ b/packages/ckeditor5-ui/tests/spinner/spinner.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/template.js
+++ b/packages/ckeditor5-ui/tests/template.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/textarea/textareaview.js
+++ b/packages/ckeditor5-ui/tests/textarea/textareaview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/toolbar/balloon/balloontoolbar.js
+++ b/packages/ckeditor5-ui/tests/toolbar/balloon/balloontoolbar.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/toolbar/block/blockbuttonview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/block/blockbuttonview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/toolbar/block/blocktoolbar.js
+++ b/packages/ckeditor5-ui/tests/toolbar/block/blocktoolbar.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/toolbar/normalizetoolbarconfig.js
+++ b/packages/ckeditor5-ui/tests/toolbar/normalizetoolbarconfig.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/toolbar/toolbarlinebreakview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/toolbarlinebreakview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/toolbar/toolbarseparatorview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/toolbarseparatorview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
+++ b/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/view.js
+++ b/packages/ckeditor5-ui/tests/view.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/tests/viewcollection.js
+++ b/packages/ckeditor5-ui/tests/viewcollection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/arialiveannouncer/arialiveannouncer.css
+++ b/packages/ckeditor5-ui/theme/components/arialiveannouncer/arialiveannouncer.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/autocomplete/autocomplete.css
+++ b/packages/ckeditor5-ui/theme/components/autocomplete/autocomplete.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/button/button.css
+++ b/packages/ckeditor5-ui/theme/components/button/button.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/button/listitembutton.css
+++ b/packages/ckeditor5-ui/theme/components/button/listitembutton.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/button/switchbutton.css
+++ b/packages/ckeditor5-ui/theme/components/button/switchbutton.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/collapsible/collapsible.css
+++ b/packages/ckeditor5-ui/theme/components/collapsible/collapsible.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/colorgrid/colorgrid.css
+++ b/packages/ckeditor5-ui/theme/components/colorgrid/colorgrid.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/colorpicker/colorpicker.css
+++ b/packages/ckeditor5-ui/theme/components/colorpicker/colorpicker.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/colorselector/colorselector.css
+++ b/packages/ckeditor5-ui/theme/components/colorselector/colorselector.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/dialog/dialog.css
+++ b/packages/ckeditor5-ui/theme/components/dialog/dialog.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/dialog/dialogactions.css
+++ b/packages/ckeditor5-ui/theme/components/dialog/dialogactions.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/dropdown/dropdown.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/dropdown.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/dropdown/listdropdown.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/listdropdown.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenu.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenu.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenubutton.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenubutton.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenulistitem.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenulistitem.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenulistitembutton.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenulistitembutton.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenupanel.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenupanel.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/dropdown/splitbutton.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/splitbutton.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/dropdown/toolbardropdown.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/toolbardropdown.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/editorui/accessibilityhelp.css
+++ b/packages/ckeditor5-ui/theme/components/editorui/accessibilityhelp.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/editorui/editorui.css
+++ b/packages/ckeditor5-ui/theme/components/editorui/editorui.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/formheader/formheader.css
+++ b/packages/ckeditor5-ui/theme/components/formheader/formheader.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/highlightedtext/highlightedtext.css
+++ b/packages/ckeditor5-ui/theme/components/highlightedtext/highlightedtext.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/icon/icon.css
+++ b/packages/ckeditor5-ui/theme/components/icon/icon.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/input/input.css
+++ b/packages/ckeditor5-ui/theme/components/input/input.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/label/label.css
+++ b/packages/ckeditor5-ui/theme/components/label/label.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/labeledfield/labeledfieldview.css
+++ b/packages/ckeditor5-ui/theme/components/labeledfield/labeledfieldview.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/labeledinput/labeledinput.css
+++ b/packages/ckeditor5-ui/theme/components/labeledinput/labeledinput.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/list/list.css
+++ b/packages/ckeditor5-ui/theme/components/list/list.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/menubar/menubar.css
+++ b/packages/ckeditor5-ui/theme/components/menubar/menubar.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/menubar/menubarmenu.css
+++ b/packages/ckeditor5-ui/theme/components/menubar/menubarmenu.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/menubar/menubarmenubutton.css
+++ b/packages/ckeditor5-ui/theme/components/menubar/menubarmenubutton.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/menubar/menubarmenulistitem.css
+++ b/packages/ckeditor5-ui/theme/components/menubar/menubarmenulistitem.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/menubar/menubarmenulistitembutton.css
+++ b/packages/ckeditor5-ui/theme/components/menubar/menubarmenulistitembutton.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/menubar/menubarmenupanel.css
+++ b/packages/ckeditor5-ui/theme/components/menubar/menubarmenupanel.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/panel/balloonpanel.css
+++ b/packages/ckeditor5-ui/theme/components/panel/balloonpanel.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/panel/balloonrotator.css
+++ b/packages/ckeditor5-ui/theme/components/panel/balloonrotator.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/panel/fakepanel.css
+++ b/packages/ckeditor5-ui/theme/components/panel/fakepanel.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/panel/stickypanel.css
+++ b/packages/ckeditor5-ui/theme/components/panel/stickypanel.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/responsive-form/responsiveform.css
+++ b/packages/ckeditor5-ui/theme/components/responsive-form/responsiveform.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/search/search.css
+++ b/packages/ckeditor5-ui/theme/components/search/search.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/spinner/spinner.css
+++ b/packages/ckeditor5-ui/theme/components/spinner/spinner.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/textarea/textarea.css
+++ b/packages/ckeditor5-ui/theme/components/textarea/textarea.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/toolbar/blocktoolbar.css
+++ b/packages/ckeditor5-ui/theme/components/toolbar/blocktoolbar.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/toolbar/toolbar.css
+++ b/packages/ckeditor5-ui/theme/components/toolbar/toolbar.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/components/tooltip/tooltip.css
+++ b/packages/ckeditor5-ui/theme/components/tooltip/tooltip.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/globals/_evaluationbadge.css
+++ b/packages/ckeditor5-ui/theme/globals/_evaluationbadge.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/globals/_hidden.css
+++ b/packages/ckeditor5-ui/theme/globals/_hidden.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/globals/_poweredby.css
+++ b/packages/ckeditor5-ui/theme/globals/_poweredby.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/globals/_transition.css
+++ b/packages/ckeditor5-ui/theme/globals/_transition.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/globals/_zindex.css
+++ b/packages/ckeditor5-ui/theme/globals/_zindex.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/globals/globals.css
+++ b/packages/ckeditor5-ui/theme/globals/globals.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/mixins/_dir.css
+++ b/packages/ckeditor5-ui/theme/mixins/_dir.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/mixins/_mediacolors.css
+++ b/packages/ckeditor5-ui/theme/mixins/_mediacolors.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/mixins/_rwd.css
+++ b/packages/ckeditor5-ui/theme/mixins/_rwd.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-ui/theme/mixins/_unselectable.css
+++ b/packages/ckeditor5-ui/theme/mixins/_unselectable.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/LICENSE.md
+++ b/packages/ckeditor5-undo/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Undo feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-undo/docs/_snippets/features/undo-redo.js
+++ b/packages/ckeditor5-undo/docs/_snippets/features/undo-redo.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/lang/translations/af.po
+++ b/packages/ckeditor5-undo/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/ar.po
+++ b/packages/ckeditor5-undo/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/ast.po
+++ b/packages/ckeditor5-undo/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/az.po
+++ b/packages/ckeditor5-undo/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/bg.po
+++ b/packages/ckeditor5-undo/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/bn.po
+++ b/packages/ckeditor5-undo/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/bs.po
+++ b/packages/ckeditor5-undo/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/ca.po
+++ b/packages/ckeditor5-undo/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/cs.po
+++ b/packages/ckeditor5-undo/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/da.po
+++ b/packages/ckeditor5-undo/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/de-ch.po
+++ b/packages/ckeditor5-undo/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/de.po
+++ b/packages/ckeditor5-undo/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/el.po
+++ b/packages/ckeditor5-undo/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/en-au.po
+++ b/packages/ckeditor5-undo/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/en-gb.po
+++ b/packages/ckeditor5-undo/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/en.po
+++ b/packages/ckeditor5-undo/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/eo.po
+++ b/packages/ckeditor5-undo/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/es-co.po
+++ b/packages/ckeditor5-undo/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/es.po
+++ b/packages/ckeditor5-undo/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/et.po
+++ b/packages/ckeditor5-undo/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/eu.po
+++ b/packages/ckeditor5-undo/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/fa.po
+++ b/packages/ckeditor5-undo/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/fi.po
+++ b/packages/ckeditor5-undo/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/fr.po
+++ b/packages/ckeditor5-undo/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/gl.po
+++ b/packages/ckeditor5-undo/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/gu.po
+++ b/packages/ckeditor5-undo/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/he.po
+++ b/packages/ckeditor5-undo/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/hi.po
+++ b/packages/ckeditor5-undo/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/hr.po
+++ b/packages/ckeditor5-undo/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/hu.po
+++ b/packages/ckeditor5-undo/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/hy.po
+++ b/packages/ckeditor5-undo/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/id.po
+++ b/packages/ckeditor5-undo/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/it.po
+++ b/packages/ckeditor5-undo/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/ja.po
+++ b/packages/ckeditor5-undo/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/jv.po
+++ b/packages/ckeditor5-undo/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/kk.po
+++ b/packages/ckeditor5-undo/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/km.po
+++ b/packages/ckeditor5-undo/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/kn.po
+++ b/packages/ckeditor5-undo/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/ko.po
+++ b/packages/ckeditor5-undo/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/ku.po
+++ b/packages/ckeditor5-undo/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/lt.po
+++ b/packages/ckeditor5-undo/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/lv.po
+++ b/packages/ckeditor5-undo/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/ms.po
+++ b/packages/ckeditor5-undo/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/nb.po
+++ b/packages/ckeditor5-undo/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/ne.po
+++ b/packages/ckeditor5-undo/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/nl.po
+++ b/packages/ckeditor5-undo/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/no.po
+++ b/packages/ckeditor5-undo/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/oc.po
+++ b/packages/ckeditor5-undo/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/pl.po
+++ b/packages/ckeditor5-undo/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/pt-br.po
+++ b/packages/ckeditor5-undo/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/pt.po
+++ b/packages/ckeditor5-undo/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/ro.po
+++ b/packages/ckeditor5-undo/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/ru.po
+++ b/packages/ckeditor5-undo/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/si.po
+++ b/packages/ckeditor5-undo/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/sk.po
+++ b/packages/ckeditor5-undo/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/sl.po
+++ b/packages/ckeditor5-undo/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/sq.po
+++ b/packages/ckeditor5-undo/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-undo/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/sr.po
+++ b/packages/ckeditor5-undo/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/sv.po
+++ b/packages/ckeditor5-undo/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/th.po
+++ b/packages/ckeditor5-undo/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/ti.po
+++ b/packages/ckeditor5-undo/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/tk.po
+++ b/packages/ckeditor5-undo/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/tr.po
+++ b/packages/ckeditor5-undo/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/tt.po
+++ b/packages/ckeditor5-undo/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/ug.po
+++ b/packages/ckeditor5-undo/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/uk.po
+++ b/packages/ckeditor5-undo/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/ur.po
+++ b/packages/ckeditor5-undo/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/uz.po
+++ b/packages/ckeditor5-undo/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/vi.po
+++ b/packages/ckeditor5-undo/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-undo/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/lang/translations/zh.po
+++ b/packages/ckeditor5-undo/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-undo/src/augmentation.ts
+++ b/packages/ckeditor5-undo/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/src/basecommand.ts
+++ b/packages/ckeditor5-undo/src/basecommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/src/index.ts
+++ b/packages/ckeditor5-undo/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/src/redocommand.ts
+++ b/packages/ckeditor5-undo/src/redocommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/src/undo.ts
+++ b/packages/ckeditor5-undo/src/undo.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/src/undocommand.ts
+++ b/packages/ckeditor5-undo/src/undocommand.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/src/undoediting.ts
+++ b/packages/ckeditor5-undo/src/undoediting.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/src/undoui.ts
+++ b/packages/ckeditor5-undo/src/undoui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/tests/basecommand.js
+++ b/packages/ckeditor5-undo/tests/basecommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/tests/manual/undo.js
+++ b/packages/ckeditor5-undo/tests/manual/undo.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/tests/redocommand.js
+++ b/packages/ckeditor5-undo/tests/redocommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/tests/undo.js
+++ b/packages/ckeditor5-undo/tests/undo.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/tests/undocommand.js
+++ b/packages/ckeditor5-undo/tests/undocommand.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/tests/undoediting-integration.js
+++ b/packages/ckeditor5-undo/tests/undoediting-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/tests/undoediting.js
+++ b/packages/ckeditor5-undo/tests/undoediting.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-undo/tests/undoui.js
+++ b/packages/ckeditor5-undo/tests/undoui.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-upload/LICENSE.md
+++ b/packages/ckeditor5-upload/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Upload feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-upload/docs/_snippets/features/base64-upload.js
+++ b/packages/ckeditor5-upload/docs/_snippets/features/base64-upload.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-upload/lang/translations/af.po
+++ b/packages/ckeditor5-upload/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/ar.po
+++ b/packages/ckeditor5-upload/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/ast.po
+++ b/packages/ckeditor5-upload/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/az.po
+++ b/packages/ckeditor5-upload/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/bg.po
+++ b/packages/ckeditor5-upload/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/bn.po
+++ b/packages/ckeditor5-upload/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/bs.po
+++ b/packages/ckeditor5-upload/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/ca.po
+++ b/packages/ckeditor5-upload/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/cs.po
+++ b/packages/ckeditor5-upload/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/da.po
+++ b/packages/ckeditor5-upload/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/de-ch.po
+++ b/packages/ckeditor5-upload/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/de.po
+++ b/packages/ckeditor5-upload/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/el.po
+++ b/packages/ckeditor5-upload/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/en-au.po
+++ b/packages/ckeditor5-upload/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/en-gb.po
+++ b/packages/ckeditor5-upload/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/en.po
+++ b/packages/ckeditor5-upload/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/eo.po
+++ b/packages/ckeditor5-upload/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/es-co.po
+++ b/packages/ckeditor5-upload/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/es.po
+++ b/packages/ckeditor5-upload/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/et.po
+++ b/packages/ckeditor5-upload/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/eu.po
+++ b/packages/ckeditor5-upload/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/fa.po
+++ b/packages/ckeditor5-upload/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/fi.po
+++ b/packages/ckeditor5-upload/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/fr.po
+++ b/packages/ckeditor5-upload/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/gl.po
+++ b/packages/ckeditor5-upload/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/gu.po
+++ b/packages/ckeditor5-upload/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/he.po
+++ b/packages/ckeditor5-upload/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/hi.po
+++ b/packages/ckeditor5-upload/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/hr.po
+++ b/packages/ckeditor5-upload/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/hu.po
+++ b/packages/ckeditor5-upload/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/hy.po
+++ b/packages/ckeditor5-upload/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/id.po
+++ b/packages/ckeditor5-upload/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/it.po
+++ b/packages/ckeditor5-upload/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/ja.po
+++ b/packages/ckeditor5-upload/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/jv.po
+++ b/packages/ckeditor5-upload/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/kk.po
+++ b/packages/ckeditor5-upload/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/km.po
+++ b/packages/ckeditor5-upload/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/kn.po
+++ b/packages/ckeditor5-upload/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/ko.po
+++ b/packages/ckeditor5-upload/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/ku.po
+++ b/packages/ckeditor5-upload/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/lt.po
+++ b/packages/ckeditor5-upload/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/lv.po
+++ b/packages/ckeditor5-upload/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/ms.po
+++ b/packages/ckeditor5-upload/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/nb.po
+++ b/packages/ckeditor5-upload/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/ne.po
+++ b/packages/ckeditor5-upload/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/nl.po
+++ b/packages/ckeditor5-upload/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/no.po
+++ b/packages/ckeditor5-upload/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/oc.po
+++ b/packages/ckeditor5-upload/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/pl.po
+++ b/packages/ckeditor5-upload/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/pt-br.po
+++ b/packages/ckeditor5-upload/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/pt.po
+++ b/packages/ckeditor5-upload/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/ro.po
+++ b/packages/ckeditor5-upload/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/ru.po
+++ b/packages/ckeditor5-upload/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/si.po
+++ b/packages/ckeditor5-upload/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/sk.po
+++ b/packages/ckeditor5-upload/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/sl.po
+++ b/packages/ckeditor5-upload/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/sq.po
+++ b/packages/ckeditor5-upload/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-upload/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/sr.po
+++ b/packages/ckeditor5-upload/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/sv.po
+++ b/packages/ckeditor5-upload/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/th.po
+++ b/packages/ckeditor5-upload/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/ti.po
+++ b/packages/ckeditor5-upload/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/tk.po
+++ b/packages/ckeditor5-upload/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/tr.po
+++ b/packages/ckeditor5-upload/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/tt.po
+++ b/packages/ckeditor5-upload/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/ug.po
+++ b/packages/ckeditor5-upload/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/uk.po
+++ b/packages/ckeditor5-upload/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/ur.po
+++ b/packages/ckeditor5-upload/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/uz.po
+++ b/packages/ckeditor5-upload/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/vi.po
+++ b/packages/ckeditor5-upload/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-upload/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/lang/translations/zh.po
+++ b/packages/ckeditor5-upload/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-upload/src/adapters/base64uploadadapter.ts
+++ b/packages/ckeditor5-upload/src/adapters/base64uploadadapter.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-upload/src/adapters/simpleuploadadapter.ts
+++ b/packages/ckeditor5-upload/src/adapters/simpleuploadadapter.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-upload/src/augmentation.ts
+++ b/packages/ckeditor5-upload/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-upload/src/filereader.ts
+++ b/packages/ckeditor5-upload/src/filereader.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-upload/src/filerepository.ts
+++ b/packages/ckeditor5-upload/src/filerepository.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-upload/src/index.ts
+++ b/packages/ckeditor5-upload/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-upload/src/uploadconfig.ts
+++ b/packages/ckeditor5-upload/src/uploadconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-upload/tests/_utils/mocks.js
+++ b/packages/ckeditor5-upload/tests/_utils/mocks.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-upload/tests/adapters/base64uploadadapter.js
+++ b/packages/ckeditor5-upload/tests/adapters/base64uploadadapter.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-upload/tests/adapters/simpleuploadadapter.js
+++ b/packages/ckeditor5-upload/tests/adapters/simpleuploadadapter.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-upload/tests/filereader.js
+++ b/packages/ckeditor5-upload/tests/filereader.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-upload/tests/filerepository.js
+++ b/packages/ckeditor5-upload/tests/filerepository.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/LICENSE.md
+++ b/packages/ckeditor5-utils/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Utilities** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-utils/src/abortabledebounce.ts
+++ b/packages/ckeditor5-utils/src/abortabledebounce.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/areconnectedthroughproperties.ts
+++ b/packages/ckeditor5-utils/src/areconnectedthroughproperties.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/ckeditorerror.ts
+++ b/packages/ckeditor5-utils/src/ckeditorerror.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/collection.ts
+++ b/packages/ckeditor5-utils/src/collection.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/comparearrays.ts
+++ b/packages/ckeditor5-utils/src/comparearrays.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/config.ts
+++ b/packages/ckeditor5-utils/src/config.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/count.ts
+++ b/packages/ckeditor5-utils/src/count.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/crc32.ts
+++ b/packages/ckeditor5-utils/src/crc32.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/delay.ts
+++ b/packages/ckeditor5-utils/src/delay.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/diff.ts
+++ b/packages/ckeditor5-utils/src/diff.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/difftochanges.ts
+++ b/packages/ckeditor5-utils/src/difftochanges.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/createelement.ts
+++ b/packages/ckeditor5-utils/src/dom/createelement.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/emittermixin.ts
+++ b/packages/ckeditor5-utils/src/dom/emittermixin.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/findclosestscrollableancestor.ts
+++ b/packages/ckeditor5-utils/src/dom/findclosestscrollableancestor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/getancestors.ts
+++ b/packages/ckeditor5-utils/src/dom/getancestors.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/getborderwidths.ts
+++ b/packages/ckeditor5-utils/src/dom/getborderwidths.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/getcommonancestor.ts
+++ b/packages/ckeditor5-utils/src/dom/getcommonancestor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/getdatafromelement.ts
+++ b/packages/ckeditor5-utils/src/dom/getdatafromelement.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/getpositionedancestor.ts
+++ b/packages/ckeditor5-utils/src/dom/getpositionedancestor.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/getrangefrommouseevent.ts
+++ b/packages/ckeditor5-utils/src/dom/getrangefrommouseevent.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/global.ts
+++ b/packages/ckeditor5-utils/src/dom/global.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/indexof.ts
+++ b/packages/ckeditor5-utils/src/dom/indexof.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/insertat.ts
+++ b/packages/ckeditor5-utils/src/dom/insertat.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/iscomment.ts
+++ b/packages/ckeditor5-utils/src/dom/iscomment.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/isnode.ts
+++ b/packages/ckeditor5-utils/src/dom/isnode.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/isrange.ts
+++ b/packages/ckeditor5-utils/src/dom/isrange.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/istext.ts
+++ b/packages/ckeditor5-utils/src/dom/istext.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/isvalidattributename.ts
+++ b/packages/ckeditor5-utils/src/dom/isvalidattributename.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/isvisible.ts
+++ b/packages/ckeditor5-utils/src/dom/isvisible.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/iswindow.ts
+++ b/packages/ckeditor5-utils/src/dom/iswindow.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/position.ts
+++ b/packages/ckeditor5-utils/src/dom/position.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/rect.ts
+++ b/packages/ckeditor5-utils/src/dom/rect.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/remove.ts
+++ b/packages/ckeditor5-utils/src/dom/remove.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/resizeobserver.ts
+++ b/packages/ckeditor5-utils/src/dom/resizeobserver.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/scroll.ts
+++ b/packages/ckeditor5-utils/src/dom/scroll.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/setdatainelement.ts
+++ b/packages/ckeditor5-utils/src/dom/setdatainelement.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/dom/tounit.ts
+++ b/packages/ckeditor5-utils/src/dom/tounit.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/elementreplacer.ts
+++ b/packages/ckeditor5-utils/src/elementreplacer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/emittermixin.ts
+++ b/packages/ckeditor5-utils/src/emittermixin.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/env.ts
+++ b/packages/ckeditor5-utils/src/env.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/eventinfo.ts
+++ b/packages/ckeditor5-utils/src/eventinfo.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/fastdiff.ts
+++ b/packages/ckeditor5-utils/src/fastdiff.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/first.ts
+++ b/packages/ckeditor5-utils/src/first.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/focustracker.ts
+++ b/packages/ckeditor5-utils/src/focustracker.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/index.ts
+++ b/packages/ckeditor5-utils/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/inserttopriorityarray.ts
+++ b/packages/ckeditor5-utils/src/inserttopriorityarray.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/isiterable.ts
+++ b/packages/ckeditor5-utils/src/isiterable.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/keyboard.ts
+++ b/packages/ckeditor5-utils/src/keyboard.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/keystrokehandler.ts
+++ b/packages/ckeditor5-utils/src/keystrokehandler.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/language.ts
+++ b/packages/ckeditor5-utils/src/language.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/locale.ts
+++ b/packages/ckeditor5-utils/src/locale.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/mapsequal.ts
+++ b/packages/ckeditor5-utils/src/mapsequal.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/mix.ts
+++ b/packages/ckeditor5-utils/src/mix.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/nth.ts
+++ b/packages/ckeditor5-utils/src/nth.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/objecttomap.ts
+++ b/packages/ckeditor5-utils/src/objecttomap.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/observablemixin.ts
+++ b/packages/ckeditor5-utils/src/observablemixin.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/parsebase64encodedobject.ts
+++ b/packages/ckeditor5-utils/src/parsebase64encodedobject.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/priorities.ts
+++ b/packages/ckeditor5-utils/src/priorities.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/retry.ts
+++ b/packages/ckeditor5-utils/src/retry.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/splicearray.ts
+++ b/packages/ckeditor5-utils/src/splicearray.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/spy.ts
+++ b/packages/ckeditor5-utils/src/spy.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/toarray.ts
+++ b/packages/ckeditor5-utils/src/toarray.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/tomap.ts
+++ b/packages/ckeditor5-utils/src/tomap.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/translation-service.ts
+++ b/packages/ckeditor5-utils/src/translation-service.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/uid.ts
+++ b/packages/ckeditor5-utils/src/uid.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/unicode.ts
+++ b/packages/ckeditor5-utils/src/unicode.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/version.ts
+++ b/packages/ckeditor5-utils/src/version.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/src/wait.ts
+++ b/packages/ckeditor5-utils/src/wait.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/_utils-tests/longtext.js
+++ b/packages/ckeditor5-utils/tests/_utils-tests/longtext.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/_utils-tests/normalizehtml.js
+++ b/packages/ckeditor5-utils/tests/_utils-tests/normalizehtml.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/_utils-tests/rectdrawer.js
+++ b/packages/ckeditor5-utils/tests/_utils-tests/rectdrawer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/_utils-tests/utils.js
+++ b/packages/ckeditor5-utils/tests/_utils-tests/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/_utils/locale-mock.js
+++ b/packages/ckeditor5-utils/tests/_utils/locale-mock.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/_utils/longtext.js
+++ b/packages/ckeditor5-utils/tests/_utils/longtext.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/_utils/normalizehtml.js
+++ b/packages/ckeditor5-utils/tests/_utils/normalizehtml.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/_utils/rectdrawer.js
+++ b/packages/ckeditor5-utils/tests/_utils/rectdrawer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/_utils/scroll.ts
+++ b/packages/ckeditor5-utils/tests/_utils/scroll.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/_utils/utils.js
+++ b/packages/ckeditor5-utils/tests/_utils/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/abortabledebounce.js
+++ b/packages/ckeditor5-utils/tests/abortabledebounce.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/areconnectedthroughproperties.js
+++ b/packages/ckeditor5-utils/tests/areconnectedthroughproperties.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/ckeditorerror.js
+++ b/packages/ckeditor5-utils/tests/ckeditorerror.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/collection.js
+++ b/packages/ckeditor5-utils/tests/collection.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/comparearrays.js
+++ b/packages/ckeditor5-utils/tests/comparearrays.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/config.js
+++ b/packages/ckeditor5-utils/tests/config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/count.js
+++ b/packages/ckeditor5-utils/tests/count.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/crc32.js
+++ b/packages/ckeditor5-utils/tests/crc32.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/delay.js
+++ b/packages/ckeditor5-utils/tests/delay.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/diff.js
+++ b/packages/ckeditor5-utils/tests/diff.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/difftochanges.js
+++ b/packages/ckeditor5-utils/tests/difftochanges.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/createelement.js
+++ b/packages/ckeditor5-utils/tests/dom/createelement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/emittermixin.js
+++ b/packages/ckeditor5-utils/tests/dom/emittermixin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/findclosestscrollableancestor.js
+++ b/packages/ckeditor5-utils/tests/dom/findclosestscrollableancestor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/getancestors.js
+++ b/packages/ckeditor5-utils/tests/dom/getancestors.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/getborderwidths.js
+++ b/packages/ckeditor5-utils/tests/dom/getborderwidths.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/getcommonancestor.js
+++ b/packages/ckeditor5-utils/tests/dom/getcommonancestor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/getdatafromelement.js
+++ b/packages/ckeditor5-utils/tests/dom/getdatafromelement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/getpositionedancestor.js
+++ b/packages/ckeditor5-utils/tests/dom/getpositionedancestor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/getrangefrommouseevent.js
+++ b/packages/ckeditor5-utils/tests/dom/getrangefrommouseevent.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/global.js
+++ b/packages/ckeditor5-utils/tests/dom/global.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/indexof.js
+++ b/packages/ckeditor5-utils/tests/dom/indexof.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/insertat.js
+++ b/packages/ckeditor5-utils/tests/dom/insertat.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/iscomment.js
+++ b/packages/ckeditor5-utils/tests/dom/iscomment.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/isdomnode.js
+++ b/packages/ckeditor5-utils/tests/dom/isdomnode.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/isrange.js
+++ b/packages/ckeditor5-utils/tests/dom/isrange.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/istext.js
+++ b/packages/ckeditor5-utils/tests/dom/istext.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/isvalidattributename.js
+++ b/packages/ckeditor5-utils/tests/dom/isvalidattributename.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/isvisible.js
+++ b/packages/ckeditor5-utils/tests/dom/isvisible.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/iswindow.js
+++ b/packages/ckeditor5-utils/tests/dom/iswindow.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/position.js
+++ b/packages/ckeditor5-utils/tests/dom/position.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/rect.js
+++ b/packages/ckeditor5-utils/tests/dom/rect.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/remove.js
+++ b/packages/ckeditor5-utils/tests/dom/remove.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/resizeobserver.js
+++ b/packages/ckeditor5-utils/tests/dom/resizeobserver.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/scroll.js
+++ b/packages/ckeditor5-utils/tests/dom/scroll.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/setdatainelement.js
+++ b/packages/ckeditor5-utils/tests/dom/setdatainelement.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/dom/tounit.js
+++ b/packages/ckeditor5-utils/tests/dom/tounit.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/elementreplacer.js
+++ b/packages/ckeditor5-utils/tests/elementreplacer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/emittermixin.js
+++ b/packages/ckeditor5-utils/tests/emittermixin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/env.js
+++ b/packages/ckeditor5-utils/tests/env.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/eventinfo.js
+++ b/packages/ckeditor5-utils/tests/eventinfo.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/fastdiff.js
+++ b/packages/ckeditor5-utils/tests/fastdiff.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/first.js
+++ b/packages/ckeditor5-utils/tests/first.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/focustracker.js
+++ b/packages/ckeditor5-utils/tests/focustracker.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/insertbypriority.js
+++ b/packages/ckeditor5-utils/tests/insertbypriority.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/isIterable.js
+++ b/packages/ckeditor5-utils/tests/isIterable.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/keyboard.js
+++ b/packages/ckeditor5-utils/tests/keyboard.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/keystrokehandler.js
+++ b/packages/ckeditor5-utils/tests/keystrokehandler.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/language.js
+++ b/packages/ckeditor5-utils/tests/language.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/locale.js
+++ b/packages/ckeditor5-utils/tests/locale.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/lodash.js
+++ b/packages/ckeditor5-utils/tests/lodash.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/manual/diff/diff.js
+++ b/packages/ckeditor5-utils/tests/manual/diff/diff.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/manual/duplicated-import/duplicated-import.js
+++ b/packages/ckeditor5-utils/tests/manual/duplicated-import/duplicated-import.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/manual/focustracker/focustracker.js
+++ b/packages/ckeditor5-utils/tests/manual/focustracker/focustracker.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/manual/locale/locale.js
+++ b/packages/ckeditor5-utils/tests/manual/locale/locale.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/manual/position/position.js
+++ b/packages/ckeditor5-utils/tests/manual/position/position.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/manual/rect/getvisible.js
+++ b/packages/ckeditor5-utils/tests/manual/rect/getvisible.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/manual/scroll/assets/scroll-iframe-child.js
+++ b/packages/ckeditor5-utils/tests/manual/scroll/assets/scroll-iframe-child.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/manual/scroll/scroll-config.js
+++ b/packages/ckeditor5-utils/tests/manual/scroll/scroll-config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/manual/scroll/scroll-iframe.js
+++ b/packages/ckeditor5-utils/tests/manual/scroll/scroll-iframe.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/manual/scroll/scroll.js
+++ b/packages/ckeditor5-utils/tests/manual/scroll/scroll.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/manual/tickets/148/1.js
+++ b/packages/ckeditor5-utils/tests/manual/tickets/148/1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/mapsequal.js
+++ b/packages/ckeditor5-utils/tests/mapsequal.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/mix.js
+++ b/packages/ckeditor5-utils/tests/mix.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/nth.js
+++ b/packages/ckeditor5-utils/tests/nth.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/observablemixin.js
+++ b/packages/ckeditor5-utils/tests/observablemixin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/parsebase64encodedobject.js
+++ b/packages/ckeditor5-utils/tests/parsebase64encodedobject.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/priorities.js
+++ b/packages/ckeditor5-utils/tests/priorities.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/retry.js
+++ b/packages/ckeditor5-utils/tests/retry.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/splicearray.js
+++ b/packages/ckeditor5-utils/tests/splicearray.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/spy.js
+++ b/packages/ckeditor5-utils/tests/spy.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/toarray.js
+++ b/packages/ckeditor5-utils/tests/toarray.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/tomap.js
+++ b/packages/ckeditor5-utils/tests/tomap.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/translation-service.js
+++ b/packages/ckeditor5-utils/tests/translation-service.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/uid.js
+++ b/packages/ckeditor5-utils/tests/uid.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/unicode.js
+++ b/packages/ckeditor5-utils/tests/unicode.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-utils/tests/wait.js
+++ b/packages/ckeditor5-utils/tests/wait.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-watchdog/LICENSE.md
+++ b/packages/ckeditor5-watchdog/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Watchdog feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-watchdog/src/augmentation.ts
+++ b/packages/ckeditor5-watchdog/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-watchdog/src/contextwatchdog.ts
+++ b/packages/ckeditor5-watchdog/src/contextwatchdog.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-watchdog/src/editorwatchdog.ts
+++ b/packages/ckeditor5-watchdog/src/editorwatchdog.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-watchdog/src/index.ts
+++ b/packages/ckeditor5-watchdog/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-watchdog/src/utils/areconnectedthroughproperties.ts
+++ b/packages/ckeditor5-watchdog/src/utils/areconnectedthroughproperties.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-watchdog/src/utils/getsubnodes.ts
+++ b/packages/ckeditor5-watchdog/src/utils/getsubnodes.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-watchdog/src/watchdog.ts
+++ b/packages/ckeditor5-watchdog/src/watchdog.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-watchdog/tests/contextwatchdog.js
+++ b/packages/ckeditor5-watchdog/tests/contextwatchdog.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-watchdog/tests/editorwatchdog.js
+++ b/packages/ckeditor5-watchdog/tests/editorwatchdog.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-data.js
+++ b/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-data.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-elements.js
+++ b/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-elements.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-watchdog/tests/manual/watchdog.js
+++ b/packages/ckeditor5-watchdog/tests/manual/watchdog.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-watchdog/tests/utils/areconnectedthroughproperties.js
+++ b/packages/ckeditor5-watchdog/tests/utils/areconnectedthroughproperties.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-watchdog/tests/watchdog.js
+++ b/packages/ckeditor5-watchdog/tests/watchdog.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/LICENSE.md
+++ b/packages/ckeditor5-widget/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Widget API** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-widget/lang/translations/af.po
+++ b/packages/ckeditor5-widget/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/ar.po
+++ b/packages/ckeditor5-widget/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/ast.po
+++ b/packages/ckeditor5-widget/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/az.po
+++ b/packages/ckeditor5-widget/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/bg.po
+++ b/packages/ckeditor5-widget/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/bn.po
+++ b/packages/ckeditor5-widget/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/bs.po
+++ b/packages/ckeditor5-widget/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/ca.po
+++ b/packages/ckeditor5-widget/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/cs.po
+++ b/packages/ckeditor5-widget/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/da.po
+++ b/packages/ckeditor5-widget/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/de-ch.po
+++ b/packages/ckeditor5-widget/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/de.po
+++ b/packages/ckeditor5-widget/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/el.po
+++ b/packages/ckeditor5-widget/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/en-au.po
+++ b/packages/ckeditor5-widget/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/en-gb.po
+++ b/packages/ckeditor5-widget/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/en.po
+++ b/packages/ckeditor5-widget/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/eo.po
+++ b/packages/ckeditor5-widget/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/es-co.po
+++ b/packages/ckeditor5-widget/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/es.po
+++ b/packages/ckeditor5-widget/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/et.po
+++ b/packages/ckeditor5-widget/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/eu.po
+++ b/packages/ckeditor5-widget/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/fa.po
+++ b/packages/ckeditor5-widget/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/fi.po
+++ b/packages/ckeditor5-widget/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/fr.po
+++ b/packages/ckeditor5-widget/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/gl.po
+++ b/packages/ckeditor5-widget/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/gu.po
+++ b/packages/ckeditor5-widget/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/he.po
+++ b/packages/ckeditor5-widget/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/hi.po
+++ b/packages/ckeditor5-widget/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/hr.po
+++ b/packages/ckeditor5-widget/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/hu.po
+++ b/packages/ckeditor5-widget/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/hy.po
+++ b/packages/ckeditor5-widget/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/id.po
+++ b/packages/ckeditor5-widget/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/it.po
+++ b/packages/ckeditor5-widget/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/ja.po
+++ b/packages/ckeditor5-widget/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/jv.po
+++ b/packages/ckeditor5-widget/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/kk.po
+++ b/packages/ckeditor5-widget/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/km.po
+++ b/packages/ckeditor5-widget/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/kn.po
+++ b/packages/ckeditor5-widget/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/ko.po
+++ b/packages/ckeditor5-widget/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/ku.po
+++ b/packages/ckeditor5-widget/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/lt.po
+++ b/packages/ckeditor5-widget/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/lv.po
+++ b/packages/ckeditor5-widget/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/ms.po
+++ b/packages/ckeditor5-widget/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/nb.po
+++ b/packages/ckeditor5-widget/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/ne.po
+++ b/packages/ckeditor5-widget/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/nl.po
+++ b/packages/ckeditor5-widget/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/no.po
+++ b/packages/ckeditor5-widget/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/oc.po
+++ b/packages/ckeditor5-widget/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/pl.po
+++ b/packages/ckeditor5-widget/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/pt-br.po
+++ b/packages/ckeditor5-widget/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/pt.po
+++ b/packages/ckeditor5-widget/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/ro.po
+++ b/packages/ckeditor5-widget/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/ru.po
+++ b/packages/ckeditor5-widget/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/si.po
+++ b/packages/ckeditor5-widget/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/sk.po
+++ b/packages/ckeditor5-widget/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/sl.po
+++ b/packages/ckeditor5-widget/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/sq.po
+++ b/packages/ckeditor5-widget/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-widget/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/sr.po
+++ b/packages/ckeditor5-widget/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/sv.po
+++ b/packages/ckeditor5-widget/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/th.po
+++ b/packages/ckeditor5-widget/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/ti.po
+++ b/packages/ckeditor5-widget/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/tk.po
+++ b/packages/ckeditor5-widget/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/tr.po
+++ b/packages/ckeditor5-widget/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/tt.po
+++ b/packages/ckeditor5-widget/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/ug.po
+++ b/packages/ckeditor5-widget/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/uk.po
+++ b/packages/ckeditor5-widget/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/ur.po
+++ b/packages/ckeditor5-widget/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/uz.po
+++ b/packages/ckeditor5-widget/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/vi.po
+++ b/packages/ckeditor5-widget/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-widget/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/lang/translations/zh.po
+++ b/packages/ckeditor5-widget/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-widget/src/augmentation.ts
+++ b/packages/ckeditor5-widget/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/src/highlightstack.ts
+++ b/packages/ckeditor5-widget/src/highlightstack.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/src/index.ts
+++ b/packages/ckeditor5-widget/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/src/utils.ts
+++ b/packages/ckeditor5-widget/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/src/verticalnavigation.ts
+++ b/packages/ckeditor5-widget/src/verticalnavigation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/src/widget.ts
+++ b/packages/ckeditor5-widget/src/widget.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/src/widgetresize.ts
+++ b/packages/ckeditor5-widget/src/widgetresize.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/src/widgetresize/resizer.ts
+++ b/packages/ckeditor5-widget/src/widgetresize/resizer.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/src/widgetresize/resizerstate.ts
+++ b/packages/ckeditor5-widget/src/widgetresize/resizerstate.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/src/widgetresize/sizeview.ts
+++ b/packages/ckeditor5-widget/src/widgetresize/sizeview.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/src/widgettoolbarrepository.ts
+++ b/packages/ckeditor5-widget/src/widgettoolbarrepository.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/src/widgettypearound/utils.ts
+++ b/packages/ckeditor5-widget/src/widgettypearound/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/src/widgettypearound/widgettypearound.ts
+++ b/packages/ckeditor5-widget/src/widgettypearound/widgettypearound.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/highlightstack.js
+++ b/packages/ckeditor5-widget/tests/highlightstack.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/manual/inline-widget.js
+++ b/packages/ckeditor5-widget/tests/manual/inline-widget.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/manual/keyboard.js
+++ b/packages/ckeditor5-widget/tests/manual/keyboard.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/manual/nested-widgets.js
+++ b/packages/ckeditor5-widget/tests/manual/nested-widgets.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/manual/selection-handle.js
+++ b/packages/ckeditor5-widget/tests/manual/selection-handle.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/manual/type-around.js
+++ b/packages/ckeditor5-widget/tests/manual/type-around.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/manual/widget-with-nestededitable.js
+++ b/packages/ckeditor5-widget/tests/manual/widget-with-nestededitable.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/utils.js
+++ b/packages/ckeditor5-widget/tests/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/verticalnavigation.js
+++ b/packages/ckeditor5-widget/tests/verticalnavigation.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/widget-events.js
+++ b/packages/ckeditor5-widget/tests/widget-events.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/widget-integration.js
+++ b/packages/ckeditor5-widget/tests/widget-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/widget.js
+++ b/packages/ckeditor5-widget/tests/widget.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/widgetresize-integration.js
+++ b/packages/ckeditor5-widget/tests/widgetresize-integration.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/widgetresize.js
+++ b/packages/ckeditor5-widget/tests/widgetresize.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/widgetresize/_utils/utils.js
+++ b/packages/ckeditor5-widget/tests/widgetresize/_utils/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/widgetresize/resizer.js
+++ b/packages/ckeditor5-widget/tests/widgetresize/resizer.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/widgetresize/resizerstate.js
+++ b/packages/ckeditor5-widget/tests/widgetresize/resizerstate.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/widgetresize/sizeview.js
+++ b/packages/ckeditor5-widget/tests/widgetresize/sizeview.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/widgettoolbarrepository.js
+++ b/packages/ckeditor5-widget/tests/widgettoolbarrepository.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/widgettypearound/utils.js
+++ b/packages/ckeditor5-widget/tests/widgettypearound/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/tests/widgettypearound/widgettypearound.js
+++ b/packages/ckeditor5-widget/tests/widgettypearound/widgettypearound.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/theme/widget.css
+++ b/packages/ckeditor5-widget/theme/widget.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/theme/widgetresize.css
+++ b/packages/ckeditor5-widget/theme/widgetresize.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-widget/theme/widgettypearound.css
+++ b/packages/ckeditor5-widget/theme/widgettypearound.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-word-count/LICENSE.md
+++ b/packages/ckeditor5-word-count/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 **CKEditor&nbsp;5 Word and character count feature** (https://github.com/ckeditor/ckeditor5)<br>
-Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
+Copyright (c) 2003–2025, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under a dual-license model, this software is available under:
 

--- a/packages/ckeditor5-word-count/docs/_snippets/features/build-word-count-source.js
+++ b/packages/ckeditor5-word-count/docs/_snippets/features/build-word-count-source.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-word-count/docs/_snippets/features/word-count-update.js
+++ b/packages/ckeditor5-word-count/docs/_snippets/features/word-count-update.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-word-count/docs/_snippets/features/word-count.js
+++ b/packages/ckeditor5-word-count/docs/_snippets/features/word-count.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-word-count/lang/translations/af.po
+++ b/packages/ckeditor5-word-count/lang/translations/af.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/ar.po
+++ b/packages/ckeditor5-word-count/lang/translations/ar.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/ast.po
+++ b/packages/ckeditor5-word-count/lang/translations/ast.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/az.po
+++ b/packages/ckeditor5-word-count/lang/translations/az.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/bg.po
+++ b/packages/ckeditor5-word-count/lang/translations/bg.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/bn.po
+++ b/packages/ckeditor5-word-count/lang/translations/bn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/bs.po
+++ b/packages/ckeditor5-word-count/lang/translations/bs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/ca.po
+++ b/packages/ckeditor5-word-count/lang/translations/ca.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/cs.po
+++ b/packages/ckeditor5-word-count/lang/translations/cs.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/da.po
+++ b/packages/ckeditor5-word-count/lang/translations/da.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/de-ch.po
+++ b/packages/ckeditor5-word-count/lang/translations/de-ch.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/de.po
+++ b/packages/ckeditor5-word-count/lang/translations/de.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/el.po
+++ b/packages/ckeditor5-word-count/lang/translations/el.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/en-au.po
+++ b/packages/ckeditor5-word-count/lang/translations/en-au.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/en-gb.po
+++ b/packages/ckeditor5-word-count/lang/translations/en-gb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/en.po
+++ b/packages/ckeditor5-word-count/lang/translations/en.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/eo.po
+++ b/packages/ckeditor5-word-count/lang/translations/eo.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/es-co.po
+++ b/packages/ckeditor5-word-count/lang/translations/es-co.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/es.po
+++ b/packages/ckeditor5-word-count/lang/translations/es.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/et.po
+++ b/packages/ckeditor5-word-count/lang/translations/et.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/eu.po
+++ b/packages/ckeditor5-word-count/lang/translations/eu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/fa.po
+++ b/packages/ckeditor5-word-count/lang/translations/fa.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/fi.po
+++ b/packages/ckeditor5-word-count/lang/translations/fi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/fr.po
+++ b/packages/ckeditor5-word-count/lang/translations/fr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/gl.po
+++ b/packages/ckeditor5-word-count/lang/translations/gl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/gu.po
+++ b/packages/ckeditor5-word-count/lang/translations/gu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/he.po
+++ b/packages/ckeditor5-word-count/lang/translations/he.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/hi.po
+++ b/packages/ckeditor5-word-count/lang/translations/hi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/hr.po
+++ b/packages/ckeditor5-word-count/lang/translations/hr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/hu.po
+++ b/packages/ckeditor5-word-count/lang/translations/hu.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/hy.po
+++ b/packages/ckeditor5-word-count/lang/translations/hy.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/id.po
+++ b/packages/ckeditor5-word-count/lang/translations/id.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/it.po
+++ b/packages/ckeditor5-word-count/lang/translations/it.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/ja.po
+++ b/packages/ckeditor5-word-count/lang/translations/ja.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/jv.po
+++ b/packages/ckeditor5-word-count/lang/translations/jv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/kk.po
+++ b/packages/ckeditor5-word-count/lang/translations/kk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/km.po
+++ b/packages/ckeditor5-word-count/lang/translations/km.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/kn.po
+++ b/packages/ckeditor5-word-count/lang/translations/kn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/ko.po
+++ b/packages/ckeditor5-word-count/lang/translations/ko.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/ku.po
+++ b/packages/ckeditor5-word-count/lang/translations/ku.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/lt.po
+++ b/packages/ckeditor5-word-count/lang/translations/lt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/lv.po
+++ b/packages/ckeditor5-word-count/lang/translations/lv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/ms.po
+++ b/packages/ckeditor5-word-count/lang/translations/ms.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/nb.po
+++ b/packages/ckeditor5-word-count/lang/translations/nb.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/ne.po
+++ b/packages/ckeditor5-word-count/lang/translations/ne.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/nl.po
+++ b/packages/ckeditor5-word-count/lang/translations/nl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/no.po
+++ b/packages/ckeditor5-word-count/lang/translations/no.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/oc.po
+++ b/packages/ckeditor5-word-count/lang/translations/oc.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/pl.po
+++ b/packages/ckeditor5-word-count/lang/translations/pl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/pt-br.po
+++ b/packages/ckeditor5-word-count/lang/translations/pt-br.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/pt.po
+++ b/packages/ckeditor5-word-count/lang/translations/pt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/ro.po
+++ b/packages/ckeditor5-word-count/lang/translations/ro.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/ru.po
+++ b/packages/ckeditor5-word-count/lang/translations/ru.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/si.po
+++ b/packages/ckeditor5-word-count/lang/translations/si.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/sk.po
+++ b/packages/ckeditor5-word-count/lang/translations/sk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/sl.po
+++ b/packages/ckeditor5-word-count/lang/translations/sl.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/sq.po
+++ b/packages/ckeditor5-word-count/lang/translations/sq.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-word-count/lang/translations/sr-latn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/sr.po
+++ b/packages/ckeditor5-word-count/lang/translations/sr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/sv.po
+++ b/packages/ckeditor5-word-count/lang/translations/sv.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/th.po
+++ b/packages/ckeditor5-word-count/lang/translations/th.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/ti.po
+++ b/packages/ckeditor5-word-count/lang/translations/ti.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/tk.po
+++ b/packages/ckeditor5-word-count/lang/translations/tk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/tr.po
+++ b/packages/ckeditor5-word-count/lang/translations/tr.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/tt.po
+++ b/packages/ckeditor5-word-count/lang/translations/tt.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/ug.po
+++ b/packages/ckeditor5-word-count/lang/translations/ug.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/uk.po
+++ b/packages/ckeditor5-word-count/lang/translations/uk.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/ur.po
+++ b/packages/ckeditor5-word-count/lang/translations/ur.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/uz.po
+++ b/packages/ckeditor5-word-count/lang/translations/uz.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/vi.po
+++ b/packages/ckeditor5-word-count/lang/translations/vi.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-word-count/lang/translations/zh-cn.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/lang/translations/zh.po
+++ b/packages/ckeditor5-word-count/lang/translations/zh.po
@@ -1,4 +1,4 @@
-# Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 #
 # Want to contribute to this file? Submit your changes via a GitHub Pull Request.
 #

--- a/packages/ckeditor5-word-count/src/augmentation.ts
+++ b/packages/ckeditor5-word-count/src/augmentation.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-word-count/src/index.ts
+++ b/packages/ckeditor5-word-count/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-word-count/src/utils.ts
+++ b/packages/ckeditor5-word-count/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-word-count/src/wordcount.ts
+++ b/packages/ckeditor5-word-count/src/wordcount.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-word-count/src/wordcountconfig.ts
+++ b/packages/ckeditor5-word-count/src/wordcountconfig.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-word-count/tests/manual/wordcount.js
+++ b/packages/ckeditor5-word-count/tests/manual/wordcount.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-word-count/tests/utils.js
+++ b/packages/ckeditor5-word-count/tests/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-word-count/tests/wordcount.js
+++ b/packages/ckeditor5-word-count/tests/wordcount.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/packages/ckeditor5-word-count/webpack.config.js
+++ b/packages/ckeditor5-word-count/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/bump-year.mjs
+++ b/scripts/bump-year.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
@@ -22,8 +22,7 @@ bumpYear( {
 			pattern: '!(build|coverage|external)/**',
 			options: {
 				ignore: [
-					'**/ckeditor5-*/build/**',
-					'**/ckeditor5-*/lang/translations/*.po'
+					'**/ckeditor5-*/build/**'
 				]
 			}
 		},

--- a/scripts/bump-year.mjs
+++ b/scripts/bump-year.mjs
@@ -30,6 +30,9 @@ bumpYear( {
 			pattern: '.husky/*'
 		},
 		{
+			pattern: '.circleci/*'
+		},
+		{
 			pattern: 'packages/*/.eslintrc.js'
 		}
 	]

--- a/scripts/check-core-backward-compatibility.sh
+++ b/scripts/check-core-backward-compatibility.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 # For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 
 # Get branch name.

--- a/scripts/check-core-backward-compatibility.sh
+++ b/scripts/check-core-backward-compatibility.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
-# For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+# For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
 
 # Get branch name.
 INITIAL_BRANCH=$( git branch --show-current )

--- a/scripts/check-exports.mjs
+++ b/scripts/check-exports.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/check-manual-tests.sh
+++ b/scripts/check-manual-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
-# For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+# For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
 
 # `set -e` cannot be used because if the web crawler will fail, the HTTP server will not be closed.
 

--- a/scripts/check-manual-tests.sh
+++ b/scripts/check-manual-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+# @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
 # For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 
 # `set -e` cannot be used because if the web crawler will fail, the HTTP server will not be closed.

--- a/scripts/check-theme-lark-imports.mjs
+++ b/scripts/check-theme-lark-imports.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/ci/check-dependencies-versions-match.mjs
+++ b/scripts/ci/check-dependencies-versions-match.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/ci/check-manual-tests-directory-structure.mjs
+++ b/scripts/ci/check-manual-tests-directory-structure.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/ci/check-unit-tests-for-package.mjs
+++ b/scripts/ci/check-unit-tests-for-package.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/ci/generate-circleci-configuration.mjs
+++ b/scripts/ci/generate-circleci-configuration.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/ci/is-ckeditor5-ready-to-release.mjs
+++ b/scripts/ci/is-ckeditor5-ready-to-release.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/ci/is-community-pr.mjs
+++ b/scripts/ci/is-community-pr.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/ci/validate-metadata-files.mjs
+++ b/scripts/ci/validate-metadata-files.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/clean-up-svg-icons.mjs
+++ b/scripts/clean-up-svg-icons.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/collect-svg-icons.mjs
+++ b/scripts/collect-svg-icons.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/constants.mjs
+++ b/scripts/constants.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/dll/build-dlls.mjs
+++ b/scripts/dll/build-dlls.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/dll/webpack-footer-plugin.mjs
+++ b/scripts/dll/webpack-footer-plugin.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/dll/webpack.config.dll.mjs
+++ b/scripts/dll/webpack.config.dll.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/docs/build-api-docs.mjs
+++ b/scripts/docs/build-api-docs.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/docs/build-content-styles.mjs
+++ b/scripts/docs/build-content-styles.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/docs/build-content-styles.mjs
+++ b/scripts/docs/build-content-styles.mjs
@@ -317,7 +317,7 @@ function generateCKEditor5Source( ckeditor5Modules, cwd ) {
 	const sourceFileContent = [
 		'/**',
 		` * @license Copyright (c) 2003-${ new Date().getFullYear() }, CKSource Holding sp. z o.o. All rights reserved.`,
-		' * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license',
+		' * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options',
 		' */',
 		'',
 		'// The editor creator to use.',

--- a/scripts/docs/build-docs.mjs
+++ b/scripts/docs/build-docs.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/docs/buildapi.mjs
+++ b/scripts/docs/buildapi.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/docs/features-html-output/build-features-html-output.cjs
+++ b/scripts/docs/features-html-output/build-features-html-output.cjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/docs/get-latest-changelogs.cjs
+++ b/scripts/docs/get-latest-changelogs.cjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/docs/getrealimportpath.mjs
+++ b/scripts/docs/getrealimportpath.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/docs/list-content-styles-plugin.mjs
+++ b/scripts/docs/list-content-styles-plugin.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/docs/parse-arguments.mjs
+++ b/scripts/docs/parse-arguments.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/docs/read-content-styles-file.cjs
+++ b/scripts/docs/read-content-styles-file.cjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/docs/snippetadapter.mjs
+++ b/scripts/docs/snippetadapter.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/docs/utils.mjs
+++ b/scripts/docs/utils.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/eslint-formatter.cjs
+++ b/scripts/eslint-formatter.cjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/nim/banner.mjs
+++ b/scripts/nim/banner.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/nim/banner.mjs
+++ b/scripts/nim/banner.mjs
@@ -6,6 +6,6 @@
 export const banner =
 `/**
  * @license Copyright (c) 2003-${ new Date().getFullYear() }, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 `;

--- a/scripts/nim/build-ckeditor5.mjs
+++ b/scripts/nim/build-ckeditor5.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/nim/build-package.mjs
+++ b/scripts/nim/build-package.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/changelog.mjs
+++ b/scripts/release/changelog.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/clean.mjs
+++ b/scripts/release/clean.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/deploycdn.mjs
+++ b/scripts/release/deploycdn.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/preparepackages.mjs
+++ b/scripts/release/preparepackages.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/publishpackages.mjs
+++ b/scripts/release/publishpackages.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/switchlatestnpm.mjs
+++ b/scripts/release/switchlatestnpm.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/buildckeditor5buildscallback.mjs
+++ b/scripts/release/utils/buildckeditor5buildscallback.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/buildpackageusingrollupcallback.mjs
+++ b/scripts/release/utils/buildpackageusingrollupcallback.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/buildtsanddllforckeditor5root.mjs
+++ b/scripts/release/utils/buildtsanddllforckeditor5root.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/compiletypescriptcallback.mjs
+++ b/scripts/release/utils/compiletypescriptcallback.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/constants.mjs
+++ b/scripts/release/utils/constants.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/getcdnversion.mjs
+++ b/scripts/release/utils/getcdnversion.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/getchangelogoptions.mjs
+++ b/scripts/release/utils/getchangelogoptions.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/getckeditor5packagejson.mjs
+++ b/scripts/release/utils/getckeditor5packagejson.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/getlistroptions.mjs
+++ b/scripts/release/utils/getlistroptions.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/getreleasedescription.mjs
+++ b/scripts/release/utils/getreleasedescription.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/isckeditor5packagefactory.mjs
+++ b/scripts/release/utils/isckeditor5packagefactory.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/isnoncommittablerelease.mjs
+++ b/scripts/release/utils/isnoncommittablerelease.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/istypescriptpackage.mjs
+++ b/scripts/release/utils/istypescriptpackage.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/parsearguments.mjs
+++ b/scripts/release/utils/parsearguments.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/preparedllbuildscallback.mjs
+++ b/scripts/release/utils/preparedllbuildscallback.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/updatepackageentrypoint.mjs
+++ b/scripts/release/utils/updatepackageentrypoint.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/updateversionreferences.mjs
+++ b/scripts/release/utils/updateversionreferences.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/utils/validatedependenciesversions.mjs
+++ b/scripts/release/utils/validatedependenciesversions.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/release/validatepackages.mjs
+++ b/scripts/release/validatepackages.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/svgo.config.cjs
+++ b/scripts/svgo.config.cjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/translations/move.mjs
+++ b/scripts/translations/move.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/translations/synchronize.mjs
+++ b/scripts/translations/synchronize.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/translations/utils.mjs
+++ b/scripts/translations/utils.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/utils/replacekebabcasewithcamelcase.mjs
+++ b/scripts/utils/replacekebabcasewithcamelcase.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/vale/vale.mjs
+++ b/scripts/vale/vale.mjs
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/scripts/web-crawler/index.mjs
+++ b/scripts/web-crawler/index.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/src/enter.ts
+++ b/src/enter.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/src/paragraph.ts
+++ b/src/paragraph.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/src/select-all.ts
+++ b/src/select-all.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/src/typing.ts
+++ b/src/typing.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/src/undo.ts
+++ b/src/undo.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/src/watchdog.ts
+++ b/src/watchdog.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/_data/data-sets/formatting-long-paragraphs.js
+++ b/tests/_data/data-sets/formatting-long-paragraphs.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/_data/data-sets/index.js
+++ b/tests/_data/data-sets/index.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/_data/data-sets/inline-styles.js
+++ b/tests/_data/data-sets/inline-styles.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/_data/data-sets/lists.js
+++ b/tests/_data/data-sets/lists.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/_data/data-sets/mixed.js
+++ b/tests/_data/data-sets/mixed.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/_data/data-sets/paragraphs.js
+++ b/tests/_data/data-sets/paragraphs.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/_data/data-sets/table-huge.js
+++ b/tests/_data/data-sets/table-huge.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/_data/data-sets/wiki.js
+++ b/tests/_data/data-sets/wiki.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/_utils/abbreviationView-level-2.js
+++ b/tests/_utils/abbreviationView-level-2.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/_utils/abbreviationView-level-3.js
+++ b/tests/_utils/abbreviationView-level-3.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/_utils/performance-config.js
+++ b/tests/_utils/performance-config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/_utils/utils.js
+++ b/tests/_utils/utils.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/dll.js
+++ b/tests/dll.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/abbreviation-level-1.js
+++ b/tests/manual/abbreviation-level-1.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/abbreviation-level-2.js
+++ b/tests/manual/abbreviation-level-2.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/abbreviation-level-3.js
+++ b/tests/manual/abbreviation-level-3.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/all-features-dll.js
+++ b/tests/manual/all-features-dll.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/all-features.js
+++ b/tests/manual/all-features.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/all-types.js
+++ b/tests/manual/all-types.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/article.js
+++ b/tests/manual/article.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/mathtype.js
+++ b/tests/manual/mathtype.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/memory/memory-semi-automated.js
+++ b/tests/manual/memory/memory-semi-automated.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/memory/memory.js
+++ b/tests/manual/memory/memory.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/performance/init-single.js
+++ b/tests/manual/performance/init-single.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/performance/init.js
+++ b/tests/manual/performance/init.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/performance/multipleeditors.js
+++ b/tests/manual/performance/multipleeditors.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/performance/paste.js
+++ b/tests/manual/performance/paste.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/performance/richeditor.js
+++ b/tests/manual/performance/richeditor.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/performance/setdata.js
+++ b/tests/manual/performance/setdata.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/translations-dll.js
+++ b/tests/manual/translations-dll.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/manual/wproofreader.js
+++ b/tests/manual/wproofreader.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/tests/node.js
+++ b/tests/node.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
 declare module '*.svg' {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Bumped the year.

Internal: Added support in the `scripts/bump-year.mjs` script for bumping the year in the `*.po` files and the `.circleci` directory.

Internal: Unified the license header in all files that contain a license header.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
