### PR TITLE
Overlapping of lists next to floating tables.

### DIFF
--- a/packages/ckeditor5-list/package.json
+++ b/packages/ckeditor5-list/package.json
@@ -46,6 +46,7 @@
     "@ckeditor/ckeditor5-page-break": "44.1.0",
     "@ckeditor/ckeditor5-paragraph": "44.1.0",
     "@ckeditor/ckeditor5-remove-format": "44.1.0",
+    "@ckeditor/ckeditor5-show-blocks": "44.1.0",
     "@ckeditor/ckeditor5-source-editing": "44.1.0",
     "@ckeditor/ckeditor5-table": "44.1.0",
     "@ckeditor/ckeditor5-theme-lark": "44.1.0",

--- a/packages/ckeditor5-list/tests/manual/list-overlapping.html
+++ b/packages/ckeditor5-list/tests/manual/list-overlapping.html
@@ -1,0 +1,174 @@
+<div id="editor-list-overlapping">
+	<figure class="table" style="float:left;">
+		<table>
+			<tbody>
+				<tr>
+					<td>1</td>
+					<td></td>
+					<td></td>
+					<td></td>
+					<td></td>
+				</tr>
+				<tr>
+					<td></td>
+					<td>2</td>
+					<td></td>
+					<td></td>
+					<td></td>
+				</tr>
+				<tr>
+					<td></td>
+					<td></td>
+					<td>3</td>
+					<td></td>
+					<td></td>
+				</tr>
+				<tr>
+					<td></td>
+					<td></td>
+					<td></td>
+					<td>4</td>
+					<td></td>
+				</tr>
+				<tr>
+					<td></td>
+					<td></td>
+					<td></td>
+					<td></td>
+					<td>5</td>
+				</tr>
+			</tbody>
+		</table>
+	</figure>
+	<ul>
+        <li>Level 1 - Item 1
+            <ul>
+                <li>Level 2 - Item 1.1</li>
+                <li>Level 2 - Item 1.2
+                    <ul>
+                        <li>Level 3 - Item 1.2.1</li>
+                        <li>Level 3 - Item 1.2.2
+                            <ul>
+                                <li>Level 4 - Item 1.2.2.1</li>
+                                <li>Level 4 - Item 1.2.2.2</li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>Level 2 - Item 1.3</li>
+            </ul>
+        </li>
+        <li>Level 1 - Item 2
+            <ul>
+                <li>Level 2 - Item 2.1</li>
+                <li>Level 2 - Item 2.2</li>
+            </ul>
+        </li>
+        <li>Level 1 - Item 3
+            <ul>
+                <li>Level 2 - Item 3.1
+                    <ul>
+                        <li>Level 3 - Item 3.1.1
+                            <ul>
+                                <li>Level 4 - Item 3.1.1.1</li>
+                                <li>Level 4 - Item 3.1.1.2</li>
+                                <li>Level 4 - Item 3.1.1.3</li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>Level 2 - Item 3.2</li>
+            </ul>
+        </li>
+        <li>Level 1 - Item 4</li>
+    </ul>
+</div>
+
+<br>
+<h2>RTL</h2>
+
+<div id="editor-list-overlapping-rtl">
+	<figure class="table" style="float:right;">
+		<table>
+			<tbody>
+				<tr>
+					<td>1</td>
+					<td></td>
+					<td></td>
+					<td></td>
+					<td></td>
+				</tr>
+				<tr>
+					<td></td>
+					<td>2</td>
+					<td></td>
+					<td></td>
+					<td></td>
+				</tr>
+				<tr>
+					<td></td>
+					<td></td>
+					<td>3</td>
+					<td></td>
+					<td></td>
+				</tr>
+				<tr>
+					<td></td>
+					<td></td>
+					<td></td>
+					<td>4</td>
+					<td></td>
+				</tr>
+				<tr>
+					<td></td>
+					<td></td>
+					<td></td>
+					<td></td>
+					<td>5</td>
+				</tr>
+			</tbody>
+		</table>
+	</figure>
+	<ul>
+		<li>Level 1 - Item 1
+			<ul>
+				<li>Level 2 - Item 1.1</li>
+				<li>Level 2 - Item 1.2
+					<ul>
+						<li>Level 3 - Item 1.2.1</li>
+						<li>Level 3 - Item 1.2.2
+							<ul>
+								<li>Level 4 - Item 1.2.2.1</li>
+								<li>Level 4 - Item 1.2.2.2</li>
+							</ul>
+						</li>
+					</ul>
+				</li>
+				<li>Level 2 - Item 1.3</li>
+			</ul>
+		</li>
+		<li>Level 1 - Item 2
+			<ul>
+				<li>Level 2 - Item 2.1</li>
+				<li>Level 2 - Item 2.2</li>
+			</ul>
+		</li>
+		<li>Level 1 - Item 3
+			<ul>
+				<li>Level 2 - Item 3.1
+					<ul>
+						<li>Level 3 - Item 3.1.1
+							<ul>
+								<li>Level 4 - Item 3.1.1.1</li>
+								<li>Level 4 - Item 3.1.1.2</li>
+								<li>Level 4 - Item 3.1.1.3</li>
+							</ul>
+						</li>
+					</ul>
+				</li>
+				<li>Level 2 - Item 3.2</li>
+			</ul>
+		</li>
+		<li>Level 1 - Item 4</li>
+	</ul>
+</div>

--- a/packages/ckeditor5-list/tests/manual/list-overlapping.html
+++ b/packages/ckeditor5-list/tests/manual/list-overlapping.html
@@ -1,5 +1,5 @@
 <div id="editor-list-overlapping">
-	<figure class="table" style="float:left;">
+	<figure class="table table-style-align-left">
 		<table>
 			<tbody>
 				<tr>

--- a/packages/ckeditor5-list/tests/manual/list-overlapping.js
+++ b/packages/ckeditor5-list/tests/manual/list-overlapping.js
@@ -1,0 +1,75 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+/* globals console, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor.js';
+import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials.js';
+import Heading from '@ckeditor/ckeditor5-heading/src/heading.js';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
+import Indent from '@ckeditor/ckeditor5-indent/src/indent.js';
+import Table from '@ckeditor/ckeditor5-table/src/table.js';
+import TableCellProperties from '@ckeditor/ckeditor5-table/src/tablecellproperties.js';
+import TableProperties from '@ckeditor/ckeditor5-table/src/tableproperties.js';
+import TableCaption from '@ckeditor/ckeditor5-table/src/tablecaption.js';
+import TableColumnResize from '@ckeditor/ckeditor5-table/src/tablecolumnresize.js';
+import TableToolbar from '@ckeditor/ckeditor5-table/src/tabletoolbar.js';
+import ShowBlocks from '@ckeditor/ckeditor5-show-blocks/src/showblocks.js';
+import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting.js';
+// import Style from '@ckeditor/ckeditor5-style/src/style.js';
+
+import List from '../../src/list.js';
+import ListProperties from '../../src/listproperties.js';
+
+const config = {
+	plugins: [
+		Essentials, Heading, Paragraph, List, ListProperties, Table, TableCellProperties, TableProperties, TableToolbar,
+		TableCaption, TableColumnResize, SourceEditing, ShowBlocks, Indent
+	],
+	toolbar: [
+		'undo', 'redo',
+		'|',
+		'sourceEditing', 'showBlocks',
+		'|',
+		'heading',
+		'|',
+		'bulletedList', 'numberedList', 'outdent', 'indent',
+		'|',
+		'insertTable'
+	],
+	table: {
+		contentToolbar: [
+			'tableColumn', 'tableRow', 'mergeTableCells', 'tableProperties', 'tableCellProperties', 'toggleTableCaption'
+		]
+	},
+	list: {
+		properties: {
+			styles: true,
+			startIndex: true,
+			reversed: true
+		}
+	}
+};
+
+ClassicEditor
+	.create( document.querySelector( '#editor-list-overlapping' ), config )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );
+
+ClassicEditor
+	.create( document.querySelector( '#editor-list-overlapping-rtl' ), {
+		...config,
+		language: 'ar'
+	} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/packages/ckeditor5-list/tests/manual/list-overlapping.md
+++ b/packages/ckeditor5-list/tests/manual/list-overlapping.md
@@ -1,0 +1,7 @@
+## List overlapping
+
+This test shows the solution of how list can be presented when they are next to element with `float`.
+
+There is one table with `float` and one `list` with randomly nesting levels.
+
+Issues: `Export to PDF` works as expected but `Export to Word` not.

--- a/packages/ckeditor5-list/theme/list.css
+++ b/packages/ckeditor5-list/theme/list.css
@@ -40,7 +40,8 @@
 }
 
 /* When an element (e.g. table) has `style` tag contains `float` `left`/`right` and has a list as a sibling,
-add margin to the end of the element. */
+add margin to the end of the element.
+See https://github.com/ckeditor/ckeditor5/issues/8412 */
 [dir="ltr"] [style*="float:left"]:has( ~ul ),
 [dir="ltr"] [style*="float:left"]:has( ~ol ),
 [dir="rtl"] [style*="float:right"]:has( ~ul ),
@@ -49,7 +50,8 @@ add margin to the end of the element. */
 }
 
 /* Add `overflow: hidden` and `padding-inline-start` to the lists, starting from the second nesting
-only when they are preceded by an element (e.g. table) has `style` tag contains `float` `left`/`right`. */
+only when they are preceded by an element (e.g. table) has `style` tag contains `float` `left`/`right`.
+See https://github.com/ckeditor/ckeditor5/issues/8412 */
 [dir="rtl"] [style*="float:right"] ~ ul ul,
 [dir="rtl"] [style*="float:right"] ~ ul ol,
 [dir="rtl"] [style*="float:right"] ~ ol ol,

--- a/packages/ckeditor5-list/theme/list.css
+++ b/packages/ckeditor5-list/theme/list.css
@@ -38,3 +38,26 @@
 		}
 	}
 }
+
+/* When an element (e.g. table) has `style` tag contains `float` `left`/`right` and has a list as a sibling,
+add margin to the end of the element. */
+[dir="ltr"] [style*="float:left"]:has( ~ul ),
+[dir="ltr"] [style*="float:left"]:has( ~ol ),
+[dir="rtl"] [style*="float:right"]:has( ~ul ),
+[dir="rtl"] [style*="float:right"]:has( ~ol ) {
+	margin-inline-end: 2em;
+}
+
+/* Add `overflow: hidden` and `padding-inline-start` to the lists, starting from the second nesting
+only when they are preceded by an element (e.g. table) has `style` tag contains `float` `left`/`right`. */
+[dir="rtl"] [style*="float:right"] ~ ul ul,
+[dir="rtl"] [style*="float:right"] ~ ul ol,
+[dir="rtl"] [style*="float:right"] ~ ol ol,
+[dir="rtl"] [style*="float:right"] ~ ol ul,
+[dir="ltr"] [style*="float:left"] ~ ul ul,
+[dir="ltr"] [style*="float:left"] ~ ul ol,
+[dir="ltr"] [style*="float:left"] ~ ol ol,
+[dir="ltr"] [style*="float:left"] ~ ol ul {
+	overflow: hidden;
+	padding-inline-start: 2em;
+}

--- a/packages/ckeditor5-list/theme/list.css
+++ b/packages/ckeditor5-list/theme/list.css
@@ -39,27 +39,17 @@
 	}
 }
 
-/* When an element (e.g. table) has `style` tag contains `float` `left`/`right` and has a list as a sibling,
-add margin to the end of the element.
-See https://github.com/ckeditor/ckeditor5/issues/8412 */
-[dir="ltr"] [style*="float:left"]:has( ~ul ),
-[dir="ltr"] [style*="float:left"]:has( ~ol ),
-[dir="rtl"] [style*="float:right"]:has( ~ul ),
-[dir="rtl"] [style*="float:right"]:has( ~ol ) {
-	margin-inline-end: 2em;
-}
-
 /* Add `overflow: hidden` and `padding-inline-start` to the lists, starting from the second nesting
-only when they are preceded by an element (e.g. table) has `style` tag contains `float` `left`/`right`.
+only when they are preceded by an element (e.g. table) has `class` name `table-style-align-right` or `table-style-align-left`.
 See https://github.com/ckeditor/ckeditor5/issues/8412 */
-[dir="rtl"] [style*="float:right"] ~ ul ul,
-[dir="rtl"] [style*="float:right"] ~ ul ol,
-[dir="rtl"] [style*="float:right"] ~ ol ol,
-[dir="rtl"] [style*="float:right"] ~ ol ul,
-[dir="ltr"] [style*="float:left"] ~ ul ul,
-[dir="ltr"] [style*="float:left"] ~ ul ol,
-[dir="ltr"] [style*="float:left"] ~ ol ol,
-[dir="ltr"] [style*="float:left"] ~ ol ul {
+.ck-content .table-style-align-right ~ ul ul,
+.ck-content .table-style-align-right ~ ul ol,
+.ck-content .table-style-align-right ~ ol ol,
+.ck-content .table-style-align-right ~ ol ul,
+.ck-content .table-style-align-left ~ ul ul,
+.ck-content .table-style-align-left ~ ul ol,
+.ck-content .table-style-align-left ~ ol ol,
+.ck-content .table-style-align-left ~ ol ul {
 	overflow: hidden;
 	padding-inline-start: 2em;
 }

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
@@ -28,6 +28,8 @@ import { getNormalizedDefaultTableProperties } from '../utils/table-properties.j
 
 const ALIGN_VALUES_REG_EXP = /^(left|center|right)$/;
 const FLOAT_VALUES_REG_EXP = /^(left|none|right)$/;
+const CSS_ALIGN_CLASSES_REG_EXP = /^(table-style-align-left|table-style-align-right|table-style-align-center)$/;
+const CSS_CLASSNAME_ALIGN_REG_EXP = /table-style-align-(.*)/;
 
 /**
  * The table properties editing feature.
@@ -169,11 +171,10 @@ function enableAlignmentProperty( schema: Schema, conversion: Conversion, defaul
 				key: 'tableAlignment'
 			},
 			view: alignment => ( {
-				key: 'style',
-				value: {
-					// Model: `alignment:center` => CSS: `float:none`.
-					float: alignment === 'center' ? 'none' : alignment
-				}
+				key: 'class',
+				value: [
+					`table-style-align-${ alignment }`
+				]
 			} ),
 			converterPriority: 'high'
 		} );
@@ -215,6 +216,29 @@ function enableAlignmentProperty( schema: Schema, conversion: Conversion, defaul
 					const align = viewElement.getAttribute( 'align' );
 
 					return align === defaultValue ? null : align;
+				}
+			}
+		} )
+		.attributeToAttribute( {
+			view: {
+				name: /^(table|figure)$/,
+				classes: CSS_ALIGN_CLASSES_REG_EXP
+			},
+			model: {
+				key: 'tableAlignment',
+				value: ( viewElement: ViewElement ) => {
+					let align = 'none';
+
+					for ( const className of viewElement.getClassNames() ) {
+						const alignmentMatch = CSS_CLASSNAME_ALIGN_REG_EXP.exec( className );
+
+						if ( alignmentMatch ) {
+							align = alignmentMatch[ 1 ];
+						}
+					}
+
+					// Return the alignment value based on the class names found.
+					return align;
 				}
 			}
 		} );

--- a/packages/ckeditor5-table/tests/_utils/utils.js
+++ b/packages/ckeditor5-table/tests/_utils/utils.js
@@ -219,12 +219,13 @@ export function assertTRBLAttribute( element, key, top, right = top, bottom = to
  * @param {String} [tableStyle=''] A style to assert on <table>.
  * @param {String} [figureStyle=''] A style to assert on <figure>.
  */
-export function assertTableStyle( editor, tableStyle, figureStyle ) {
+export function assertTableStyle( editor, tableStyle, figureStyle, tableCssClass ) {
 	const tableStyleEntry = tableStyle ? ` style="${ tableStyle }"` : '';
 	const figureStyleEntry = figureStyle ? ` style="${ figureStyle }"` : '';
+	const tableClassEntry = tableCssClass ? ` ${ tableCssClass }` : '';
 
 	expect( editor.getData() ).to.equalMarkup(
-		`<figure class="table"${ figureStyleEntry }>` +
+		`<figure class="table${ tableClassEntry }"${ figureStyleEntry }>` +
 			`<table${ tableStyleEntry }>` +
 				'<tbody><tr><td>foo</td></tr></tbody>' +
 			'</table>' +

--- a/packages/ckeditor5-table/tests/plaintableoutput.js
+++ b/packages/ckeditor5-table/tests/plaintableoutput.js
@@ -236,7 +236,7 @@ describe( 'PlainTableOutput', () => {
 				it( 'tableAlignment', () => {
 					model.change( writer => writer.setAttribute( 'tableAlignment', 'right', table ) );
 
-					assertPlainTableStyle( editor, 'float:right;' );
+					assertPlainTableStyle( editor, '', 'table-style-align-right' );
 				} );
 
 				it( 'tableWidth', () => {
@@ -313,7 +313,7 @@ describe( 'PlainTableOutput', () => {
 				it( 'tableAlignment', () => {
 					model.change( writer => writer.setAttribute( 'tableAlignment', 'right', table ) );
 
-					assertPlainTableStyle( editor, 'float:right;' );
+					assertPlainTableStyle( editor, '', 'table-style-align-right' );
 
 					model.change( writer => writer.removeAttribute( 'tableAlignment', table ) );
 
@@ -508,11 +508,12 @@ describe( 'PlainTableOutput', () => {
 				return model.document.getRoot().getNodeByPath( [ 0 ] );
 			}
 
-			function assertPlainTableStyle( editor, tableStyle ) {
+			function assertPlainTableStyle( editor, tableStyle, tableClass ) {
 				const tableStyleEntry = tableStyle ? ` style="${ tableStyle }"` : '';
+				const tableClassEntry = tableClass ? ` class="${ tableClass }"` : '';
 
 				expect( editor.getData() ).to.equalMarkup(
-					`<table${ tableStyleEntry }>` +
+					`<table${ tableClassEntry }${ tableStyleEntry }>` +
 						'<tbody><tr><td>foo</td></tr></tbody>' +
 					'</table>'
 				);

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tablealignmentcommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tablealignmentcommand.js
@@ -131,7 +131,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: 'right' } );
 
-						assertTableStyle( editor, null, 'float:right;' );
+						assertTableStyle( editor, null, '', 'table-style-align-right' );
 					} );
 
 					it( 'should change selected table alignment to a passed value', () => {
@@ -139,7 +139,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: 'right' } );
 
-						assertTableStyle( editor, null, 'float:right;' );
+						assertTableStyle( editor, null, '', 'table-style-align-right' );
 					} );
 
 					it( 'should remove alignment from a selected table if no value is passed', () => {
@@ -165,7 +165,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: 'right' } );
 
-						assertTableStyle( editor, null, 'float:right;' );
+						assertTableStyle( editor, null, '', 'table-style-align-right' );
 					} );
 
 					it( 'should change selected table alignment to a passed value', () => {
@@ -173,7 +173,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: 'right' } );
 
-						assertTableStyle( editor, null, 'float:right;' );
+						assertTableStyle( editor, null, '', 'table-style-align-right' );
 					} );
 
 					it( 'should remove alignment from a selected table if no value is passed', () => {
@@ -199,7 +199,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: 'right' } );
 
-						assertTableStyle( editor, null, 'float:right;' );
+						assertTableStyle( editor, null, '', 'table-style-align-right' );
 					} );
 
 					it( 'should change selected table alignment to a passed value', () => {
@@ -207,7 +207,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: 'right' } );
 
-						assertTableStyle( editor, null, 'float:right;' );
+						assertTableStyle( editor, null, '', 'table-style-align-right' );
 					} );
 
 					it( 'should remove alignment from a selected table if no value is passed', () => {

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting-integration.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting-integration.js
@@ -39,7 +39,7 @@ describe( 'table properties', () => {
 			it( 'should properly downcast table with Alignment plugin enabled', () => {
 				model.change( writer => writer.setAttribute( 'tableAlignment', 'right', table ) );
 
-				assertTableStyle( editor, null, 'float:right;' );
+				assertTableStyle( editor, null, '', 'table-style-align-right' );
 			} );
 
 			it( 'Alignment command should be disabled when table is selected', () => {

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -1238,45 +1238,45 @@ describe( 'table properties', () => {
 				it( 'should downcast "right" tableAlignment', () => {
 					model.change( writer => writer.setAttribute( 'tableAlignment', 'right', table ) );
 
-					assertTableStyle( editor, null, 'float:right;' );
+					assertTableStyle( editor, null, '', 'table-style-align-right' );
 				} );
 
 				it( 'should downcast "left" tableAlignment', () => {
 					model.change( writer => writer.setAttribute( 'tableAlignment', 'left', table ) );
 
-					assertTableStyle( editor, null, 'float:left;' );
+					assertTableStyle( editor, null, '', 'table-style-align-left' );
 				} );
 
 				it( 'should downcast "center" tableAlignment', () => {
 					model.change( writer => writer.setAttribute( 'tableAlignment', 'center', table ) );
 
-					assertTableStyle( editor, null, 'float:none;' );
+					assertTableStyle( editor, null, '', 'table-style-align-center' );
 				} );
 
 				it( 'should downcast changed tableAlignment (left -> right)', () => {
 					model.change( writer => writer.setAttribute( 'tableAlignment', 'left', table ) );
 
-					assertTableStyle( editor, null, 'float:left;' );
+					assertTableStyle( editor, null, '', 'table-style-align-left' );
 
 					model.change( writer => writer.setAttribute( 'tableAlignment', 'right', table ) );
 
-					assertTableStyle( editor, null, 'float:right;' );
+					assertTableStyle( editor, null, '', 'table-style-align-right' );
 				} );
 
 				it( 'should downcast changed tableAlignment (right -> left)', () => {
 					model.change( writer => writer.setAttribute( 'tableAlignment', 'right', table ) );
 
-					assertTableStyle( editor, null, 'float:right;' );
+					assertTableStyle( editor, null, '', 'table-style-align-right' );
 
 					model.change( writer => writer.setAttribute( 'tableAlignment', 'left', table ) );
 
-					assertTableStyle( editor, null, 'float:left;' );
+					assertTableStyle( editor, null, '', 'table-style-align-left' );
 				} );
 
 				it( 'should downcast removed tableAlignment (from left)', () => {
 					model.change( writer => writer.setAttribute( 'tableAlignment', 'left', table ) );
 
-					assertTableStyle( editor, null, 'float:left;' );
+					assertTableStyle( editor, null, '', 'table-style-align-left' );
 
 					model.change( writer => writer.removeAttribute( 'tableAlignment', table ) );
 
@@ -1286,7 +1286,7 @@ describe( 'table properties', () => {
 				it( 'should downcast removed tableAlignment (from right)', () => {
 					model.change( writer => writer.setAttribute( 'tableAlignment', 'right', table ) );
 
-					assertTableStyle( editor, null, 'float:right;' );
+					assertTableStyle( editor, null, '', 'table-style-align-right' );
 
 					model.change( writer => writer.removeAttribute( 'tableAlignment', table ) );
 

--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -3,6 +3,23 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
+/* Styles for plain table output */
+.ck-content table {
+	&.table-style-align-left {
+		float: left;
+		margin-inline-end: 2em;
+	}
+
+	&.table-style-align-right {
+		float: right;
+		margin-inline-end: 2em;
+	}
+
+	&.table-style-align-center {
+		float: none;
+	}
+}
+
 .ck-content .table {
 	/* Give the table widget some air and center it horizontally */
 	/* The first value should be equal to --ck-spacing-large variable if used in the editor context
@@ -39,6 +56,20 @@
 			font-weight: bold;
 			background: hsla(0, 0%, 0%, 5%);
 		}
+	}
+
+	&.table-style-align-left {
+		float: left;
+		margin-inline-end: 2em;
+	}
+
+	&.table-style-align-right {
+		float: right;
+		margin-inline-end: 2em;
+	}
+
+	&.table-style-align-center {
+		float: none;
 	}
 }
 

--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -4,72 +4,74 @@
  */
 
 /* Styles for plain table output */
-.ck-content table {
-	&.table-style-align-left {
-		float: left;
-		margin-inline-end: 2em;
-	}
-
-	&.table-style-align-right {
-		float: right;
-		margin-inline-end: 2em;
-	}
-
-	&.table-style-align-center {
-		float: none;
-	}
-}
-
-.ck-content .table {
-	/* Give the table widget some air and center it horizontally */
-	/* The first value should be equal to --ck-spacing-large variable if used in the editor context
-	to avoid the content jumping (See https://github.com/ckeditor/ckeditor5/issues/9825). */
-	margin: 0.9em auto;
-	display: table;
-
+.ck-content {
 	& table {
-		/* The table cells should have slight borders */
-		border-collapse: collapse;
-		border-spacing: 0;
-
-		/* Table width and height are set on the parent <figure>. Make sure the table inside stretches
-		to the full dimensions of the container (https://github.com/ckeditor/ckeditor5/issues/6186). */
-		width: 100%;
-		height: 100%;
-
-		/* The outer border of the table should be slightly darker than the inner lines.
-		Also see https://github.com/ckeditor/ckeditor5-table/issues/50. */
-		border: 1px double hsl(0, 0%, 70%);
-
-		& td,
-		& th {
-			min-width: 2em;
-			padding: .4em;
-
-			/* The border is inherited from .ck-editor__nested-editable styles, so theoretically it's not necessary here.
-			However, the border is a content style, so it should use .ck-content (so it works outside the editor).
-			Hence, the duplication. See https://github.com/ckeditor/ckeditor5/issues/6314 */
-			border: 1px solid hsl(0, 0%, 75%);
+		&.table-style-align-left {
+			float: left;
+			margin-inline-end: 2em;
 		}
 
-		& th {
-			font-weight: bold;
-			background: hsla(0, 0%, 0%, 5%);
+		&.table-style-align-right {
+			float: right;
+			margin-inline-end: 2em;
+		}
+
+		&.table-style-align-center {
+			float: none;
 		}
 	}
 
-	&.table-style-align-left {
-		float: left;
-		margin-inline-end: 2em;
-	}
+	& .table {
+		/* Give the table widget some air and center it horizontally */
+		/* The first value should be equal to --ck-spacing-large variable if used in the editor context
+		to avoid the content jumping (See https://github.com/ckeditor/ckeditor5/issues/9825). */
+		margin: 0.9em auto;
+		display: table;
 
-	&.table-style-align-right {
-		float: right;
-		margin-inline-end: 2em;
-	}
+		& table {
+			/* The table cells should have slight borders */
+			border-collapse: collapse;
+			border-spacing: 0;
 
-	&.table-style-align-center {
-		float: none;
+			/* Table width and height are set on the parent <figure>. Make sure the table inside stretches
+			to the full dimensions of the container (https://github.com/ckeditor/ckeditor5/issues/6186). */
+			width: 100%;
+			height: 100%;
+
+			/* The outer border of the table should be slightly darker than the inner lines.
+			Also see https://github.com/ckeditor/ckeditor5-table/issues/50. */
+			border: 1px double hsl(0, 0%, 70%);
+
+			& td,
+			& th {
+				min-width: 2em;
+				padding: .4em;
+
+				/* The border is inherited from .ck-editor__nested-editable styles, so theoretically it's not necessary here.
+				However, the border is a content style, so it should use .ck-content (so it works outside the editor).
+				Hence, the duplication. See https://github.com/ckeditor/ckeditor5/issues/6314 */
+				border: 1px solid hsl(0, 0%, 75%);
+			}
+
+			& th {
+				font-weight: bold;
+				background: hsla(0, 0%, 0%, 5%);
+			}
+		}
+
+		&.table-style-align-left {
+			float: left;
+			margin-inline-end: 2em;
+		}
+
+		&.table-style-align-right {
+			float: right;
+			margin-inline-end: 2em;
+		}
+
+		&.table-style-align-center {
+			float: none;
+		}
 	}
 }
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Type: Message. Closes #8412.

---

### Additional information

This is not 100% super solid solution but some kind of a workaround for this problem. 

Description:

In `Tables` the change were made from inline styles that were responsible for floating to CSS classes. That helped to add `margin-inline-end` with value of `2em` to preserve the space when lists were next to the floating table. Also by this class there is a chance to set on the lists `overflow: hidden` and `padding-inline-start` (starting from the second nesting ONLY) when they are preceded by an element with CSS class mention earlier.

The only potential risk is the `overflow: hidden`, but regular user wont' be able to break anything - without specific CSS that could manipulate the content (like `position: absolute` and manipulating the `top`, `left`, `right` or `bottom`).  

---

Before:
<img width="622" alt="Screenshot 2025-01-10 at 14 58 48" src="https://github.com/user-attachments/assets/ac27c7f8-d8b6-4df1-890b-8aea6dd65a5b" />

After:
<img width="647" alt="Screenshot 2025-01-10 at 14 57 33" src="https://github.com/user-attachments/assets/3bbab28c-48c1-466b-8a9b-d8553390f94a" />


---

⚠️ It's not working with `Export to Word`.