### PR TITLE
Allow to specify which list style types are shown in list type selector dropdown.

### DIFF
--- a/packages/ckeditor5-list/src/listconfig.ts
+++ b/packages/ckeditor5-list/src/listconfig.ts
@@ -168,6 +168,50 @@ export interface ListPropertiesStyleConfig {
 	 * @default false
 	 */
 	useAttribute?: boolean;
+
+	/**
+	 * Defines which list styles should be available in the UI.
+	 * Accepts an array of style names or `true` to enable all styles.
+	 *
+	 * Available styles for numbered lists:
+	 * - 'decimal'
+	 * - 'decimal-leading-zero'
+	 * - 'lower-roman'
+	 * - 'upper-roman'
+	 * - 'lower-latin'
+	 * - 'upper-latin'
+	 *
+	 * Available styles for bulleted lists:
+	 * - 'disc'
+	 * - 'circle'
+	 * - 'square'
+	 *
+	 * ```ts
+	 * {
+	 *   list: {
+	 *     properties: {
+	 *       styles: {
+	 *         listStyleTypes: [ 'decimal', 'lower-roman', 'upper-roman' ]
+	 *       }
+	 *     }
+	 *   }
+	 * }
+	 * ```
+	 *
+	 * @default ['decimal','decimal-leading-zero','lower-roman','upper-roman','lower-latin','upper-latin','disc','circle','square']
+	 */
+	listStyleTypes?: Array<ListPropertiesStyleListStyleType>;
 }
 
 export type ListPropertiesStyleListType = 'numbered' | 'bulleted';
+
+export type ListPropertiesStyleListStyleType =
+	| 'decimal'
+	| 'decimal-leading-zero'
+	| 'lower-roman'
+	| 'upper-roman'
+	| 'lower-latin'
+	| 'upper-latin'
+	| 'disc'
+	| 'circle'
+	| 'square';

--- a/packages/ckeditor5-list/src/listconfig.ts
+++ b/packages/ckeditor5-list/src/listconfig.ts
@@ -171,47 +171,47 @@ export interface ListPropertiesStyleConfig {
 
 	/**
 	 * Defines which list styles should be available in the UI.
-	 * Accepts an array of style names or `true` to enable all styles.
-	 *
-	 * Available styles for numbered lists:
-	 * - 'decimal'
-	 * - 'decimal-leading-zero'
-	 * - 'lower-roman'
-	 * - 'upper-roman'
-	 * - 'lower-latin'
-	 * - 'upper-latin'
-	 *
-	 * Available styles for bulleted lists:
-	 * - 'disc'
-	 * - 'circle'
-	 * - 'square'
+	 * Accepts a configuration object with numbered and bulleted styles or `true` to enable all styles.
 	 *
 	 * ```ts
 	 * {
 	 *   list: {
 	 *     properties: {
 	 *       styles: {
-	 *         listStyleTypes: [ 'decimal', 'lower-roman', 'upper-roman' ]
+	 *         listTypesStyles: {
+	 *           numbered: [ 'decimal', 'lower-roman', 'upper-roman' ],
+	 *           bulleted: [ 'disc', 'circle' ]
+	 *         }
 	 *       }
 	 *     }
 	 *   }
 	 * }
 	 * ```
 	 *
-	 * @default ['decimal','decimal-leading-zero','lower-roman','upper-roman','lower-latin','upper-latin','disc','circle','square']
+	 * @default {
+	 *   numbered: ['decimal', 'decimal-leading-zero', 'lower-roman', 'upper-roman', 'lower-latin', 'upper-latin'],
+	 *   bulleted: ['disc', 'circle', 'square']
+	 * }
 	 */
-	listStyleTypes?: Array<ListPropertiesStyleListStyleType>;
+	listTypesStyles?: ListStyleTypesConfig;
+}
+
+export interface ListStyleTypesConfig {
+	numbered?: Array<NumberedListStyleType>;
+	bulleted?: Array<BulletedListStyleType>;
 }
 
 export type ListPropertiesStyleListType = 'numbered' | 'bulleted';
 
-export type ListPropertiesStyleListStyleType =
+export type NumberedListStyleType =
 	| 'decimal'
 	| 'decimal-leading-zero'
 	| 'lower-roman'
 	| 'upper-roman'
 	| 'lower-latin'
-	| 'upper-latin'
+	| 'upper-latin';
+
+export type BulletedListStyleType =
 	| 'disc'
 	| 'circle'
 	| 'square';

--- a/packages/ckeditor5-list/src/listconfig.ts
+++ b/packages/ckeditor5-list/src/listconfig.ts
@@ -171,14 +171,14 @@ export interface ListPropertiesStyleConfig {
 
 	/**
 	 * Defines which list styles should be available in the UI.
-	 * Accepts a configuration object with numbered and bulleted styles or `true` to enable all styles.
+	 * Accepts a configuration object with numbered and bulleted styles.
 	 *
 	 * ```ts
 	 * {
 	 *   list: {
 	 *     properties: {
 	 *       styles: {
-	 *         listTypesStyles: {
+	 *         listStyleTypes: {
 	 *           numbered: [ 'decimal', 'lower-roman', 'upper-roman' ],
 	 *           bulleted: [ 'disc', 'circle' ]
 	 *         }
@@ -193,7 +193,7 @@ export interface ListPropertiesStyleConfig {
 	 *   bulleted: ['disc', 'circle', 'square']
 	 * }
 	 */
-	listTypesStyles?: ListStyleTypesConfig;
+	listStyleTypes?: ListStyleTypesConfig;
 }
 
 export interface ListStyleTypesConfig {

--- a/packages/ckeditor5-list/src/listconfig.ts
+++ b/packages/ckeditor5-list/src/listconfig.ts
@@ -173,9 +173,6 @@ export interface ListPropertiesStyleConfig {
 	 * Defines which list styles should be available in the UI.
 	 * Accepts a configuration object with numbered and bulleted styles.
 	 *
-	 * **Note**: This configuration works only with
-	 * {@link module:list/listproperties~ListProperties list properties}.
-	 *
 	 * ```ts
 	 * {
 	 *   list: {
@@ -212,9 +209,12 @@ export interface ListPropertiesStyleConfig {
 	 *
 	 * Only the numbered list styles will be available in the UI, as the `listTypes` property limits style selection to numbered lists only.
 	 *
+	 * **Note**: This configuration works only with
+	 * {@link module:list/listproperties~ListProperties list properties}.
+	 *
 	 * @default {
-	 *   numbered: ['decimal', 'decimal-leading-zero', 'lower-roman', 'upper-roman', 'lower-latin', 'upper-latin'],
-	 *   bulleted: ['disc', 'circle', 'square']
+	 *   numbered: [ 'decimal', 'decimal-leading-zero', 'lower-roman', 'upper-roman', 'lower-latin', 'upper-latin' ],
+	 *   bulleted: [ 'disc', 'circle', 'square' ]
 	 * }
 	 */
 	listStyleTypes?: ListStyleTypesConfig;

--- a/packages/ckeditor5-list/src/listconfig.ts
+++ b/packages/ckeditor5-list/src/listconfig.ts
@@ -173,6 +173,9 @@ export interface ListPropertiesStyleConfig {
 	 * Defines which list styles should be available in the UI.
 	 * Accepts a configuration object with numbered and bulleted styles.
 	 *
+	 * **Note**: This configuration works only with
+	 * {@link module:list/listproperties~ListProperties list properties}.
+	 *
 	 * ```ts
 	 * {
 	 *   list: {

--- a/packages/ckeditor5-list/src/listconfig.ts
+++ b/packages/ckeditor5-list/src/listconfig.ts
@@ -191,6 +191,27 @@ export interface ListPropertiesStyleConfig {
 	 * }
 	 * ```
 	 *
+	 * When the `listTypes` configuration is set, `listStyleTypes` will only take effect for the enabled list types.
+	 * For example, with the following configuration:
+	 *
+	 * ```ts
+	 * {
+	 *   list: {
+	 *     properties: {
+	 *       styles: {
+	 *         listTypes: 'numbered',
+	 *         listStyleTypes: {
+	 *           numbered: [ 'decimal', 'lower-roman' ],
+	 *           bulleted: [ 'disc', 'circle' ]
+	 *         }
+	 *       }
+	 *     }
+	 *   }
+	 * }
+	 * ```
+	 *
+	 * Only the numbered list styles will be available in the UI, as the `listTypes` property limits style selection to numbered lists only.
+	 *
 	 * @default {
 	 *   numbered: ['decimal', 'decimal-leading-zero', 'lower-roman', 'upper-roman', 'lower-latin', 'upper-latin'],
 	 *   bulleted: ['disc', 'circle', 'square']

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
@@ -269,6 +269,7 @@ function createAttributeStrategies( enabledProperties: ListPropertiesConfig ) {
 
 	if ( enabledProperties.styles ) {
 		const useAttribute = normalizedConfig.styles.useAttribute;
+		const allowedListStyleTypes = normalizedConfig.styles.listStyleTypes;
 
 		strategies.push( {
 			attributeName: 'listStyle',
@@ -280,6 +281,10 @@ function createAttributeStrategies( enabledProperties: ListPropertiesConfig ) {
 
 				if ( useAttribute ) {
 					supportedTypes = supportedTypes.filter( styleType => !!getTypeAttributeFromListStyleType( styleType ) );
+				}
+
+				if ( Array.isArray( allowedListStyleTypes ) ) {
+					supportedTypes = supportedTypes.filter( styleType => allowedListStyleTypes.includes( styleType ) );
 				}
 
 				editor.commands.add( 'listStyle', new ListStyleCommand( editor, DEFAULT_LIST_TYPE, supportedTypes ) );

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
@@ -270,9 +270,9 @@ function createAttributeStrategies( enabledProperties: ListPropertiesConfig ) {
 	if ( enabledProperties.styles ) {
 		const useAttribute = normalizedConfig.styles.useAttribute;
 		const configuredTypes = normalizedConfig.styles.listTypesStyles;
-		const allowedTypes = {
-			numbered: ( configuredTypes && configuredTypes.numbered ) || [],
-			bulleted: ( configuredTypes && configuredTypes.bulleted ) || []
+		const allowedTypes = configuredTypes && {
+			numbered: configuredTypes.numbered || [],
+			bulleted: configuredTypes.bulleted || []
 		};
 
 		strategies.push( {

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
@@ -289,8 +289,9 @@ function createAttributeStrategies( enabledProperties: ListPropertiesConfig ) {
 
 				if ( allowedTypes ) {
 					supportedTypes = supportedTypes.filter( styleType => {
-						const listType = getListTypeFromListStyleType( styleType );
-						return allowedTypes[ listType as 'numbered' | 'bulleted' ].includes( styleType );
+						const listType = getListTypeFromListStyleType( styleType )!;
+
+						return allowedTypes[ listType ].includes( styleType );
 					} );
 				}
 

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
@@ -269,7 +269,11 @@ function createAttributeStrategies( enabledProperties: ListPropertiesConfig ) {
 
 	if ( enabledProperties.styles ) {
 		const useAttribute = normalizedConfig.styles.useAttribute;
-		const allowedListStyleTypes = normalizedConfig.styles.listStyleTypes;
+		const configuredTypes = normalizedConfig.styles.listTypesStyles;
+		const allowedTypes = {
+			numbered: ( configuredTypes && configuredTypes.numbered ) || [],
+			bulleted: ( configuredTypes && configuredTypes.bulleted ) || []
+		};
 
 		strategies.push( {
 			attributeName: 'listStyle',
@@ -283,8 +287,11 @@ function createAttributeStrategies( enabledProperties: ListPropertiesConfig ) {
 					supportedTypes = supportedTypes.filter( styleType => !!getTypeAttributeFromListStyleType( styleType ) );
 				}
 
-				if ( Array.isArray( allowedListStyleTypes ) ) {
-					supportedTypes = supportedTypes.filter( styleType => allowedListStyleTypes.includes( styleType ) );
+				if ( allowedTypes ) {
+					supportedTypes = supportedTypes.filter( styleType => {
+						const listType = getListTypeFromListStyleType( styleType );
+						return allowedTypes[ listType as 'numbered' | 'bulleted' ].includes( styleType );
+					} );
 				}
 
 				editor.commands.add( 'listStyle', new ListStyleCommand( editor, DEFAULT_LIST_TYPE, supportedTypes ) );

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
@@ -269,11 +269,6 @@ function createAttributeStrategies( enabledProperties: ListPropertiesConfig ) {
 
 	if ( enabledProperties.styles ) {
 		const useAttribute = normalizedConfig.styles.useAttribute;
-		const configuredTypes = normalizedConfig.styles.listTypesStyles;
-		const allowedTypes = configuredTypes && {
-			numbered: configuredTypes.numbered || [],
-			bulleted: configuredTypes.bulleted || []
-		};
 
 		strategies.push( {
 			attributeName: 'listStyle',
@@ -285,14 +280,6 @@ function createAttributeStrategies( enabledProperties: ListPropertiesConfig ) {
 
 				if ( useAttribute ) {
 					supportedTypes = supportedTypes.filter( styleType => !!getTypeAttributeFromListStyleType( styleType ) );
-				}
-
-				if ( allowedTypes ) {
-					supportedTypes = supportedTypes.filter( styleType => {
-						const listType = getListTypeFromListStyleType( styleType )!;
-
-						return allowedTypes[ listType ].includes( styleType );
-					} );
 				}
 
 				editor.commands.add( 'listStyle', new ListStyleCommand( editor, DEFAULT_LIST_TYPE, supportedTypes ) );

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
@@ -474,15 +474,11 @@ function getMenuBarStylesMenuCreator(
 
 		if ( configuredTypes ) {
 			const listType = parentCommandName.replace( 'List', '' ) as 'numbered' | 'bulleted';
-			const allowedTypes = configuredTypes[ listType ] || [];
 
-			filteredDefinitions = styleDefinitions.filter( def => allowedTypes.includes( def.type ) );
+			filteredDefinitions = styleDefinitions.filter( def => ( configuredTypes[ listType ] || [] ).includes( def.type ) );
 		}
 
-		const styleButtonViews = filteredDefinitions
-			.filter( isStyleTypeSupported )
-			.map( styleButtonCreator );
-
+		const styleButtonViews = filteredDefinitions.filter( isStyleTypeSupported ).map( styleButtonCreator );
 		const listPropertiesView = new ListPropertiesView( locale, {
 			styleGridAriaLabel,
 			enabledProperties: {

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
@@ -373,7 +373,7 @@ function createListPropertiesView( {
 			listStyleCommand
 		} );
 
-		const configuredListStylesTypes = normalizedConfig.styles.listTypesStyles;
+		const configuredListStylesTypes = normalizedConfig.styles.listStyleTypes;
 		let filteredDefinitions = styleDefinitions;
 
 		if ( configuredListStylesTypes ) {
@@ -466,7 +466,7 @@ function getMenuBarStylesMenuCreator(
 			listStyleCommand
 		} );
 
-		const configuredListStylesTypes = normalizedConfig.styles.listTypesStyles;
+		const configuredListStylesTypes = normalizedConfig.styles.listStyleTypes;
 		let filteredDefinitions = styleDefinitions;
 
 		if ( configuredListStylesTypes ) {

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
@@ -470,7 +470,7 @@ function getMenuBarStylesMenuCreator(
 		let filteredDefinitions = styleDefinitions;
 
 		if ( configuredListStylesTypes ) {
-			const listType = parentCommandName.replace( 'List', '' ) as 'numbered' | 'bulleted';
+			const listType = listCommand.type as 'numbered' | 'bulleted';
 			const allowedTypes = configuredListStylesTypes[ listType ];
 
 			if ( allowedTypes ) {

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
@@ -226,12 +226,6 @@ function getDropdownViewCreator( {
 	styleDefinitions: Array<StyleDefinition>;
 } ) {
 	const parentCommand = editor.commands.get( parentCommandName )!;
-	const allowedListStyleTypes = normalizedConfig.styles.listTypesStyles;
-
-	// Filter style definitions if specific styles are configured
-	const filteredStyleDefinitions = Array.isArray( allowedListStyleTypes ) ?
-		styleDefinitions.filter( def => allowedListStyleTypes.includes( def.type ) ) :
-		styleDefinitions;
 
 	return ( locale: Locale ) => {
 		const dropdownView = createDropdown( locale, SplitButtonView );
@@ -262,7 +256,7 @@ function getDropdownViewCreator( {
 				dropdownView,
 				parentCommandName,
 				styleGridAriaLabel,
-				styleDefinitions: filteredStyleDefinitions
+				styleDefinitions
 			} );
 
 			dropdownView.panelView.children.add( listPropertiesView );
@@ -379,12 +373,15 @@ function createListPropertiesView( {
 			listStyleCommand
 		} );
 
-		const configuredTypes = normalizedConfig.styles.listTypesStyles;
+		const configuredListStylesTypes = normalizedConfig.styles.listTypesStyles;
 		let filteredDefinitions = styleDefinitions;
 
-		if ( configuredTypes ) {
-			const allowedTypes = configuredTypes[ listType ] || [];
-			filteredDefinitions = styleDefinitions.filter( def => allowedTypes.includes( def.type ) );
+		if ( configuredListStylesTypes ) {
+			const allowedTypes = configuredListStylesTypes[ listType ];
+
+			if ( allowedTypes ) {
+				filteredDefinitions = styleDefinitions.filter( def => allowedTypes.includes( def.type ) );
+			}
 		}
 
 		const isStyleTypeSupported = getStyleTypeSupportChecker( listStyleCommand );
@@ -469,13 +466,16 @@ function getMenuBarStylesMenuCreator(
 			listStyleCommand
 		} );
 
-		const configuredTypes = normalizedConfig.styles.listTypesStyles;
+		const configuredListStylesTypes = normalizedConfig.styles.listTypesStyles;
 		let filteredDefinitions = styleDefinitions;
 
-		if ( configuredTypes ) {
+		if ( configuredListStylesTypes ) {
 			const listType = parentCommandName.replace( 'List', '' ) as 'numbered' | 'bulleted';
+			const allowedTypes = configuredListStylesTypes[ listType ];
 
-			filteredDefinitions = styleDefinitions.filter( def => ( configuredTypes[ listType ] || [] ).includes( def.type ) );
+			if ( allowedTypes ) {
+				filteredDefinitions = styleDefinitions.filter( def => allowedTypes.includes( def.type ) );
+			}
 		}
 
 		const styleButtonViews = filteredDefinitions.filter( isStyleTypeSupported ).map( styleButtonCreator );

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
@@ -226,6 +226,12 @@ function getDropdownViewCreator( {
 	styleDefinitions: Array<StyleDefinition>;
 } ) {
 	const parentCommand = editor.commands.get( parentCommandName )!;
+	const allowedListStyleTypes = normalizedConfig.styles.listStyleTypes;
+
+	// Filter style definitions if specific styles are configured
+	const filteredStyleDefinitions = Array.isArray( allowedListStyleTypes ) ?
+		styleDefinitions.filter( def => allowedListStyleTypes.includes( def.type ) ) :
+		styleDefinitions;
 
 	return ( locale: Locale ) => {
 		const dropdownView = createDropdown( locale, SplitButtonView );
@@ -256,7 +262,7 @@ function getDropdownViewCreator( {
 				dropdownView,
 				parentCommandName,
 				styleGridAriaLabel,
-				styleDefinitions
+				styleDefinitions: filteredStyleDefinitions
 			} );
 
 			dropdownView.panelView.children.add( listPropertiesView );

--- a/packages/ckeditor5-list/src/listproperties/utils/config.ts
+++ b/packages/ckeditor5-list/src/listproperties/utils/config.ts
@@ -75,8 +75,8 @@ function getNormalizedStylesConfig( styles: ListPropertiesConfig[ 'styles' ] ): 
 
 		normalizedConfig.useAttribute = !!styles.useAttribute;
 
-		if ( styles.listTypesStyles ) {
-			normalizedConfig.listTypesStyles = styles.listTypesStyles;
+		if ( styles.listStyleTypes ) {
+			normalizedConfig.listStyleTypes = styles.listStyleTypes;
 		}
 	}
 
@@ -89,7 +89,7 @@ function getNormalizedStylesConfig( styles: ListPropertiesConfig[ 'styles' ] ): 
 export type NormalizedListPropertiesConfig = {
 	styles: {
 		listTypes: Array<ListPropertiesStyleListType>;
-		listTypesStyles?: {
+		listStyleTypes?: {
 			numbered?: Array<string>;
 			bulleted?: Array<string>;
 		};

--- a/packages/ckeditor5-list/src/listproperties/utils/config.ts
+++ b/packages/ckeditor5-list/src/listproperties/utils/config.ts
@@ -53,8 +53,8 @@ export function getNormalizedConfig( config: ListPropertiesConfig ): NormalizedL
  * @returns An object with normalized list properties styles.
  */
 function getNormalizedStylesConfig( styles: ListPropertiesConfig[ 'styles' ] ): NormalizedListPropertiesConfig[ 'styles' ] {
-	const normalizedConfig = {
-		listTypes: [ 'bulleted', 'numbered' ] as Array<ListPropertiesStyleListType>,
+	const normalizedConfig: NormalizedListPropertiesConfig['styles'] = {
+		listTypes: [ 'bulleted', 'numbered' ],
 		useAttribute: false
 	};
 
@@ -74,6 +74,7 @@ function getNormalizedStylesConfig( styles: ListPropertiesConfig[ 'styles' ] ): 
 			normalizedConfig.listTypes;
 
 		normalizedConfig.useAttribute = !!styles.useAttribute;
+		normalizedConfig.listStyleTypes = styles.listStyleTypes;
 	}
 
 	return normalizedConfig;
@@ -85,6 +86,7 @@ function getNormalizedStylesConfig( styles: ListPropertiesConfig[ 'styles' ] ): 
 export type NormalizedListPropertiesConfig = {
 	styles: {
 		listTypes: Array<ListPropertiesStyleListType>;
+		listStyleTypes?: Array<string>;
 		useAttribute: boolean;
 	};
 	startIndex: boolean;

--- a/packages/ckeditor5-list/src/listproperties/utils/config.ts
+++ b/packages/ckeditor5-list/src/listproperties/utils/config.ts
@@ -74,7 +74,7 @@ function getNormalizedStylesConfig( styles: ListPropertiesConfig[ 'styles' ] ): 
 			normalizedConfig.listTypes;
 
 		normalizedConfig.useAttribute = !!styles.useAttribute;
-		normalizedConfig.listStyleTypes = styles.listStyleTypes;
+		normalizedConfig.listTypesStyles = styles.listTypesStyles;
 	}
 
 	return normalizedConfig;
@@ -86,7 +86,10 @@ function getNormalizedStylesConfig( styles: ListPropertiesConfig[ 'styles' ] ): 
 export type NormalizedListPropertiesConfig = {
 	styles: {
 		listTypes: Array<ListPropertiesStyleListType>;
-		listStyleTypes?: Array<string>;
+		listTypesStyles?: {
+			numbered?: Array<string>;
+			bulleted?: Array<string>;
+		};
 		useAttribute: boolean;
 	};
 	startIndex: boolean;

--- a/packages/ckeditor5-list/src/listproperties/utils/config.ts
+++ b/packages/ckeditor5-list/src/listproperties/utils/config.ts
@@ -53,7 +53,7 @@ export function getNormalizedConfig( config: ListPropertiesConfig ): NormalizedL
  * @returns An object with normalized list properties styles.
  */
 function getNormalizedStylesConfig( styles: ListPropertiesConfig[ 'styles' ] ): NormalizedListPropertiesConfig[ 'styles' ] {
-	const normalizedConfig: NormalizedListPropertiesConfig['styles'] = {
+	const normalizedConfig: NormalizedListPropertiesConfig[ 'styles' ] = {
 		listTypes: [ 'bulleted', 'numbered' ],
 		useAttribute: false
 	};

--- a/packages/ckeditor5-list/src/listproperties/utils/config.ts
+++ b/packages/ckeditor5-list/src/listproperties/utils/config.ts
@@ -74,7 +74,10 @@ function getNormalizedStylesConfig( styles: ListPropertiesConfig[ 'styles' ] ): 
 			normalizedConfig.listTypes;
 
 		normalizedConfig.useAttribute = !!styles.useAttribute;
-		normalizedConfig.listTypesStyles = styles.listTypesStyles;
+
+		if ( styles.listTypesStyles ) {
+			normalizedConfig.listTypesStyles = styles.listTypesStyles;
+		}
 	}
 
 	return normalizedConfig;

--- a/packages/ckeditor5-list/tests/listproperties/listpropertiesui.js
+++ b/packages/ckeditor5-list/tests/listproperties/listpropertiesui.js
@@ -256,11 +256,11 @@ describe( 'ListPropertiesUI', () => {
 					} );
 				} );
 
-				describe( 'listTypesStyles config entry', () => {
-					it( 'should register buttons filtered by listTypesStyles for bulleted list', () => {
+				describe( 'listStyleTypes config entry', () => {
+					it( 'should register buttons filtered by listStyleTypes for bulleted list', () => {
 						return withEditor( {
 							styles: {
-								listTypesStyles: {
+								listStyleTypes: {
 									bulleted: [ 'disc', 'circle' ]
 								}
 							}
@@ -284,10 +284,10 @@ describe( 'ListPropertiesUI', () => {
 						} );
 					} );
 
-					it( 'should register buttons filtered by listTypesStyles for numbered list', () => {
+					it( 'should register buttons filtered by listStyleTypes for numbered list', () => {
 						return withEditor( {
 							styles: {
-								listTypesStyles: {
+								listStyleTypes: {
 									numbered: [ 'decimal', 'lower-roman' ]
 								}
 							}
@@ -311,7 +311,7 @@ describe( 'ListPropertiesUI', () => {
 						} );
 					} );
 
-					it( 'should register all buttons when listTypesStyles is undefined', () => {
+					it( 'should register all buttons when listStyleTypes is undefined', () => {
 						return withEditor( {
 							styles: true
 						}, editor => {
@@ -341,10 +341,10 @@ describe( 'ListPropertiesUI', () => {
 						} );
 					} );
 
-					it( 'should register no buttons when listTypesStyles has empty array', () => {
+					it( 'should register no buttons when listStyleTypes has empty array', () => {
 						return withEditor( {
 							styles: {
-								listTypesStyles: {
+								listStyleTypes: {
 									numbered: [],
 									bulleted: []
 								}
@@ -1186,11 +1186,11 @@ describe( 'ListPropertiesUI', () => {
 					} );
 				} );
 
-				describe( 'listTypesStyles config entry', () => {
-					it( 'should register buttons filtered by listTypesStyles for bulleted list in menu bar', () => {
+				describe( 'listStyleTypes config entry', () => {
+					it( 'should register buttons filtered by listStyleTypes for bulleted list in menu bar', () => {
 						return withEditor( {
 							styles: {
-								listTypesStyles: {
+								listStyleTypes: {
 									bulleted: [ 'disc', 'circle' ]
 								}
 							}
@@ -1214,10 +1214,10 @@ describe( 'ListPropertiesUI', () => {
 						} );
 					} );
 
-					it( 'should register buttons filtered by listTypesStyles for numbered list in menu bar', () => {
+					it( 'should register buttons filtered by listStyleTypes for numbered list in menu bar', () => {
 						return withEditor( {
 							styles: {
-								listTypesStyles: {
+								listStyleTypes: {
 									numbered: [ 'decimal', 'lower-roman' ]
 								}
 							}
@@ -1241,7 +1241,7 @@ describe( 'ListPropertiesUI', () => {
 						} );
 					} );
 
-					it( 'should register all buttons when listTypesStyles is undefined in menu bar', () => {
+					it( 'should register all buttons when listStyleTypes is undefined in menu bar', () => {
 						return withEditor( {
 							styles: true
 						}, editor => {
@@ -1271,10 +1271,10 @@ describe( 'ListPropertiesUI', () => {
 						} );
 					} );
 
-					it( 'should register no buttons when listTypesStyles has empty array in menu bar', () => {
+					it( 'should register no buttons when listStyleTypes has empty array in menu bar', () => {
 						return withEditor( {
 							styles: {
-								listTypesStyles: {
+								listStyleTypes: {
 									numbered: [],
 									bulleted: []
 								}

--- a/packages/ckeditor5-list/tests/listproperties/listpropertiesui.js
+++ b/packages/ckeditor5-list/tests/listproperties/listpropertiesui.js
@@ -255,6 +255,119 @@ describe( 'ListPropertiesUI', () => {
 						expect( componentFactory.has( 'numberedList' ) ).to.be.false;
 					} );
 				} );
+
+				describe( 'listTypesStyles config entry', () => {
+					it( 'should register buttons filtered by listTypesStyles for bulleted list', () => {
+						return withEditor( {
+							styles: {
+								listTypesStyles: {
+									bulleted: [ 'disc', 'circle' ]
+								}
+							}
+						}, editor => {
+							const componentFactory = editor.ui.componentFactory;
+							const bulletedListDropdown = componentFactory.create( 'bulletedList' );
+
+							bulletedListDropdown.render();
+							document.body.appendChild( bulletedListDropdown.element );
+
+							// Trigger lazy init
+							bulletedListDropdown.isOpen = true;
+							bulletedListDropdown.isOpen = false;
+
+							const listPropertiesView = bulletedListDropdown.panelView.children.first;
+							const stylesView = listPropertiesView.stylesView;
+
+							expect( stylesView.children.map( b => b.tooltip ) ).to.deep.equal( [ 'Disc', 'Circle' ] );
+
+							bulletedListDropdown.element.remove();
+						} );
+					} );
+
+					it( 'should register buttons filtered by listTypesStyles for numbered list', () => {
+						return withEditor( {
+							styles: {
+								listTypesStyles: {
+									numbered: [ 'decimal', 'lower-roman' ]
+								}
+							}
+						}, editor => {
+							const componentFactory = editor.ui.componentFactory;
+							const numberedListDropdown = componentFactory.create( 'numberedList' );
+
+							numberedListDropdown.render();
+							document.body.appendChild( numberedListDropdown.element );
+
+							// Trigger lazy init
+							numberedListDropdown.isOpen = true;
+							numberedListDropdown.isOpen = false;
+
+							const listPropertiesView = numberedListDropdown.panelView.children.first;
+							const stylesView = listPropertiesView.stylesView;
+
+							expect( stylesView.children.map( b => b.tooltip ) ).to.deep.equal( [ 'Decimal', 'Lower–roman' ] );
+
+							numberedListDropdown.element.remove();
+						} );
+					} );
+
+					it( 'should register all buttons when listTypesStyles is undefined', () => {
+						return withEditor( {
+							styles: true
+						}, editor => {
+							const componentFactory = editor.ui.componentFactory;
+							const numberedListDropdown = componentFactory.create( 'numberedList' );
+
+							numberedListDropdown.render();
+							document.body.appendChild( numberedListDropdown.element );
+
+							// Trigger lazy init
+							numberedListDropdown.isOpen = true;
+							numberedListDropdown.isOpen = false;
+
+							const listPropertiesView = numberedListDropdown.panelView.children.first;
+							const stylesView = listPropertiesView.stylesView;
+
+							expect( stylesView.children.map( b => b.tooltip ) ).to.deep.equal( [
+								'Decimal',
+								'Decimal with leading zero',
+								'Lower–roman',
+								'Upper-roman',
+								'Lower-latin',
+								'Upper-latin'
+							] );
+
+							numberedListDropdown.element.remove();
+						} );
+					} );
+
+					it( 'should register no buttons when listTypesStyles has empty array', () => {
+						return withEditor( {
+							styles: {
+								listTypesStyles: {
+									numbered: [],
+									bulleted: []
+								}
+							}
+						}, editor => {
+							const componentFactory = editor.ui.componentFactory;
+							const numberedListDropdown = componentFactory.create( 'numberedList' );
+
+							numberedListDropdown.render();
+							document.body.appendChild( numberedListDropdown.element );
+
+							// Trigger lazy init
+							numberedListDropdown.isOpen = true;
+							numberedListDropdown.isOpen = false;
+
+							const listPropertiesView = numberedListDropdown.panelView.children.first;
+
+							expect( listPropertiesView.stylesView ).to.be.null;
+
+							numberedListDropdown.element.remove();
+						} );
+					} );
+				} );
 			} );
 
 			describe( 'bulleted list dropdown', () => {
@@ -1070,6 +1183,119 @@ describe( 'ListPropertiesUI', () => {
 
 						expect( componentFactory.has( 'menuBar:numberedList' ) ).to.be.false;
 						expect( componentFactory.has( 'menuBar:bulletedList' ) ).to.be.false;
+					} );
+				} );
+
+				describe( 'listTypesStyles config entry', () => {
+					it( 'should register buttons filtered by listTypesStyles for bulleted list in menu bar', () => {
+						return withEditor( {
+							styles: {
+								listTypesStyles: {
+									bulleted: [ 'disc', 'circle' ]
+								}
+							}
+						}, editor => {
+							const componentFactory = editor.ui.componentFactory;
+							const bulletedListMenu = componentFactory.create( 'menuBar:bulletedList' );
+
+							bulletedListMenu.render();
+							document.body.appendChild( bulletedListMenu.element );
+
+							// Trigger lazy init
+							bulletedListMenu.isOpen = true;
+							bulletedListMenu.isOpen = false;
+
+							const listPropertiesView = bulletedListMenu.panelView.children.first;
+							const stylesView = listPropertiesView.stylesView;
+
+							expect( stylesView.children.map( b => b.tooltip ) ).to.deep.equal( [ 'Disc', 'Circle' ] );
+
+							bulletedListMenu.element.remove();
+						} );
+					} );
+
+					it( 'should register buttons filtered by listTypesStyles for numbered list in menu bar', () => {
+						return withEditor( {
+							styles: {
+								listTypesStyles: {
+									numbered: [ 'decimal', 'lower-roman' ]
+								}
+							}
+						}, editor => {
+							const componentFactory = editor.ui.componentFactory;
+							const numberedListMenu = componentFactory.create( 'menuBar:numberedList' );
+
+							numberedListMenu.render();
+							document.body.appendChild( numberedListMenu.element );
+
+							// Trigger lazy init
+							numberedListMenu.isOpen = true;
+							numberedListMenu.isOpen = false;
+
+							const listPropertiesView = numberedListMenu.panelView.children.first;
+							const stylesView = listPropertiesView.stylesView;
+
+							expect( stylesView.children.map( b => b.tooltip ) ).to.deep.equal( [ 'Decimal', 'Lower–roman' ] );
+
+							numberedListMenu.element.remove();
+						} );
+					} );
+
+					it( 'should register all buttons when listTypesStyles is undefined in menu bar', () => {
+						return withEditor( {
+							styles: true
+						}, editor => {
+							const componentFactory = editor.ui.componentFactory;
+							const numberedListMenu = componentFactory.create( 'menuBar:numberedList' );
+
+							numberedListMenu.render();
+							document.body.appendChild( numberedListMenu.element );
+
+							// Trigger lazy init
+							numberedListMenu.isOpen = true;
+							numberedListMenu.isOpen = false;
+
+							const listPropertiesView = numberedListMenu.panelView.children.first;
+							const stylesView = listPropertiesView.stylesView;
+
+							expect( stylesView.children.map( b => b.tooltip ) ).to.deep.equal( [
+								'Decimal',
+								'Decimal with leading zero',
+								'Lower–roman',
+								'Upper-roman',
+								'Lower-latin',
+								'Upper-latin'
+							] );
+
+							numberedListMenu.element.remove();
+						} );
+					} );
+
+					it( 'should register no buttons when listTypesStyles has empty array in menu bar', () => {
+						return withEditor( {
+							styles: {
+								listTypesStyles: {
+									numbered: [],
+									bulleted: []
+								}
+							}
+						}, editor => {
+							const componentFactory = editor.ui.componentFactory;
+							const numberedListMenu = componentFactory.create( 'menuBar:numberedList' );
+
+							numberedListMenu.render();
+							document.body.appendChild( numberedListMenu.element );
+
+							// Trigger lazy init
+							numberedListMenu.isOpen = true;
+							numberedListMenu.isOpen = false;
+
+							const listPropertiesView = numberedListMenu.panelView.children.first;
+
+							expect( listPropertiesView.stylesView ).to.be.null;
+
+							numberedListMenu.element.remove();
+						} );
 					} );
 				} );
 			} );

--- a/packages/ckeditor5-list/tests/manual/list-properties.html
+++ b/packages/ckeditor5-list/tests/manual/list-properties.html
@@ -27,3 +27,7 @@
 <h2>No properties enabled</h2>
 
 <div id="editor-h"></div>
+
+<h2>Hidden lower-latin and upper-latin styles</h2>
+
+<div id="editor-i"></div>

--- a/packages/ckeditor5-list/tests/manual/list-properties.js
+++ b/packages/ckeditor5-list/tests/manual/list-properties.js
@@ -222,3 +222,33 @@ ClassicEditor
 	.catch( err => {
 		console.error( err.stack );
 	} );
+
+// ------------------------------------------------------------------
+
+ClassicEditor
+	.create( document.querySelector( '#editor-i' ), {
+		...config,
+		list: {
+			properties: {
+				styles: {
+					listStyleTypes: [
+						'decimal',
+						'decimal-leading-zero',
+						'lower-roman',
+						'upper-roman',
+						// 'lower-latin',
+						// 'upper-latin',
+						'disc',
+						'circle',
+						'square'
+					]
+				}
+			}
+		}
+	} )
+	.then( editor => {
+		CKEditorInspector.attach( { 'No properties enabled': editor } );
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/packages/ckeditor5-list/tests/manual/list-properties.js
+++ b/packages/ckeditor5-list/tests/manual/list-properties.js
@@ -228,6 +228,9 @@ ClassicEditor
 ClassicEditor
 	.create( document.querySelector( '#editor-i' ), {
 		...config,
+		menuBar: {
+			isVisible: true
+		},
 		list: {
 			properties: {
 				styles: {

--- a/packages/ckeditor5-list/tests/manual/list-properties.js
+++ b/packages/ckeditor5-list/tests/manual/list-properties.js
@@ -234,7 +234,7 @@ ClassicEditor
 		list: {
 			properties: {
 				styles: {
-					listTypesStyles: {
+					listStyleTypes: {
 						numbered: [
 							'decimal',
 							'decimal-leading-zero',

--- a/packages/ckeditor5-list/tests/manual/list-properties.js
+++ b/packages/ckeditor5-list/tests/manual/list-properties.js
@@ -231,17 +231,19 @@ ClassicEditor
 		list: {
 			properties: {
 				styles: {
-					listStyleTypes: [
-						'decimal',
-						'decimal-leading-zero',
-						'lower-roman',
-						'upper-roman',
-						// 'lower-latin',
-						// 'upper-latin',
-						'disc',
-						'circle',
-						'square'
-					]
+					listTypesStyles: {
+						numbered: [
+							'decimal',
+							'decimal-leading-zero',
+							'lower-roman',
+							'upper-roman'
+						],
+						bulleted: [
+							'disc',
+							'circle',
+							'square'
+						]
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (list): Allow to specify which list style types are shown in list type selector dropdown. Closes #17176

---

### Additional information

I added `listTypesStyles` to `list` config property, so it's now possible to limit which list types styles are available in lit dropdown.

Example:

```ts
// ... editor config
list: {
  properties: {
    styles: {
      listTypesStyles: {
        numbered: [
          'decimal',
          'decimal-leading-zero',
          'lower-roman',
          'upper-roman'
        ],
        bulleted: [
          'disc',
          'circle',
          'square'
        ]
      }
    }
  }
}
```

Which renders to:

![obraz](https://github.com/user-attachments/assets/02bc625b-3713-4e38-828e-9da4fdbbff9c)

Where this one is default behavior:

![obraz](https://github.com/user-attachments/assets/e94961df-9e91-4539-9b31-07db8a45dc76)
