### PR TITLE
Close SourceEditing view on plugin disabling

### DIFF
--- a/packages/ckeditor5-source-editing/src/sourceediting.ts
+++ b/packages/ckeditor5-source-editing/src/sourceediting.ts
@@ -10,6 +10,7 @@
 /* global console */
 
 import { type Editor, Plugin, PendingActions } from 'ckeditor5/src/core.js';
+import { CommentsOnly } from '@ckeditor/ckeditor5-comments';
 import { ButtonView, MenuBarMenuListItemButtonView, type Dialog } from 'ckeditor5/src/ui.js';
 import { CKEditorError, createElement, ElementReplacer } from 'ckeditor5/src/utils.js';
 import { formatHtml } from './utils/formathtml.js';
@@ -135,6 +136,14 @@ export default class SourceEditing extends Plugin {
 			this.on( 'change:isEnabled', ( evt, name, isEnabled ) => this._handleReadOnlyMode( !isEnabled ) );
 
 			this.listenTo( editor, 'change:isReadOnly', ( evt, name, isReadOnly ) => this._handleReadOnlyMode( isReadOnly ) );
+
+			if ( editor.plugins.has( CommentsOnly ) ) {
+				this.listenTo( editor.plugins.get( CommentsOnly ), 'change:isEnabled', ( evt, name, isCommentsOnlyEnabled ) => {
+					if ( isCommentsOnlyEnabled ) {
+						this.isSourceEditingMode = false;
+					}
+				} );
+			}
 		}
 
 		// Update the editor data while calling editor.getData() in the source editing mode.
@@ -411,37 +420,56 @@ export default class SourceEditing extends Plugin {
 
 		buttonView.bind( 'isOn' ).to( this, 'isSourceEditingMode' );
 
-		// The button should be disabled if one of the following conditions is met:
-		buttonView.bind( 'isEnabled' ).to(
-			this, 'isEnabled',
-			editor, 'isReadOnly',
-			editor.plugins.get( PendingActions ), 'hasAny',
-			( isEnabled, isEditorReadOnly, hasAnyPendingActions ) => {
-				// (1) The plugin itself is disabled.
-				if ( !isEnabled ) {
-					return false;
-				}
-
-				// (2) The editor is in read-only mode.
-				if ( isEditorReadOnly ) {
-					return false;
-				}
-
-				// (3) Any pending action is scheduled. It may change the model, so modifying the document source should be prevented
-				// until the model is finally set.
-				if ( hasAnyPendingActions ) {
-					return false;
-				}
-
-				return true;
-			}
-		);
+		if ( editor.plugins.has( CommentsOnly ) ) {
+			buttonView.bind( 'isEnabled' ).to(
+				this, 'isEnabled',
+				editor, 'isReadOnly',
+				editor.plugins.get( PendingActions ), 'hasAny',
+				editor.plugins.get( CommentsOnly ), 'isEnabled',
+				this._isSourceEditingButtonEnabled
+			);
+		} else {
+			buttonView.bind( 'isEnabled' ).to(
+				this, 'isEnabled',
+				editor, 'isReadOnly',
+				editor.plugins.get( PendingActions ), 'hasAny',
+				this._isSourceEditingButtonEnabled
+			);
+		}
 
 		this.listenTo( buttonView, 'execute', () => {
 			this.isSourceEditingMode = !this.isSourceEditingMode;
 		} );
 
 		return buttonView;
+	}
+
+	// The button should be disabled if one of the following conditions is met:
+	private _isSourceEditingButtonEnabled(
+		isEnabled: boolean, isEditorReadOnly: boolean, hasAnyPendingActions: boolean, isCommentsOnlyEnabled?: boolean
+	): boolean {
+		// (1) The plugin itself is disabled.
+		if ( !isEnabled ) {
+			return false;
+		}
+
+		// (2) The editor is in read-only mode.
+		if ( isEditorReadOnly ) {
+			return false;
+		}
+
+		// (3) Any pending action is scheduled. It may change the model, so modifying the document source should be prevented
+		// until the model is finally set.
+		if ( hasAnyPendingActions ) {
+			return false;
+		}
+
+		// (4) The ediotr is in comments-only mode
+		if ( isCommentsOnlyEnabled ) {
+			return false;
+		}
+
+		return true;
 	}
 }
 

--- a/packages/ckeditor5-source-editing/tests/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/sourceediting.js
@@ -425,16 +425,11 @@ describe( 'SourceEditing', () => {
 		it( 'should disable textarea if plugin is disabled', () => {
 			button.fire( 'execute' );
 
-			const domRoot = editor.editing.view.getDomRoot();
-			const textarea = domRoot.nextSibling.children[ 0 ];
-
 			plugin.forceDisabled( 'disablePlugin' );
 
-			expect( textarea.readOnly ).to.be.true;
+			expect( plugin.isSourceEditingMode ).to.be.false;
 
 			plugin.clearForceDisabled( 'disablePlugin' );
-
-			expect( textarea.readOnly ).to.be.false;
 		} );
 
 		it( 'should remember replaced roots', () => {

--- a/packages/ckeditor5-source-editing/tests/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/sourceediting.js
@@ -422,7 +422,7 @@ describe( 'SourceEditing', () => {
 			expect( textarea.readOnly ).to.be.false;
 		} );
 
-		it( 'should disable textarea if plugin is disabled', () => {
+		it( 'should close source editing mode if plugin is disabled', () => {
 			button.fire( 'execute' );
 
 			plugin.forceDisabled( 'disablePlugin' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (source-editing): The SourceEditing plugin now closes its view upon being disabled, preventing users from remaining stuck in this mode.

---

### Additional information

A change is needed to ensure that SourceEditing is properly closed when CommentsOnly mode is enabled or when SourceEditing is disabled by API calls. These two plugins should not operate simultaneously.
