### PR TITLE
The ClipboardPipeline and PasteFromOffice should allow for common HTML string normalisation before conversion to view

### DIFF
--- a/packages/ckeditor5-clipboard/src/clipboardobserver.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardobserver.ts
@@ -185,12 +185,13 @@ export interface ClipboardInputEventData {
 	targetRanges: Array<ViewRange> | null;
 
 	/**
-	 * The content of clipboard input.
+	 * The content of clipboard input. Defaults to `text/html`. Falls-back to `text/plain`.
 	 */
 	content: string | ViewDocumentFragment;
 
 	/**
-	 * TODO
+	 * Custom data stored by the `clipboardInput` event handlers. Custom properties of this object can be defined and use to
+	 * pass parameters between listeners. Content of this property is passed to the `inputTransformation` event.
 	 */
 	extraContent?: unknown;
 }

--- a/packages/ckeditor5-clipboard/src/clipboardobserver.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardobserver.ts
@@ -19,6 +19,8 @@ import {
 	type ViewRange
 } from '@ckeditor/ckeditor5-engine';
 
+import plainTextToHtml from './utils/plaintexttohtml.js';
+
 /**
  * Clipboard events observer.
  *
@@ -63,10 +65,20 @@ export default class ClipboardObserver extends DomEventObserver<
 				data.preventDefault();
 
 				const targetRanges = data.dropRange ? [ data.dropRange ] : null;
+				const dataTransfer = data.dataTransfer;
+				let content = '';
+
+				if ( dataTransfer.getData( 'text/html' ) ) {
+					content = dataTransfer.getData( 'text/html' );
+				} else if ( dataTransfer.getData( 'text/plain' ) ) {
+					content = plainTextToHtml( dataTransfer.getData( 'text/plain' ) );
+				}
+
 				const eventInfo = new EventInfo( viewDocument, type );
 
 				viewDocument.fire( eventInfo, {
-					dataTransfer: data.dataTransfer,
+					dataTransfer,
+					content,
 					method: evt.name,
 					targetRanges,
 					target: data.target,
@@ -175,7 +187,7 @@ export interface ClipboardInputEventData {
 	/**
 	 * The content of clipboard input.
 	 */
-	content?: ViewDocumentFragment;
+	content: string | ViewDocumentFragment;
 
 	/**
 	 * TODO

--- a/packages/ckeditor5-clipboard/src/clipboardobserver.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardobserver.ts
@@ -176,6 +176,11 @@ export interface ClipboardInputEventData {
 	 * The content of clipboard input.
 	 */
 	content?: ViewDocumentFragment;
+
+	/**
+	 * TODO
+	 */
+	extraContent?: unknown;
 }
 
 /**

--- a/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
@@ -239,6 +239,7 @@ export default class ClipboardPipeline extends Plugin {
 
 			this.fire<ClipboardInputTransformationEvent>( eventInfo, {
 				content,
+				extraContent: data.extraContent,
 				dataTransfer,
 				targetRanges: data.targetRanges,
 				method: data.method as 'paste' | 'drop'
@@ -374,6 +375,11 @@ export interface ClipboardInputTransformationData {
 	 * the {@glink framework/deep-dive/clipboard clipboard deep-dive} guide.
 	 */
 	content: ViewDocumentFragment;
+
+	/**
+	 * TODO
+	 */
+	extraContent?: unknown;
 
 	/**
 	 * The data transfer instance.

--- a/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
@@ -216,14 +216,11 @@ export default class ClipboardPipeline extends Plugin {
 		}, { priority: 'highest' } );
 
 		this.listenTo<ViewDocumentClipboardInputEvent>( viewDocument, 'clipboardInput', ( evt, data ) => {
-			if ( typeof data.content == 'string' ) {
-				data.content = normalizeClipboardHtml( data.content );
-			}
-		}, { priority: 'low' } );
-
-		this.listenTo<ViewDocumentClipboardInputEvent>( viewDocument, 'clipboardInput', ( evt, data ) => {
 			// Some feature could already inject content in the higher priority event handler (i.e., codeBlock, paste from office).
-			const content = typeof data.content == 'string' ? this.editor.data.htmlProcessor.toView( data.content ) : data.content;
+			const content = typeof data.content == 'string' ?
+				this.editor.data.htmlProcessor.toView( normalizeClipboardHtml( data.content ) ) :
+				data.content;
+
 			const eventInfo = new EventInfo( this, 'inputTransformation' );
 
 			this.fire<ClipboardInputTransformationEvent>( eventInfo, {

--- a/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
@@ -363,7 +363,7 @@ export interface ClipboardInputTransformationData {
 	content: ViewDocumentFragment;
 
 	/**
-	 * TODO
+	 * Custom data stored by the `clipboardInput` event handlers. Content of this property is passed from the `clipboardInput` event.
 	 */
 	extraContent?: unknown;
 

--- a/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
@@ -323,6 +323,7 @@ describe( 'ClipboardPipeline feature', () => {
 
 			viewDocument.fire( 'clipboardInput', {
 				dataTransfer: dataTransferMock,
+				content: dataTransferMock.getData( 'text/html' ),
 				method: 'paste'
 			} );
 
@@ -331,7 +332,8 @@ describe( 'ClipboardPipeline feature', () => {
 			editor.disableReadOnlyMode( 'unit-test' );
 
 			viewDocument.fire( 'clipboardInput', {
-				dataTransfer: dataTransferMock
+				dataTransfer: dataTransferMock,
+				content: dataTransferMock.getData( 'text/html' )
 			} );
 
 			sinon.assert.calledOnce( spy );

--- a/packages/ckeditor5-clipboard/tests/dragdrop.js
+++ b/packages/ckeditor5-clipboard/tests/dragdrop.js
@@ -2531,6 +2531,7 @@ describe( 'Drag and Drop', () => {
 			...prepareEventData( modelPositionOrRange ),
 			method: 'dragging',
 			dataTransfer: dataTransferMock,
+			content: dataTransferMock.getData( 'text/html' ),
 			stopPropagation: () => {},
 			preventDefault: () => {}
 		} );
@@ -2541,6 +2542,7 @@ describe( 'Drag and Drop', () => {
 			...prepareEventData( modelPosition ),
 			method: 'drop',
 			dataTransfer: dataTransferMock,
+			content: dataTransferMock.getData( 'text/html' ),
 			stopPropagation: () => {},
 			preventDefault: () => {}
 		} );

--- a/packages/ckeditor5-clipboard/tests/pasteplaintext.js
+++ b/packages/ckeditor5-clipboard/tests/pasteplaintext.js
@@ -194,6 +194,7 @@ describe( 'PastePlainText', () => {
 
 		viewDocument.fire( 'clipboardInput', {
 			dataTransfer: dataTransferMock,
+			content: dataTransferMock.getData( 'text/html' ),
 			stopPropagation() {},
 			preventDefault() {}
 		} );
@@ -222,6 +223,7 @@ describe( 'PastePlainText', () => {
 
 		viewDocument.fire( 'clipboardInput', {
 			dataTransfer: dataTransferMock,
+			content: dataTransferMock.getData( 'text/html' ),
 			stopPropagation() {},
 			preventDefault() {}
 		} );
@@ -237,6 +239,7 @@ describe( 'PastePlainText', () => {
 				'text/html': 'foo',
 				'text/plain': 'foo'
 			} ),
+			content: 'foo',
 			stopPropagation() {},
 			preventDefault() {}
 		} );
@@ -252,6 +255,7 @@ describe( 'PastePlainText', () => {
 				'text/html': 'foo',
 				'text/plain': 'foo'
 			} ),
+			content: 'foo',
 			stopPropagation() {},
 			preventDefault() {}
 		} );
@@ -275,6 +279,7 @@ describe( 'PastePlainText', () => {
 				'text/html': '<obj></obj>',
 				'text/plain': 'foo'
 			} ),
+			content: '<obj></obj>',
 			stopPropagation() {},
 			preventDefault() {}
 		} );

--- a/packages/ckeditor5-code-block/src/codeblockediting.ts
+++ b/packages/ckeditor5-code-block/src/codeblockediting.ts
@@ -22,7 +22,7 @@ import {
 	type Element,
 	type SelectionChangeRangeEvent
 } from 'ckeditor5/src/engine.js';
-import { ClipboardPipeline, type ClipboardContentInsertionEvent } from 'ckeditor5/src/clipboard.js';
+import { ClipboardPipeline, type ClipboardContentInsertionEvent, type ViewDocumentClipboardInputEvent } from 'ckeditor5/src/clipboard.js';
 
 import CodeBlockCommand from './codeblockcommand.js';
 import IndentCodeBlockCommand from './indentcodeblockcommand.js';
@@ -178,7 +178,7 @@ export default class CodeBlockEditing extends Plugin {
 		// Intercept the clipboard input (paste) when the selection is anchored in the code block and force the clipboard
 		// data to be pasted as a single plain text. Otherwise, the code lines will split the code block and
 		// "spill out" as separate paragraphs.
-		this.listenTo( editor.editing.view.document, 'clipboardInput', ( evt, data ) => {
+		this.listenTo<ViewDocumentClipboardInputEvent>( editor.editing.view.document, 'clipboardInput', ( evt, data ) => {
 			let insertionRange = model.createRange( model.document.selection.anchor! );
 
 			// Use target ranges in case this is a drop.

--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -1646,6 +1646,7 @@ describe( 'CodeBlockEditing', () => {
 			};
 
 			viewDoc.fire( 'clipboardInput', {
+				content: dataTransferMock.getData( 'text/plain' ),
 				dataTransfer: dataTransferMock,
 				stop: sinon.spy()
 			} );
@@ -1669,6 +1670,7 @@ describe( 'CodeBlockEditing', () => {
 			};
 
 			viewDoc.fire( 'clipboardInput', {
+				content: dataTransferMock.getData( 'text/plain' ),
 				dataTransfer: dataTransferMock,
 				stop: sinon.spy()
 			} );

--- a/packages/ckeditor5-engine/src/view/view.ts
+++ b/packages/ckeditor5-engine/src/view/view.ts
@@ -25,6 +25,7 @@ import type { StylesProcessor } from './stylesmap.js';
 import type Element from './element.js';
 import type { default as Node, ViewNodeChangeEvent } from './node.js';
 import type Item from './item.js';
+import type DocumentFragment from './documentfragment.js';
 
 import KeyObserver from './observer/keyobserver.js';
 import FakeSelectionObserver from './observer/fakeselectionobserver.js';
@@ -679,7 +680,7 @@ export default class View extends /* #__PURE__ */ ObservableMixin() {
 	 *
 	 * @param element Element which is a parent for the range.
 	 */
-	public createRangeIn( element: Element ): Range {
+	public createRangeIn( element: Element | DocumentFragment ): Range {
 		return Range._createIn( element );
 	}
 

--- a/packages/ckeditor5-image/src/autoimage.ts
+++ b/packages/ckeditor5-image/src/autoimage.ts
@@ -8,7 +8,7 @@
  */
 
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
-import { Clipboard, type ClipboardPipeline } from 'ckeditor5/src/clipboard.js';
+import { Clipboard, type ClipboardInputTransformationEvent, type ClipboardPipeline } from 'ckeditor5/src/clipboard.js';
 import { LivePosition, LiveRange } from 'ckeditor5/src/engine.js';
 import { Undo } from 'ckeditor5/src/undo.js';
 import { Delete } from 'ckeditor5/src/typing.js';
@@ -82,7 +82,7 @@ export default class AutoImage extends Plugin {
 		// We need to listen on `Clipboard#inputTransformation` because we need to save positions of selection.
 		// After pasting, the content between those positions will be checked for a URL that could be transformed
 		// into an image.
-		this.listenTo( clipboardPipeline, 'inputTransformation', () => {
+		this.listenTo<ClipboardInputTransformationEvent>( clipboardPipeline, 'inputTransformation', () => {
 			const firstRange = modelDocument.selection.getFirstRange()!;
 
 			const leftLivePosition = LivePosition.fromPosition( firstRange.start );

--- a/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
@@ -22,7 +22,11 @@ import {
 } from 'ckeditor5/src/engine.js';
 
 import { Notification } from 'ckeditor5/src/ui.js';
-import { ClipboardPipeline, type ViewDocumentClipboardInputEvent } from 'ckeditor5/src/clipboard.js';
+import {
+	ClipboardPipeline,
+	type ClipboardInputTransformationEvent,
+	type ViewDocumentClipboardInputEvent
+} from 'ckeditor5/src/clipboard.js';
 import { FileRepository, type UploadResponse, type FileLoader } from 'ckeditor5/src/upload.js';
 import { env } from 'ckeditor5/src/utils.js';
 
@@ -199,7 +203,7 @@ export default class ImageUploadEditing extends Plugin {
 		// For every image file, a new file loader is created and a placeholder image is
 		// inserted into the content. Then, those images are uploaded once they appear in the model
 		// (see Document#change listener below).
-		this.listenTo( clipboardPipeline, 'inputTransformation', ( evt, data ) => {
+		this.listenTo<ClipboardInputTransformationEvent>( clipboardPipeline, 'inputTransformation', ( evt, data ) => {
 			const fetchableImages = Array.from( editor.editing.view.createRangeIn( data.content ) )
 				.map( value => value.item as ViewElement )
 				.filter( viewElement =>

--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -8,7 +8,7 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core.js';
-import type { ClipboardInputTransformationData } from 'ckeditor5/src/clipboard.js';
+import type { ClipboardInputTransformationData, ClipboardInputTransformationEvent } from 'ckeditor5/src/clipboard.js';
 import type { DocumentSelectionChangeEvent, Element, Model, Position, Range, Writer } from 'ckeditor5/src/engine.js';
 import { Delete, TextWatcher, getLastTextLine, findAttributeRange, type TextWatcherMatchedDataEvent } from 'ckeditor5/src/typing.js';
 import type { EnterCommand, ShiftEnterCommand } from 'ckeditor5/src/enter.js';
@@ -160,7 +160,7 @@ export default class AutoLink extends Plugin {
 		const clipboardPipeline = editor.plugins.get( 'ClipboardPipeline' );
 		const linkCommand = editor.commands.get( 'link' )!;
 
-		clipboardPipeline.on( 'inputTransformation', ( evt, data: ClipboardInputTransformationData ) => {
+		clipboardPipeline.on<ClipboardInputTransformationEvent>( 'inputTransformation', ( evt, data: ClipboardInputTransformationData ) => {
 			if ( !this.isEnabled || !linkCommand.isEnabled || selection.isCollapsed || data.method !== 'paste' ) {
 				// Abort if we are disabled or the selection is collapsed.
 				return;

--- a/packages/ckeditor5-media-embed/src/automediaembed.ts
+++ b/packages/ckeditor5-media-embed/src/automediaembed.ts
@@ -9,7 +9,7 @@
 
 import { type Editor, Plugin } from 'ckeditor5/src/core.js';
 import { LiveRange, LivePosition } from 'ckeditor5/src/engine.js';
-import { Clipboard, type ClipboardPipeline } from 'ckeditor5/src/clipboard.js';
+import { Clipboard, type ClipboardInputTransformationEvent, type ClipboardPipeline } from 'ckeditor5/src/clipboard.js';
 import { Delete } from 'ckeditor5/src/typing.js';
 import { Undo, type UndoCommand } from 'ckeditor5/src/undo.js';
 import { global } from 'ckeditor5/src/utils.js';
@@ -79,7 +79,7 @@ export default class AutoMediaEmbed extends Plugin {
 		// After pasting, the content between those positions will be checked for a URL that could be transformed
 		// into media.
 		const clipboardPipeline: ClipboardPipeline = editor.plugins.get( 'ClipboardPipeline' );
-		this.listenTo( clipboardPipeline, 'inputTransformation', () => {
+		this.listenTo<ClipboardInputTransformationEvent>( clipboardPipeline, 'inputTransformation', () => {
 			const firstRange = modelDocument.selection.getFirstRange()!;
 
 			const leftLivePosition = LivePosition.fromPosition( firstRange.start );

--- a/packages/ckeditor5-paste-from-office/src/index.ts
+++ b/packages/ckeditor5-paste-from-office/src/index.ts
@@ -8,7 +8,7 @@
  */
 
 export { default as PasteFromOffice } from './pastefromoffice.js';
-export type { Normalizer, NormalizerData } from './normalizer.js';
+export type { Normalizer } from './normalizer.js';
 export { default as MSWordNormalizer } from './normalizers/mswordnormalizer.js';
 export { parseHtml } from './filters/parse.js';
 

--- a/packages/ckeditor5-paste-from-office/src/normalizer.ts
+++ b/packages/ckeditor5-paste-from-office/src/normalizer.ts
@@ -8,7 +8,6 @@
  */
 
 import type { ClipboardInputTransformationData } from 'ckeditor5/src/clipboard.js';
-import type { ParseHtmlResult } from './filters/parse.js';
 
 /**
  * Interface defining a content transformation pasted from an external editor.
@@ -27,10 +26,5 @@ export interface Normalizer {
 	/**
 	 * Executes the normalization of a given data.
 	 */
-	execute( data: NormalizerData ): void;
-}
-
-export interface NormalizerData extends ClipboardInputTransformationData {
-	_isTransformedWithPasteFromOffice?: boolean;
-	_parsedData: ParseHtmlResult;
+	execute( data: ClipboardInputTransformationData ): void;
 }

--- a/packages/ckeditor5-paste-from-office/src/normalizers/googledocsnormalizer.ts
+++ b/packages/ckeditor5-paste-from-office/src/normalizers/googledocsnormalizer.ts
@@ -12,7 +12,8 @@ import { UpcastWriter, type ViewDocument } from 'ckeditor5/src/engine.js';
 import removeBoldWrapper from '../filters/removeboldwrapper.js';
 import transformBlockBrsToParagraphs from '../filters/br.js';
 import { unwrapParagraphInListItem } from '../filters/list.js';
-import type { Normalizer, NormalizerData } from '../normalizer.js';
+import type { Normalizer } from '../normalizer.js';
+import type { ClipboardInputTransformationData } from 'ckeditor5/src/clipboard.js';
 
 const googleDocsMatch = /id=("|')docs-internal-guid-[-0-9a-f]+("|')/i;
 
@@ -41,14 +42,11 @@ export default class GoogleDocsNormalizer implements Normalizer {
 	/**
 	 * @inheritDoc
 	 */
-	public execute( data: NormalizerData ): void {
+	public execute( data: ClipboardInputTransformationData ): void {
 		const writer = new UpcastWriter( this.document );
-		const { body: documentFragment } = data._parsedData;
 
-		removeBoldWrapper( documentFragment, writer );
-		unwrapParagraphInListItem( documentFragment, writer );
-		transformBlockBrsToParagraphs( documentFragment, writer );
-
-		data.content = documentFragment;
+		removeBoldWrapper( data.content, writer );
+		unwrapParagraphInListItem( data.content, writer );
+		transformBlockBrsToParagraphs( data.content, writer );
 	}
 }

--- a/packages/ckeditor5-paste-from-office/src/normalizers/googlesheetsnormalizer.ts
+++ b/packages/ckeditor5-paste-from-office/src/normalizers/googlesheetsnormalizer.ts
@@ -13,7 +13,8 @@ import removeXmlns from '../filters/removexmlns.js';
 import removeGoogleSheetsTag from '../filters/removegooglesheetstag.js';
 import removeInvalidTableWidth from '../filters/removeinvalidtablewidth.js';
 import removeStyleBlock from '../filters/removestyleblock.js';
-import type { Normalizer, NormalizerData } from '../normalizer.js';
+import type { Normalizer } from '../normalizer.js';
+import type { ClipboardInputTransformationData } from 'ckeditor5/src/clipboard.js';
 
 const googleSheetsMatch = /<google-sheets-html-origin/i;
 
@@ -42,15 +43,12 @@ export default class GoogleSheetsNormalizer implements Normalizer {
 	/**
 	 * @inheritDoc
 	 */
-	public execute( data: NormalizerData ): void {
+	public execute( data: ClipboardInputTransformationData ): void {
 		const writer = new UpcastWriter( this.document );
-		const { body: documentFragment } = data._parsedData;
 
-		removeGoogleSheetsTag( documentFragment, writer );
-		removeXmlns( documentFragment, writer );
-		removeInvalidTableWidth( documentFragment, writer );
-		removeStyleBlock( documentFragment, writer );
-
-		data.content = documentFragment;
+		removeGoogleSheetsTag( data.content, writer );
+		removeXmlns( data.content, writer );
+		removeInvalidTableWidth( data.content, writer );
+		removeStyleBlock( data.content, writer );
 	}
 }

--- a/packages/ckeditor5-paste-from-office/src/normalizers/mswordnormalizer.ts
+++ b/packages/ckeditor5-paste-from-office/src/normalizers/mswordnormalizer.ts
@@ -12,7 +12,8 @@ import { transformListItemLikeElementsIntoLists } from '../filters/list.js';
 import { replaceImagesSourceWithBase64 } from '../filters/image.js';
 import removeMSAttributes from '../filters/removemsattributes.js';
 import { UpcastWriter, type ViewDocument } from 'ckeditor5/src/engine.js';
-import type { Normalizer, NormalizerData } from '../normalizer.js';
+import type { Normalizer } from '../normalizer.js';
+import type { ClipboardInputTransformationData } from 'ckeditor5/src/clipboard.js';
 
 const msWordMatch1 = /<meta\s*name="?generator"?\s*content="?microsoft\s*word\s*\d+"?\/?>/i;
 const msWordMatch2 = /xmlns:o="urn:schemas-microsoft-com/i;
@@ -45,15 +46,13 @@ export default class MSWordNormalizer implements Normalizer {
 	/**
 	 * @inheritDoc
 	 */
-	public execute( data: NormalizerData ): void {
+	public execute( data: ClipboardInputTransformationData ): void {
 		const writer = new UpcastWriter( this.document );
-		const { body: documentFragment, stylesString } = data._parsedData;
+		const stylesString = ( data.extraContent as { stylesString: string } ).stylesString;
 
-		transformBookmarks( documentFragment, writer );
-		transformListItemLikeElementsIntoLists( documentFragment, stylesString, this.hasMultiLevelListPlugin );
-		replaceImagesSourceWithBase64( documentFragment, data.dataTransfer.getData( 'text/rtf' ) );
-		removeMSAttributes( documentFragment );
-
-		data.content = documentFragment;
+		transformBookmarks( data.content, writer );
+		transformListItemLikeElementsIntoLists( data.content, stylesString, this.hasMultiLevelListPlugin );
+		replaceImagesSourceWithBase64( data.content, data.dataTransfer.getData( 'text/rtf' ) );
+		removeMSAttributes( data.content );
 	}
 }

--- a/packages/ckeditor5-paste-from-office/src/pastefromoffice.ts
+++ b/packages/ckeditor5-paste-from-office/src/pastefromoffice.ts
@@ -38,7 +38,7 @@ import type { Normalizer } from './normalizer.js';
  */
 export default class PasteFromOffice extends Plugin {
 	/**
-	 * TODO
+	 * The priority array of registered normalizers.
 	 */
 	private _normalizers = [] as Array<{
 		normalizer: Normalizer;
@@ -67,7 +67,7 @@ export default class PasteFromOffice extends Plugin {
 	}
 
 	/**
-	 * TODO
+	 * Registers a normalizer with the given priority.
 	 */
 	public registerNormalizer(
 		normalizer: Normalizer,

--- a/packages/ckeditor5-paste-from-office/tests/_utils/utils.js
+++ b/packages/ckeditor5-paste-from-office/tests/_utils/utils.js
@@ -176,18 +176,16 @@ function generateNormalizationTests( title, fixtures, editorConfig, skip, only )
 					'text/rtf': fixtures.inputRtf && fixtures.inputRtf[ name ]
 				} );
 
-				const clipboardInputData = { dataTransfer };
+				// data.content might be completely overwritten with a new object, so we need obtain final result for comparison.
+				let inputTransformationData;
+
+				clipboardPlugin.on( 'inputTransformation', ( evt, data ) => {
+					inputTransformationData = data;
+				} );
+
+				const clipboardInputData = { dataTransfer, content: fixtures.input[ name ] };
 
 				editor.editing.view.document.fire( 'clipboardInput', clipboardInputData );
-
-				// data.content might be completely overwritten with a new object, so we need obtain final result for comparison.
-				const inputTransformationData = {
-					content: clipboardInputData.content,
-					extraContent: clipboardInputData.extraContent,
-					dataTransfer
-				};
-
-				clipboardPlugin.fire( 'inputTransformation', inputTransformationData );
 
 				const transformedContent = inputTransformationData.content;
 

--- a/packages/ckeditor5-paste-from-office/tests/_utils/utils.js
+++ b/packages/ckeditor5-paste-from-office/tests/_utils/utils.js
@@ -7,17 +7,10 @@
 
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor.js';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
-import ViewDocument from '@ckeditor/ckeditor5-engine/src/view/document.js';
 
-import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor.js';
-import normalizeClipboardData from '@ckeditor/ckeditor5-clipboard/src/utils/normalizeclipboarddata.js';
 import normalizeHtml from '@ckeditor/ckeditor5-utils/tests/_utils/normalizehtml.js';
 import { setData, stringify as stringifyModel } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
 import { stringify as stringifyView } from '@ckeditor/ckeditor5-engine/src/dev-utils/view.js';
-
-import { StylesProcessor } from '@ckeditor/ckeditor5-engine/src/view/stylesmap.js';
-
-const htmlDataProcessor = new HtmlDataProcessor( new ViewDocument( new StylesProcessor() ) );
 
 /**
  * Mocks dataTransfer object which can be used for simulating paste.
@@ -156,9 +149,13 @@ function generateNormalizationTests( title, fixtures, editorConfig, skip, only )
 
 		beforeEach( async () => {
 			editor = await VirtualTestEditor.create( await editorConfig() );
+
+			// Stub `editor.editing.view.scrollToTheSelection` as it will fail on VirtualTestEditor without DOM.
+			sinon.stub( editor.editing.view, 'scrollToTheSelection' );
 		} );
 
 		afterEach( async () => {
+			sinon.restore();
 			await editor.destroy();
 		} );
 
@@ -174,16 +171,25 @@ function generateNormalizationTests( title, fixtures, editorConfig, skip, only )
 			testRunner( name, () => {
 				// Simulate data from Clipboard event
 				const clipboardPlugin = editor.plugins.get( 'ClipboardPipeline' );
-				const content = htmlDataProcessor.toView( normalizeClipboardData( fixtures.input[ name ] ) );
 				const dataTransfer = createDataTransfer( {
 					'text/html': fixtures.input[ name ],
 					'text/rtf': fixtures.inputRtf && fixtures.inputRtf[ name ]
 				} );
 
+				const clipboardInputData = { dataTransfer };
+
+				editor.editing.view.document.fire( 'clipboardInput', clipboardInputData );
+
 				// data.content might be completely overwritten with a new object, so we need obtain final result for comparison.
-				const data = { content, dataTransfer };
-				clipboardPlugin.fire( 'inputTransformation', data );
-				const transformedContent = data.content;
+				const inputTransformationData = {
+					content: clipboardInputData.content,
+					extraContent: clipboardInputData.extraContent,
+					dataTransfer
+				};
+
+				clipboardPlugin.fire( 'inputTransformation', inputTransformationData );
+
+				const transformedContent = inputTransformationData.content;
 
 				expectNormalized(
 					transformedContent,

--- a/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
+++ b/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
@@ -6,23 +6,17 @@
 import PasteFromOffice from '../src/pastefromoffice.js';
 import ClipboardPipeline from '@ckeditor/ckeditor5-clipboard/src/clipboardpipeline.js';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
-import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor.js';
 import { createDataTransfer } from './_utils/utils.js';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
-import { StylesProcessor } from '@ckeditor/ckeditor5-engine/src/view/stylesmap.js';
-import ViewDocument from '@ckeditor/ckeditor5-engine/src/view/document.js';
 import ViewDocumentFragment from '@ckeditor/ckeditor5-engine/src/view/documentfragment.js';
 import CodeBlockUI from '@ckeditor/ckeditor5-code-block/src/codeblockui.js';
 import CodeBlockEditing from '@ckeditor/ckeditor5-code-block/src/codeblockediting.js';
 import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
-import { priorities } from '@ckeditor/ckeditor5-utils';
-import { DomConverter } from '@ckeditor/ckeditor5-engine';
 
-/* global document, DOMParser */
+/* global document */
 
 describe( 'PasteFromOffice', () => {
-	const htmlDataProcessor = new HtmlDataProcessor( new ViewDocument( new StylesProcessor() ) );
 	let editor, pasteFromOffice, clipboard, element, viewDocument;
 
 	testUtils.createSinonSandbox();
@@ -63,37 +57,6 @@ describe( 'PasteFromOffice', () => {
 
 	it( 'should load Clipboard plugin', () => {
 		expect( editor.plugins.get( ClipboardPipeline ) ).to.be.instanceOf( ClipboardPipeline );
-	} );
-
-	it( 'should work on already parsed data if another plugin hooked into #inputTransformation with a higher priority', () => {
-		const clipboardPipeline = editor.plugins.get( 'ClipboardPipeline' );
-		const viewDocument = editor.editing.view.document;
-
-		// Simulate a plugin that hooks into the pipeline earlier and parses the data.
-		clipboardPipeline.on( 'inputTransformation', ( evt, data ) => {
-			const domParser = new DOMParser();
-			const htmlDocument = domParser.parseFromString( '<p>Existing data</p>', 'text/html' );
-			const domConverter = new DomConverter( viewDocument, { renderingMode: 'data' } );
-			const fragment = htmlDocument.createDocumentFragment();
-
-			data._parsedData = {
-				body: domConverter.domToView( fragment, { skipComments: true } ),
-				bodyString: '<body>Already parsed data</body>',
-				styles: [],
-				stylesString: ''
-			};
-		}, { priority: priorities.get( 'high' ) + 1 } );
-
-		const eventData = {
-			content: htmlDataProcessor.toView( '<meta name=Generator content="Microsoft Word 15">' ),
-			dataTransfer: createDataTransfer( { 'text/html': '<meta name=Generator content="Microsoft Word 15">' } )
-		};
-
-		// Trigger some event that would normally trigger the paste from office plugin.
-		clipboard.fire( 'inputTransformation', eventData );
-
-		// Verify if the PFO plugin works on an already parsed data.
-		expect( eventData._parsedData.bodyString ).to.equal( '<body>Already parsed data</body>' );
 	} );
 
 	describe( 'parsed with extraContent property set', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (clipboard): TODO The `ClipboardPipeline` and `PasteFromOffice` should allow for common HTML string normalization before conversion to view. Closes #17309.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
