### PR TITLE
Fixed display of the no results message

### DIFF
--- a/packages/ckeditor5-emoji/lang/translations/en.po
+++ b/packages/ckeditor5-emoji/lang/translations/en.po
@@ -26,3 +26,7 @@ msgstr "Skin tone toolbar"
 msgctxt "Label displayed in the emoji feature search field."
 msgid "Find an emoji (min. 2 characters)"
 msgstr "Find an emoji (min. 2 characters)"
+
+msgctxt "Label displayed in the emoji grid when no emoji matches the search query."
+msgid "Nothing found"
+msgstr "Nothing found"

--- a/packages/ckeditor5-emoji/src/emojipicker.ts
+++ b/packages/ckeditor5-emoji/src/emojipicker.ts
@@ -272,12 +272,10 @@ export default class EmojiPicker extends Plugin {
 	 * Updates the symbol grid depending on the currently selected emoji category.
 	 */
 	private async _updateGrid( { gridView, categoriesView }: DropdownPanelContent ): Promise<void> {
-		// Updating the grid starts with removing all tiles belonging to the old group.
-		gridView.tiles.clear();
-
 		if ( !this._searchQuery || this._searchQuery.length < 2 ) {
 			const emojisForCategory = this._getEmojisForCategory( this._currentCategoryName );
 
+			gridView.tiles.clear();
 			this._addTilesToGrid( gridView, emojisForCategory );
 			categoriesView.enableCategories();
 
@@ -303,6 +301,7 @@ export default class EmojiPicker extends Plugin {
 			return { name, emojis };
 		} );
 
+		gridView.tiles.clear();
 		this._addTilesToGrid( gridView, tilesToAdd.filter( Boolean ) as Array<EmojiItem> );
 		categoriesView.disableCategories();
 	}
@@ -384,6 +383,7 @@ export default class EmojiPicker extends Plugin {
 		}
 
 		this._showFakeVisualSelection();
+		this._emojiPickerView.refreshGridViewContainer();
 	}
 
 	/**

--- a/packages/ckeditor5-emoji/src/ui/emojigridview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojigridview.ts
@@ -61,7 +61,11 @@ export default class EmojiGridView extends View<HTMLDivElement> {
 							'hidden'
 						]
 					},
-					children: [ { text: 'Nothing found.' } ]
+					children: [
+						{
+							text: locale.t( 'Nothing found' )
+						}
+					]
 				}
 			],
 			attributes: {
@@ -129,6 +133,19 @@ export default class EmojiGridView extends View<HTMLDivElement> {
 	}
 
 	/**
+	 * Shows or hides the "nothing found" message depending on whether or not the grid has any tiles.
+	 */
+	public refreshContainer(): void {
+		const nothingFoundDiv = this.element!.querySelector( '.ck.ck-emoji-nothing-found' )!;
+
+		if ( this.tiles.length === 0 ) {
+			nothingFoundDiv.classList.remove( 'hidden' );
+		} else {
+			nothingFoundDiv.classList.add( 'hidden' );
+		}
+	}
+
+	/**
 	 * @inheritDoc
 	 */
 	public override render(): void {
@@ -139,13 +156,7 @@ export default class EmojiGridView extends View<HTMLDivElement> {
 		}
 
 		this.tiles.on( 'change', ( eventInfo, { added, removed } ) => {
-			const nothingFoundDiv = document.querySelector( '.ck.ck-emoji-nothing-found' )!;
-
-			if ( this.tiles.length === 0 ) {
-				nothingFoundDiv.classList.remove( 'hidden' );
-			} else {
-				nothingFoundDiv.classList.add( 'hidden' );
-			}
+			this.refreshContainer();
 
 			if ( added.length > 0 ) {
 				for ( const item of added ) {

--- a/packages/ckeditor5-emoji/src/ui/emojipickerview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojipickerview.ts
@@ -121,6 +121,10 @@ export default class EmojiPickerView extends View<HTMLDivElement> {
 		this.items.add( this.gridView );
 	}
 
+	public refreshGridViewContainer(): void {
+		this.gridView.refreshContainer();
+	}
+
 	/**
 	 * @inheritDoc
 	 */

--- a/packages/ckeditor5-emoji/tests/emojimention.js
+++ b/packages/ckeditor5-emoji/tests/emojimention.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-/* global document, console */
+/* global document, console, setTimeout */
 
 import { ClassicEditor } from '@ckeditor/ckeditor5-editor-classic';
 import { Emoji, EmojiMention, EmojiPicker } from '../src/index.js';
@@ -261,12 +261,40 @@ describe( 'EmojiMention', () => {
 			expect( getModelData( editor.model ) ).to.equal( '<paragraph>Hello world![]</paragraph>' );
 
 			const range = editor.model.document.selection.getFirstRange();
-			editor.commands.execute( 'mention', { range, mention: { id: 'emoji:__SHOW_ALL_EMOJI__:', text: 'flag_poland' } } );
+			editor.commands.execute( 'mention', { range, mention: { id: 'emoji:__SHOW_ALL_EMOJI__:', text: 'see no evil' } } );
 
 			expect( getModelData( editor.model ) ).to.equal( '<paragraph>Hello world![]</paragraph>' );
 
 			const emojiSearchBar = document.querySelector( '.ck-emoji-input input' );
-			expect( emojiSearchBar.value ).to.equal( 'flag_poland' );
+			expect( emojiSearchBar.value ).to.equal( 'see no evil' );
+		} );
+
+		it( 'should have the "Nothing found" message hidden after opening the picker when an emoji is found', async () => {
+			setModelData( editor.model, '<paragraph>Hello world![]</paragraph>' );
+
+			const range = editor.model.document.selection.getFirstRange();
+			editor.commands.execute( 'mention', { range, mention: { id: 'emoji:__SHOW_ALL_EMOJI__:', text: 'see no evil' } } );
+
+			// Wait for the emojis to load.
+			await new Promise( resolve => setTimeout( resolve, 250 ) );
+
+			expect(
+				document.querySelector( '.ck.ck-emoji-nothing-found' ).classList.contains( 'hidden' )
+			).to.equal( true );
+		} );
+
+		it( 'should have the "Nothing found" message shown after opening the picker when no emoji is found', async () => {
+			setModelData( editor.model, '<paragraph>Hello world![]</paragraph>' );
+
+			const range = editor.model.document.selection.getFirstRange();
+			editor.commands.execute( 'mention', { range, mention: { id: 'emoji:__SHOW_ALL_EMOJI__:', text: 'fooooooooooooooooooooooo' } } );
+
+			// Wait for the emojis to load.
+			await new Promise( resolve => setTimeout( resolve, 250 ) );
+
+			expect(
+				document.querySelector( '.ck.ck-emoji-nothing-found' ).classList.contains( 'hidden' )
+			).to.equal( false );
 		} );
 	} );
 
@@ -288,10 +316,10 @@ describe( 'EmojiMention', () => {
 		} );
 
 		it( 'should query single emoji properly properly', () => {
-			return queryEmoji( 'flag_poland' ).then( queryResult => {
+			return queryEmoji( 'see no evil' ).then( queryResult => {
 				expect( queryResult ).to.deep.equal( [
-					{ id: 'emoji:flag_poland:', text: '🇵🇱' },
-					{ id: 'emoji:__SHOW_ALL_EMOJI__:', text: 'flag_poland' }
+					{ id: 'emoji:see-no-evil_monkey:', text: '🙈' },
+					{ id: 'emoji:__SHOW_ALL_EMOJI__:', text: 'see no evil' }
 				] );
 			} );
 		} );
@@ -378,12 +406,12 @@ describe( 'EmojiMention', () => {
 		it( 'should return emojis with the default skin tone when the skin tone is selected but the emoji does not have variants', () => {
 			editor.plugins.get( EmojiPicker )._selectedSkinTone = 5;
 
-			return queryEmoji( 'flag_poland' ).then( queryResult => {
+			return queryEmoji( 'see no evil' ).then( queryResult => {
 				expect( queryResult.length ).to.equal( 2 );
 
 				expect( queryResult[ 0 ] ).to.deep.equal( {
-					id: 'emoji:flag_poland:',
-					text: '🇵🇱'
+					id: 'emoji:see-no-evil_monkey:',
+					text: '🙈'
 				} );
 				expect( queryResult[ 1 ].id ).to.equal( 'emoji:__SHOW_ALL_EMOJI__:' );
 			} );

--- a/packages/ckeditor5-emoji/tests/emojipicker.js
+++ b/packages/ckeditor5-emoji/tests/emojipicker.js
@@ -83,6 +83,14 @@ describe( 'EmojiPicker', () => {
 		expect( emojiGrid.checkVisibility() ).to.equal( true );
 	} );
 
+	it( 'should have the "Nothing found" message hidden after opening the picker by default', async () => {
+		clickEmojiToolbarButton();
+
+		expect(
+			document.querySelector( '.ck.ck-emoji-nothing-found' ).classList.contains( 'hidden' )
+		).to.equal( true );
+	} );
+
 	it( 'should insert an emoji after clicking on it in the picker', async () => {
 		expect( getModelData( editor.model ) ).to.equal( '<paragraph>[]</paragraph>' );
 

--- a/packages/ckeditor5-emoji/tests/ui/emojigridview.js
+++ b/packages/ckeditor5-emoji/tests/ui/emojigridview.js
@@ -12,22 +12,21 @@ import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard.js';
 
 describe( 'EmojiGridView', () => {
-	let view, nothingFoundElement;
+	let view, locale;
 
 	testUtils.createSinonSandbox();
 
 	beforeEach( () => {
-		nothingFoundElement = document.createElement( 'div' );
-		nothingFoundElement.classList.add( 'ck', 'ck-emoji-nothing-found' );
+		locale = {
+			t: str => str
+		};
 
-		document.body.append( nothingFoundElement );
-		view = new EmojiGridView();
+		view = new EmojiGridView( locale );
 		view.render();
 	} );
 
 	afterEach( () => {
 		view.destroy();
-		nothingFoundElement.remove();
 	} );
 
 	describe( 'constructor()', () => {
@@ -54,7 +53,7 @@ describe( 'EmojiGridView', () => {
 			let view;
 
 			beforeEach( () => {
-				view = new EmojiGridView();
+				view = new EmojiGridView( locale );
 
 				createTilesForGrid( view );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: The "No results" message will now display properly when the picker is opened via the mention feature with no search results. Closes #17731.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
