### PR TITLE
Improve performance of placeholder and add ghs performance test

### DIFF
--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
@@ -951,7 +951,8 @@ describe( 'CKBoxImageEditCommand', () => {
 				'while waiting for the processed image', async () => {
 				expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal(
 					'<figure class="ck-widget ck-widget_selected image" contenteditable="false" data-ckbox-resource-id="example-id">' +
-						'<img alt="alt text" height="50" src="/assets/sample.png" style="aspect-ratio:50/50" width="50"></img>' +
+						'<img alt="alt text" height="50" loading="lazy" src="/assets/sample.png" style="aspect-ratio:50/50" width="50">' +
+						'</img>' +
 						'<div class="ck ck-reset_all ck-widget__type-around"></div>' +
 					'</figure>'
 				);
@@ -961,7 +962,9 @@ describe( 'CKBoxImageEditCommand', () => {
 				expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal(
 					'<figure class="ck-widget ck-widget_selected image image-processing" ' +
 						'contenteditable="false" data-ckbox-resource-id="example-id">' +
-						'<img alt="alt text" height="100" src="/assets/sample.png" style="height:100px;width:100px" width="100"></img>' +
+						'<img alt="alt text" height="100" loading="lazy" src="/assets/sample.png" ' +
+							'style="height:100px;width:100px" width="100">' +
+						'</img>' +
 						'<div class="ck ck-reset_all ck-widget__type-around"></div>' +
 					'</figure>'
 				);

--- a/packages/ckeditor5-engine/tests/view/placeholder.js
+++ b/packages/ckeditor5-engine/tests/view/placeholder.js
@@ -288,6 +288,8 @@ describe( 'placeholder', () => {
 				isDirectHost: true
 			} );
 
+			view.forceRender();
+
 			expect( viewRoot.getChild( 0 ).getAttribute( 'data-placeholder' ) ).to.equal( 'bar' );
 			expect( viewRoot.getChild( 0 ).isEmpty ).to.be.true;
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.true;

--- a/packages/ckeditor5-image/src/imagesizeattributes.ts
+++ b/packages/ckeditor5-image/src/imagesizeattributes.ts
@@ -121,8 +121,8 @@ export default class ImageSizeAttributes extends Plugin {
 
 		// Dedicated converters to propagate attributes to the <img> element.
 		editor.conversion.for( 'editingDowncast' ).add( dispatcher => {
-			attachDowncastConverter( dispatcher, 'width', 'width', true );
-			attachDowncastConverter( dispatcher, 'height', 'height', true );
+			attachDowncastConverter( dispatcher, 'width', 'width', true, true );
+			attachDowncastConverter( dispatcher, 'height', 'height', true, true );
 		} );
 
 		editor.conversion.for( 'dataDowncast' ).add( dispatcher => {
@@ -134,7 +134,8 @@ export default class ImageSizeAttributes extends Plugin {
 			dispatcher: DowncastDispatcher,
 			modelAttributeName: string,
 			viewAttributeName: string,
-			setRatioForInlineImage: boolean
+			setRatioForInlineImage: boolean,
+			isEditingDowncast: boolean = false
 		) {
 			dispatcher.on<DowncastAttributeEvent>( `attribute:${ modelAttributeName }:${ imageType }`, ( evt, data, conversionApi ) => {
 				if ( !conversionApi.consumable.consume( data.item, evt.name ) ) {
@@ -166,8 +167,14 @@ export default class ImageSizeAttributes extends Plugin {
 				const width = data.item.getAttribute( 'width' );
 				const height = data.item.getAttribute( 'height' );
 
-				if ( width && height ) {
-					viewWriter.setStyle( 'aspect-ratio', `${ width }/${ height }`, img );
+				if ( !width || !height ) {
+					return;
+				}
+
+				viewWriter.setStyle( 'aspect-ratio', `${ width }/${ height }`, img );
+
+				if ( isEditingDowncast ) {
+					viewWriter.setAttribute( 'loading', 'lazy', img );
 				}
 			} );
 		}

--- a/packages/ckeditor5-image/tests/imagesizeattributes.js
+++ b/packages/ckeditor5-image/tests/imagesizeattributes.js
@@ -290,7 +290,8 @@ describe( 'ImageSizeAttributes', () => {
 
 						expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
 							'<p><span class="ck-widget image-inline image_resized" contenteditable="false" style="width:50px">' +
-								'<img height="200" src="/assets/sample.png" style="aspect-ratio:100/200" width="100"></img>' +
+								'<img height="200" loading="lazy" src="/assets/sample.png" style="aspect-ratio:100/200" width="100">' +
+								'</img>' +
 							'</span></p>'
 						);
 
@@ -307,7 +308,8 @@ describe( 'ImageSizeAttributes', () => {
 
 						expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
 							'<p><span class="ck-widget image-inline" contenteditable="false">' +
-								'<img height="200" src="/assets/sample.png" style="aspect-ratio:100/200" width="100"></img>' +
+								'<img height="200" loading="lazy" src="/assets/sample.png" style="aspect-ratio:100/200" width="100">' +
+								'</img>' +
 							'</span></p>'
 						);
 
@@ -489,7 +491,8 @@ describe( 'ImageSizeAttributes', () => {
 
 						expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
 							'<figure class="ck-widget image image_resized" contenteditable="false" style="width:50px">' +
-								'<img height="200" src="/assets/sample.png" style="aspect-ratio:100/200" width="100"></img>' +
+								'<img height="200" loading="lazy" src="/assets/sample.png" style="aspect-ratio:100/200" width="100">' +
+								'</img>' +
 							'</figure>'
 						);
 
@@ -507,7 +510,8 @@ describe( 'ImageSizeAttributes', () => {
 
 						expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
 							'<figure class="ck-widget image" contenteditable="false">' +
-								'<img height="200" src="/assets/sample.png" style="aspect-ratio:100/200" width="100"></img>' +
+								'<img height="200" loading="lazy" src="/assets/sample.png" style="aspect-ratio:100/200" width="100">' +
+								'</img>' +
 							'</figure>'
 						);
 

--- a/tests/_data/data-sets/ghs.js
+++ b/tests/_data/data-sets/ghs.js
@@ -1,0 +1,83 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+// This is main Wikipedia page source copied four times. This is to test content with a lot of messy / unsupported markup.
+// After it is loaded in the editor, it is ~150 A4 pages (however there are a lot of very short paragraphs and list items).
+
+/* eslint-disable */
+
+const initialData =
+	`<p style="color:blue;">Feature paragraph</p>
+
+	<h2 style="color:green">Feature heading1</h2>
+	<h3 style="color:green">Feature heading2</h3>
+	<h4 style="color:green">Feature heading3</h4>
+
+	<p><strong style="color:blue;">Feature bold</strong></p>
+	<p><i style="color:blue;">Feature italic</i></p>
+	<p><s style="color:blue;">Feature strike</s></p>
+	<p><u style="color:blue;">Feature underline</u></p>
+	<p><code style="color:blue;">Feature code</code></p>
+	<p><sub style="color:blue;">Feature subscript</sub></p>
+	<p><sup style="color:blue;">Feature superscript</sup></p>
+
+	<p><a style="color:green;" href="https://example.com">Link feature</a></p>
+	<p><a name="anchor" id="anchor">Anchor (name, ID only)</a></p>
+
+	<p><mark class="marker-yellow" data-mark>Mark feature</mark></p>
+
+	<p><span class="text-big text-italic" style="background-color:hsl(60, 75%, 60%);color:hsl(240, 75%, 60%);font-family:'Courier New', Courier, monospace;border:1px solid black">Font feature</span></p>
+
+	<ul style="background:blue;">
+		<li style="color:yellow;">Bulleted List feature</li>
+		<li style="color:yellow;">Bulleted List feature</li>
+		<li style="color:yellow;">Bulleted List feature</li>
+	</ul>
+
+	<ol style="background:blue;">
+		<li style="color:yellow;">Numbered List feature</li>
+		<li style="color:yellow;">Numbered List feature</li>
+		<li style="color:yellow;">Numbered List feature</li>
+	</ol>
+
+	<ul class="todo-list" style="background:blue;">
+		<li style="color:yellow;">
+			<label class="todo-list__label">
+				<input type="checkbox" disabled="disabled">
+				<span class="todo-list__label__description">Todo List feature</span>
+			</label>
+		</li>
+		<li style="color:yellow;">
+			<label class="todo-list__label">
+				<input type="checkbox" disabled="disabled">
+				<span class="todo-list__label__description">Todo List feature</span>
+			</label>
+		</li>
+		<li style="color:yellow;">
+			<label class="todo-list__label">
+				<input type="checkbox" disabled="disabled">
+				<span class="todo-list__label__description">Todo List feature</span>
+			</label>
+		</li>
+	</ul>
+
+	<blockquote style="color:blue;"><p>Blockquote Feature</p></blockquote>
+
+	<figure style="border: 1px solid blue;" class="image">
+		<img src="/ckeditor5/tests/manual/sample.jpg" width="826" height="388"/>
+		<figcaption style="background:yellow;">Caption</figcaption>
+	</figure>
+
+	<pre style="background:blue;"><code style="color:yellow;" class="language-plaintext">Code Block</code></pre>
+
+	<div style="border: 1px solid blue" class="raw-html-embed">HTML snippet</div>
+	<div data-foo class="page-break" style="page-break-after:always;"><span style="display:none;">&nbsp;</span></div>
+	<p><i class="inline-icon"></i> empty inline at start</p>
+	<p>Text with <i class="inline-icon"></i> empty inline inside</p>
+	<p>Text with empty inline at the end <i class="inline-icon"></i></p>`;
+
+export default function makeData() {
+  return initialData.repeat( 250 );
+}

--- a/tests/_data/data-sets/index.js
+++ b/tests/_data/data-sets/index.js
@@ -3,14 +3,22 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import paragraphs from './paragraphs.js';
-import lists from './lists.js';
-import tableHuge from './table-huge.js';
 import formattingLongP from './formatting-long-paragraphs.js';
+import ghs from './ghs.js';
 import inlineStyles from './inline-styles.js';
+import lists from './lists.js';
 import mixed from './mixed.js';
+import paragraphs from './paragraphs.js';
+import tableHuge from './table-huge.js';
 import wiki from './wiki.js';
 
 export default {
-	paragraphs, lists, tableHuge, formattingLongP, inlineStyles, mixed, wiki
+	formattingLongP,
+	ghs,
+	inlineStyles,
+	lists,
+	mixed,
+	paragraphs,
+	tableHuge,
+	wiki
 };


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (engine): Improve performance of the placeholders.

Other (image): Attribute `loading="lazy"` will be automatically added in editing view to images with `height` and `width` attributes set to improve loading performance.

Tests: Added new `ghs` manual performance test.

MINOR BREAKING CHANGE (image): Starting from this release, images that have `height` and `width` attributes set will automatically receive `loading="lazy"` attribute in the editing area. This happens only for the content loaded into the editor, the data output produced by the editor remains the same. The reason for this change is to improve user experience in documents that may contain hundreds of images.

---

This is a continuation of #17589.

When looking at the numbers reported by the performance tests, we can see that these changes have reduced the load time of the `ghs` test by around 23% (from 9400ms to 7300ms).

However, when images were present in the document, a lot of code was run after they were loaded, so the browser window was still frozen for a few seconds after the editor was rendered. When this is considered, the performance is now 2 times better (loading, scripting, rendering, and painting took 17800ms before, but only 8900 ms after, including devtools overhead).