### PR TITLE
Remove `.` from editor warning.

### DIFF
--- a/packages/ckeditor5-core/src/editor/editor.ts
+++ b/packages/ckeditor5-core/src/editor/editor.ts
@@ -537,7 +537,7 @@ export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 				console.warn(
 					`⚠️ You are using a ${ licenseType } license of CKEditor 5` +
 					`${ licenseType === 'trial' ? ' which is for evaluation purposes only' : '' }. ` +
-					'For production usage, please obtain a production license at https://portal.ckeditor.com/.'
+					'For production usage, please obtain a production license at https://portal.ckeditor.com/'
 				);
 			}
 

--- a/packages/ckeditor5-core/tests/editor/licensecheck.js
+++ b/packages/ckeditor5-core/tests/editor/licensecheck.js
@@ -407,7 +407,7 @@ describe( 'Editor - license check', () => {
 						consoleWarnStub,
 						`⚠️ You are using a ${ licenseType } license of CKEditor 5` +
 						`${ licenseType === 'trial' ? ' which is for evaluation purposes only' : '' }. ` +
-						'For production usage, please obtain a production license at https://portal.ckeditor.com/.'
+						'For production usage, please obtain a production license at https://portal.ckeditor.com/'
 					);
 
 					dateNow.restore();
@@ -468,7 +468,7 @@ describe( 'Editor - license check', () => {
 				sinon.assert.calledWith(
 					consoleWarnStub,
 					'⚠️ You are using a development license of CKEditor 5. ' +
-					'For production usage, please obtain a production license at https://portal.ckeditor.com/.'
+					'For production usage, please obtain a production license at https://portal.ckeditor.com/'
 				);
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (editor): Do not append `.` character after portal link. 