### PR TITLE
Add and use the `registerIcon` and `useIcon` utils

### DIFF
--- a/docs/examples/custom/bottom-toolbar-editor.md
+++ b/docs/examples/custom/bottom-toolbar-editor.md
@@ -59,10 +59,12 @@ import {
 	DropdownButtonView,
 	DropdownPanelView,
 	DropdownView,
-	ToolbarView
+	ToolbarView,
+	IconFontColor
 } from 'ckeditor5';
 import { EasyImage } from 'ckeditor5-premium-features';
-import fontColorIcon from '@ckeditor/ckeditor5-font/theme/icons/font-color.svg';
+
+const fontColorIcon =/* #__PURE__ */ registerIcon( 'fontColor', IconFontColor );
 
 class FormattingOptions extends Plugin {
 	/**
@@ -143,7 +145,7 @@ class FormattingOptions extends Plugin {
 			// Using the font color icon to visually represent the formatting.
 			buttonView.set( {
 				tooltip: t( 'Formatting options' ),
-				icon: fontColorIcon
+				icon: fontColorIcon()
 			} );
 
 			dropdownView.panelView.children.add( toolbarView );

--- a/docs/framework/contributing/code-style.md
+++ b/docs/framework/contributing/code-style.md
@@ -1086,7 +1086,7 @@ This rule ensures that all imports from the `@ckeditor/*` packages are done thro
 import Table from '@ckeditor/ckeditor5-table/src/table';
 
 // Importing from the `/theme/` folder is not allowed.
-import BoldIcon from '@ckeditor/ckeditor5-core/theme/icons/bold.svg';
+import BoldIcon from '@ckeditor/ckeditor5-icons/theme/icons/bold.svg';
 ```
 
 👍&nbsp; Examples of correct code for this rule:

--- a/docs/getting-started/advanced/integrating-from-source-webpack.md
+++ b/docs/getting-started/advanced/integrating-from-source-webpack.md
@@ -93,7 +93,7 @@ module.exports = {
 	module: {
 		rules: [
 			{
-				test: /ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/,
+				test: /ckeditor5-icons\/theme\/icons\/[^/\\]+\.svg$/,
 				use: [ 'raw-loader' ]
 			},
 			{
@@ -170,7 +170,7 @@ module.exports = {
 				use: [ 'ts-loader' ]
 			},
 			{
-				test: /ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/,
+				test: /cckeditor5-icons\/theme\/icons\/[^/\\]+\.svg$/,
 
 				use: [ 'raw-loader' ]
 			},
@@ -225,7 +225,7 @@ Encore.
 
 	// Use raw-loader for CKEditor 5 SVG files.
 	.addRule( {
-		test: /ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/,
+		test: /cckeditor5-icons\/theme\/icons\/[^/\\]+\.svg$/,
 		loader: 'raw-loader'
 	} )
 
@@ -586,7 +586,7 @@ module.exports = {
 	module: {
 		rules: [
 			{
-				test: /ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/,
+				test: /cckeditor5-icons\/theme\/icons\/[^/\\]+\.svg$/,
 				use: [ 'raw-loader' ]
 			},
 			{

--- a/docs/getting-started/legacy-getting-started/integrations/react.md
+++ b/docs/getting-started/legacy-getting-started/integrations/react.md
@@ -450,7 +450,7 @@ Then, add two new elements to the exported object under the `module.rules` array
 
 ```js
 {
-	test: /ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/,
+	test: /ckeditor5-icons\/theme\/icons\/[^/\\]+\.svg$/,
 	use: [ 'raw-loader' ]
 },
 {

--- a/docs/getting-started/legacy-getting-started/quick-start-other.md
+++ b/docs/getting-started/legacy-getting-started/quick-start-other.md
@@ -240,7 +240,7 @@ module.exports = {
 	module: {
 		rules: [
 			{
-				test: /ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/,
+				test: /ckeditor5-icons\/theme\/icons\/[^/\\]+\.svg$/,
 
 				use: [ 'raw-loader' ]
 			},

--- a/docs/tutorials/supporting-multiple-versions.md
+++ b/docs/tutorials/supporting-multiple-versions.md
@@ -74,7 +74,7 @@ If you want to support legacy versions of CKEditor&nbsp;5, you cannot import fro
 	 import Table from '@ckeditor/ckeditor5-table/src/table';
 
 	 // ❌
-	 import TableRowIcon from '@ckeditor/ckeditor5-table/theme/icons/table-row.svg';
+	 import TableRowIcon from '@ckeditor/ckeditor5-icons/theme/icons/table-row.svg';
 	 ```
 
 During the build process, these imports will be used as-is when generating the bundles for the legacy versions of CKEditor&nbsp;5, but will be replaced with `ckeditor5` and `ckeditor5-premium-features` in the bundles for the latest version.

--- a/docs/updating/nim-migration/migration-to-new-installation-methods.md
+++ b/docs/updating/nim-migration/migration-to-new-installation-methods.md
@@ -39,7 +39,7 @@ module.exports = {
 	module: {
 		rules: [
 			{
-				test: /ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/,
+				test: /ckeditor5-icons\/theme\/icons\/[^/\\]+\.svg$/,
 				use: [ 'raw-loader' ]
 			},
 			{

--- a/packages/ckeditor5-alignment/src/alignmentui.ts
+++ b/packages/ckeditor5-alignment/src/alignmentui.ts
@@ -7,7 +7,7 @@
  * @module alignment/alignmentui
  */
 
-import { Plugin, type Editor } from 'ckeditor5/src/core.js';
+import { Plugin } from 'ckeditor5/src/core.js';
 import {
 	type Button,
 	ButtonView,
@@ -30,6 +30,21 @@ const alignRightIcon = /* #__PURE__ */ registerIcon( 'alignRight', IconAlignRigh
 const alignCenterIcon = /* #__PURE__ */ registerIcon( 'alignCenter', IconAlignCenter );
 const alignJustifyIcon = /* #__PURE__ */ registerIcon( 'alignJustify', IconAlignJustify );
 
+const iconsMap: Record<string, string> = {
+	get left() {
+		return alignLeftIcon();
+	},
+	get right() {
+		return alignRightIcon();
+	},
+	get center() {
+		return alignCenterIcon();
+	},
+	get justify() {
+		return alignJustifyIcon();
+	}
+};
+
 /**
  * The default alignment UI plugin.
  *
@@ -37,19 +52,6 @@ const alignJustifyIcon = /* #__PURE__ */ registerIcon( 'alignJustify', IconAlign
  * and the `'alignment'` dropdown.
  */
 export default class AlignmentUI extends Plugin {
-	private icons: Map<string, string>;
-
-	constructor( editor: Editor ) {
-		super( editor );
-
-		this.icons = new Map( [
-			[ 'left', alignLeftIcon() ],
-			[ 'right', alignRightIcon() ],
-			[ 'center', alignCenterIcon() ],
-			[ 'justify', alignJustifyIcon() ]
-		] );
-	}
-
 	/**
 	 * Returns the localized option titles provided by the plugin.
 	 *
@@ -133,7 +135,7 @@ export default class AlignmentUI extends Plugin {
 
 		buttonView.set( {
 			label: this.localizedOptionTitles[ option ],
-			icon: this.icons.get( option ),
+			icon: iconsMap[ option ],
 			tooltip: true,
 			isToggleable: true,
 			...buttonAttrs
@@ -190,11 +192,11 @@ export default class AlignmentUI extends Plugin {
 			} );
 
 			// The default icon depends on the direction of the content.
-			const defaultIcon = locale.contentLanguageDirection === 'rtl' ? this.icons.get( 'right' ) : this.icons.get( 'left' );
+			const defaultIcon = locale.contentLanguageDirection === 'rtl' ? iconsMap.right : iconsMap.left;
 			const command: AlignmentCommand = editor.commands.get( 'alignment' )!;
 
 			// Change icon to reflect current selection's alignment.
-			dropdownView.buttonView.bind( 'icon' ).to( command, 'value', value => this.icons.get( value ) || defaultIcon );
+			dropdownView.buttonView.bind( 'icon' ).to( command, 'value', value => iconsMap[ value ] || defaultIcon );
 
 			// Enable button if any of the buttons is enabled.
 			dropdownView.bind( 'isEnabled' ).to( command, 'isEnabled' );
@@ -241,7 +243,7 @@ export default class AlignmentUI extends Plugin {
 				buttonView.delegate( 'execute' ).to( menuView );
 				buttonView.set( {
 					label: this.localizedOptionTitles[ option.name ],
-					icon: this.icons.get( option.name ),
+					icon: iconsMap[ option.name ],
 					role: 'menuitemcheckbox',
 					isToggleable: true
 				} );

--- a/packages/ckeditor5-alignment/src/alignmentui.ts
+++ b/packages/ckeditor5-alignment/src/alignmentui.ts
@@ -7,7 +7,7 @@
  * @module alignment/alignmentui
  */
 
-import { Plugin } from 'ckeditor5/src/core.js';
+import { Plugin, type Editor } from 'ckeditor5/src/core.js';
 import {
 	type Button,
 	ButtonView,
@@ -19,18 +19,16 @@ import {
 	MenuBarMenuListView
 } from 'ckeditor5/src/ui.js';
 import { IconAlignCenter, IconAlignJustify, IconAlignLeft, IconAlignRight } from 'ckeditor5/src/icons.js';
-import type { Locale } from 'ckeditor5/src/utils.js';
+import { registerIcon, type Locale } from 'ckeditor5/src/utils.js';
 
 import { isSupported, normalizeAlignmentOptions } from './utils.js';
 import type { AlignmentFormat, SupportedOption } from './alignmentconfig.js';
 import type AlignmentCommand from './alignmentcommand.js';
 
-const iconsMap = /* #__PURE__ */ ( () => new Map( [
-	[ 'left', IconAlignLeft ],
-	[ 'right', IconAlignRight ],
-	[ 'center', IconAlignCenter ],
-	[ 'justify', IconAlignJustify ]
-] ) )();
+const alignLeftIcon =/* #__PURE__ */ registerIcon( 'alignLeft', IconAlignLeft );
+const alignRightIcon = /* #__PURE__ */ registerIcon( 'alignRight', IconAlignRight );
+const alignCenterIcon = /* #__PURE__ */ registerIcon( 'alignCenter', IconAlignCenter );
+const alignJustifyIcon = /* #__PURE__ */ registerIcon( 'alignJustify', IconAlignJustify );
 
 /**
  * The default alignment UI plugin.
@@ -39,6 +37,19 @@ const iconsMap = /* #__PURE__ */ ( () => new Map( [
  * and the `'alignment'` dropdown.
  */
 export default class AlignmentUI extends Plugin {
+	private icons: Map<string, string>;
+
+	constructor( editor: Editor ) {
+		super( editor );
+
+		this.icons = new Map( [
+			[ 'left', alignLeftIcon() ],
+			[ 'right', alignRightIcon() ],
+			[ 'center', alignCenterIcon() ],
+			[ 'justify', alignJustifyIcon() ]
+		] );
+	}
+
 	/**
 	 * Returns the localized option titles provided by the plugin.
 	 *
@@ -122,7 +133,7 @@ export default class AlignmentUI extends Plugin {
 
 		buttonView.set( {
 			label: this.localizedOptionTitles[ option ],
-			icon: iconsMap.get( option ),
+			icon: this.icons.get( option ),
 			tooltip: true,
 			isToggleable: true,
 			...buttonAttrs
@@ -179,11 +190,11 @@ export default class AlignmentUI extends Plugin {
 			} );
 
 			// The default icon depends on the direction of the content.
-			const defaultIcon = locale.contentLanguageDirection === 'rtl' ? iconsMap.get( 'right' ) : iconsMap.get( 'left' );
+			const defaultIcon = locale.contentLanguageDirection === 'rtl' ? this.icons.get( 'right' ) : this.icons.get( 'left' );
 			const command: AlignmentCommand = editor.commands.get( 'alignment' )!;
 
 			// Change icon to reflect current selection's alignment.
-			dropdownView.buttonView.bind( 'icon' ).to( command, 'value', value => iconsMap.get( value ) || defaultIcon );
+			dropdownView.buttonView.bind( 'icon' ).to( command, 'value', value => this.icons.get( value ) || defaultIcon );
 
 			// Enable button if any of the buttons is enabled.
 			dropdownView.bind( 'isEnabled' ).to( command, 'isEnabled' );
@@ -230,7 +241,7 @@ export default class AlignmentUI extends Plugin {
 				buttonView.delegate( 'execute' ).to( menuView );
 				buttonView.set( {
 					label: this.localizedOptionTitles[ option.name ],
-					icon: iconsMap.get( option.name ),
+					icon: this.icons.get( option.name ),
 					role: 'menuitemcheckbox',
 					isToggleable: true
 				} );

--- a/packages/ckeditor5-basic-styles/package.json
+++ b/packages/ckeditor5-basic-styles/package.json
@@ -17,6 +17,7 @@
     "@ckeditor/ckeditor5-icons": "0.0.1",
     "@ckeditor/ckeditor5-typing": "44.1.0",
     "@ckeditor/ckeditor5-ui": "44.1.0",
+    "@ckeditor/ckeditor5-utils": "44.1.0",
     "ckeditor5": "44.1.0"
   },
   "devDependencies": {
@@ -26,7 +27,6 @@
     "@ckeditor/ckeditor5-essentials": "44.1.0",
     "@ckeditor/ckeditor5-paragraph": "44.1.0",
     "@ckeditor/ckeditor5-theme-lark": "44.1.0",
-    "@ckeditor/ckeditor5-utils": "44.1.0",
     "typescript": "5.0.4",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4"

--- a/packages/ckeditor5-basic-styles/src/bold/boldui.ts
+++ b/packages/ckeditor5-basic-styles/src/bold/boldui.ts
@@ -9,10 +9,11 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import { IconBold } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 import { getButtonCreator } from '../utils.js';
 
-const BOLD = 'bold';
+const boldIcon = /* #__PURE__ */ registerIcon( 'bold', IconBold );
 
 /**
  * The bold UI feature. It introduces the Bold button.
@@ -36,13 +37,14 @@ export default class BoldUI extends Plugin {
 	 * @inheritDoc
 	 */
 	public init(): void {
+		const BOLD = 'bold';
 		const editor = this.editor;
 		const t = editor.locale.t;
 		const createButton = getButtonCreator( {
 			editor,
 			commandName: BOLD,
 			plugin: this,
-			icon: IconBold,
+			icon: boldIcon(),
 			label: t( 'Bold' ),
 			keystroke: 'CTRL+B'
 		} );

--- a/packages/ckeditor5-basic-styles/src/code/codeui.ts
+++ b/packages/ckeditor5-basic-styles/src/code/codeui.ts
@@ -9,12 +9,13 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import { IconCode } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 import { getButtonCreator } from '../utils.js';
 
 import '../../theme/code.css';
 
-const CODE = 'code';
+const codeIcon = /* #__PURE__ */ registerIcon( 'code', IconCode );
 
 /**
  * The code UI feature. It introduces the Code button.
@@ -38,13 +39,14 @@ export default class CodeUI extends Plugin {
 	 * @inheritDoc
 	 */
 	public init(): void {
+		const CODE = 'code';
 		const editor = this.editor;
 		const t = editor.locale.t;
 		const createButton = getButtonCreator( {
 			editor,
 			commandName: CODE,
 			plugin: this,
-			icon: IconCode,
+			icon: codeIcon(),
 			label: t( 'Code' )
 		} );
 

--- a/packages/ckeditor5-basic-styles/src/italic/italicui.ts
+++ b/packages/ckeditor5-basic-styles/src/italic/italicui.ts
@@ -9,10 +9,11 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import { IconItalic } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { MenuBarMenuListItemButtonView, ButtonView } from 'ckeditor5/src/ui.js';
 import { getButtonCreator } from '../utils.js';
 
-const ITALIC = 'italic';
+const italicIcon = /* #__PURE__ */ registerIcon( 'utalic', IconItalic );
 
 /**
  * The italic UI feature. It introduces the Italic button.
@@ -36,13 +37,14 @@ export default class ItalicUI extends Plugin {
 	 * @inheritDoc
 	 */
 	public init(): void {
+		const ITALIC = 'italic';
 		const editor = this.editor;
 		const t = editor.locale.t;
 		const createButton = getButtonCreator( {
 			editor,
 			commandName: ITALIC,
 			plugin: this,
-			icon: IconItalic,
+			icon: italicIcon(),
 			keystroke: 'CTRL+I',
 			label: t( 'Italic' )
 		} );

--- a/packages/ckeditor5-basic-styles/src/strikethrough/strikethroughui.ts
+++ b/packages/ckeditor5-basic-styles/src/strikethrough/strikethroughui.ts
@@ -9,10 +9,11 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import { IconStrikethrough } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 import { getButtonCreator } from '../utils.js';
 
-const STRIKETHROUGH = 'strikethrough';
+const strikethroughIcon = /* #__PURE__ */ registerIcon( 'strikethrough', IconStrikethrough );
 
 /**
  * The strikethrough UI feature. It introduces the Strikethrough button.
@@ -36,13 +37,14 @@ export default class StrikethroughUI extends Plugin {
 	 * @inheritDoc
 	 */
 	public init(): void {
+		const STRIKETHROUGH = 'strikethrough';
 		const editor = this.editor;
 		const t = editor.locale.t;
 		const createButton = getButtonCreator( {
 			editor,
 			commandName: STRIKETHROUGH,
 			plugin: this,
-			icon: IconStrikethrough,
+			icon: strikethroughIcon(),
 			keystroke: 'CTRL+SHIFT+X',
 			label: t( 'Strikethrough' )
 		} );

--- a/packages/ckeditor5-basic-styles/src/subscript/subscriptui.ts
+++ b/packages/ckeditor5-basic-styles/src/subscript/subscriptui.ts
@@ -9,10 +9,11 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import { IconSubscript } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 import { getButtonCreator } from '../utils.js';
 
-const SUBSCRIPT = 'subscript';
+const subscriptIcon = /* #__PURE__ */ registerIcon( 'subscript', IconSubscript );
 
 /**
  * The subscript UI feature. It introduces the Subscript button.
@@ -36,6 +37,7 @@ export default class SubscriptUI extends Plugin {
 	 * @inheritDoc
 	 */
 	public init(): void {
+		const SUBSCRIPT = 'subscript';
 		const editor = this.editor;
 		const t = editor.locale.t;
 
@@ -43,7 +45,7 @@ export default class SubscriptUI extends Plugin {
 			editor,
 			commandName: SUBSCRIPT,
 			plugin: this,
-			icon: IconSubscript,
+			icon: subscriptIcon(),
 			label: t( 'Subscript' )
 		} );
 

--- a/packages/ckeditor5-basic-styles/src/superscript/superscriptui.ts
+++ b/packages/ckeditor5-basic-styles/src/superscript/superscriptui.ts
@@ -9,10 +9,11 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import { IconSuperscript } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 import { getButtonCreator } from '../utils.js';
 
-const SUPERSCRIPT = 'superscript';
+const superscriptIcon = /* #__PURE__ */ registerIcon( 'superscript', IconSuperscript );
 
 /**
  * The superscript UI feature. It introduces the Superscript button.
@@ -36,13 +37,14 @@ export default class SuperscriptUI extends Plugin {
 	 * @inheritDoc
 	 */
 	public init(): void {
+		const SUPERSCRIPT = 'superscript';
 		const editor = this.editor;
 		const t = editor.locale.t;
 		const createButton = getButtonCreator( {
 			editor,
 			commandName: SUPERSCRIPT,
 			plugin: this,
-			icon: IconSuperscript,
+			icon: superscriptIcon(),
 			label: t( 'Superscript' )
 		} );
 

--- a/packages/ckeditor5-basic-styles/src/underline/underlineui.ts
+++ b/packages/ckeditor5-basic-styles/src/underline/underlineui.ts
@@ -9,10 +9,11 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import { IconUnderline } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 import { getButtonCreator } from '../utils.js';
 
-const UNDERLINE = 'underline';
+const underlineIcon = /* #__PURE__ */ registerIcon( 'underline', IconUnderline );
 
 /**
  * The underline UI feature. It introduces the Underline button.
@@ -36,13 +37,14 @@ export default class UnderlineUI extends Plugin {
 	 * @inheritDoc
 	 */
 	public init(): void {
+		const UNDERLINE = 'underline';
 		const editor = this.editor;
 		const t = editor.locale.t;
 		const createButton = getButtonCreator( {
 			editor,
 			commandName: UNDERLINE,
 			plugin: this,
-			icon: IconUnderline,
+			icon: underlineIcon(),
 			label: t( 'Underline' ),
 			keystroke: 'CTRL+U'
 		} );

--- a/packages/ckeditor5-block-quote/src/blockquoteui.ts
+++ b/packages/ckeditor5-block-quote/src/blockquoteui.ts
@@ -9,9 +9,12 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import { IconQuote } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 
 import '../theme/blockquote.css';
+
+const quoteIcon = /* #__PURE__ */ registerIcon( 'quote', IconQuote );
 
 /**
  * The block quote UI plugin.
@@ -74,7 +77,7 @@ export default class BlockQuoteUI extends Plugin {
 
 		view.set( {
 			label: t( 'Block quote' ),
-			icon: IconQuote,
+			icon: quoteIcon(),
 			isToggleable: true
 		} );
 

--- a/packages/ckeditor5-bookmark/src/bookmarkediting.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkediting.ts
@@ -11,8 +11,7 @@ import { type Editor, Plugin } from 'ckeditor5/src/core.js';
 import { toWidget } from 'ckeditor5/src/widget.js';
 import { IconView } from 'ckeditor5/src/ui.js';
 import { IconBookmarkInline } from 'ckeditor5/src/icons.js';
-import type { EventInfo } from 'ckeditor5/src/utils.js';
-
+import { registerIcon, type EventInfo } from 'ckeditor5/src/utils.js';
 import type {
 	ViewUIElement,
 	DowncastWriter,
@@ -23,11 +22,12 @@ import type {
 	UpcastConversionData,
 	UpcastConversionApi
 } from 'ckeditor5/src/engine.js';
-
 import InsertBookmarkCommand from './insertbookmarkcommand.js';
 import UpdateBookmarkCommand from './updatebookmarkcommand.js';
 
 import '../theme/bookmark.css';
+
+const bookmarkInlineIcon = /* #__PURE__ */ registerIcon( 'bookmarkInline', IconBookmarkInline );
 
 /**
  * The bookmark editing plugin.
@@ -161,7 +161,7 @@ export default class BookmarkEditing extends Plugin {
 			const icon = new IconView();
 
 			icon.set( {
-				content: IconBookmarkInline,
+				content: bookmarkInlineIcon(),
 				isColorInherited: false
 			} );
 

--- a/packages/ckeditor5-bookmark/src/bookmarkui.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkui.ts
@@ -17,14 +17,13 @@ import {
 	type ViewWithCssTransitionDisabler
 } from 'ckeditor5/src/ui.js';
 import { IconBookmark } from 'ckeditor5/src/icons.js';
+import { registerIcon, type PositionOptions } from 'ckeditor5/src/utils.js';
 import {
 	ClickObserver,
 	type ViewDocumentClickEvent,
 	type Element,
 	type ViewElement
 } from 'ckeditor5/src/engine.js';
-
-import type { PositionOptions } from 'ckeditor5/src/utils.js';
 import type { DeleteCommand } from 'ckeditor5/src/typing.js';
 
 import BookmarkFormView, { type BookmarkFormValidatorCallback } from './ui/bookmarkformview.js';
@@ -33,6 +32,8 @@ import type UpdateBookmarkCommand from './updatebookmarkcommand.js';
 import type InsertBookmarkCommand from './insertbookmarkcommand.js';
 
 import BookmarkEditing from './bookmarkediting.js';
+
+const bookmarkIcon = /* #__PURE__ */ registerIcon( 'bookmark', IconBookmark );
 
 const VISUAL_SELECTION_MARKER_NAME = 'bookmark-ui';
 
@@ -273,7 +274,7 @@ export default class BookmarkUI extends Plugin {
 
 		view.set( {
 			label: t( 'Bookmark' ),
-			icon: IconBookmark
+			icon: bookmarkIcon()
 		} );
 
 		// Execute the command.

--- a/packages/ckeditor5-bookmark/src/ui/bookmarkactionsview.ts
+++ b/packages/ckeditor5-bookmark/src/ui/bookmarkactionsview.ts
@@ -17,6 +17,7 @@ import {
 } from 'ckeditor5/src/ui.js';
 
 import {
+	registerIcon,
 	FocusTracker,
 	KeystrokeHandler,
 	type LocaleTranslate,
@@ -27,6 +28,9 @@ import { IconPencil, IconRemove } from 'ckeditor5/src/icons.js';
 // eslint-disable-next-line ckeditor5-rules/ckeditor-imports
 import '@ckeditor/ckeditor5-ui/theme/components/responsive-form/responsiveform.css';
 import '../../theme/bookmarkactions.css';
+
+const pencilIcon = /* #__PURE__ */ registerIcon( 'pencil', IconPencil );
+const removeIcon = /* #__PURE__ */ registerIcon( 'remove', IconRemove );
 
 /**
  * The bookmark actions view class. This view displays the bookmark preview, allows
@@ -86,8 +90,8 @@ export default class BookmarkActionsView extends View {
 		const t = locale.t;
 
 		this.bookmarkPreviewView = this._createBookmarkPreviewView();
-		this.removeButtonView = this._createButton( t( 'Remove bookmark' ), IconRemove, 'remove', this.bookmarkPreviewView );
-		this.editButtonView = this._createButton( t( 'Edit bookmark' ), IconPencil, 'edit', this.bookmarkPreviewView );
+		this.removeButtonView = this._createButton( t( 'Remove bookmark' ), removeIcon(), 'remove', this.bookmarkPreviewView );
+		this.editButtonView = this._createButton( t( 'Edit bookmark' ), pencilIcon(), 'edit', this.bookmarkPreviewView );
 
 		this.set( 'id', undefined );
 

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditui.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditui.ts
@@ -10,6 +10,9 @@
 import { Plugin } from 'ckeditor5/src/core.js';
 import { ButtonView } from 'ckeditor5/src/ui.js';
 import { IconCkboxImageEdit } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
+
+const ckboxImageEditIcon = /* #__PURE__ */ registerIcon( 'ckboxImageEdit', IconCkboxImageEdit );
 
 /**
  * The UI plugin of the CKBox image edit feature.
@@ -45,7 +48,7 @@ export default class CKBoxImageEditUI extends Plugin {
 			const t = locale.t;
 
 			view.set( {
-				icon: IconCkboxImageEdit,
+				icon: ckboxImageEditIcon(),
 				tooltip: true
 			} );
 

--- a/packages/ckeditor5-ckbox/src/ckboxui.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxui.ts
@@ -8,10 +8,13 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 import { IconBrowseFiles, IconImageAssetManager } from 'ckeditor5/src/icons.js';
-
 import type { ImageInsertUI } from '@ckeditor/ckeditor5-image';
+
+const browseFilesIcon = /* #__PURE__ */ registerIcon( 'browseFiles', IconBrowseFiles );
+const imageAssetManagerIcon = /* #__PURE__ */ registerIcon( 'imageAssetManager', IconImageAssetManager );
 
 /**
  * Introduces UI components for the `CKBox` plugin.
@@ -89,7 +92,7 @@ export default class CKBoxUI extends Plugin {
 		const t = this.editor.locale.t;
 		const button = this._createButton( ButtonView );
 
-		button.icon = IconBrowseFiles;
+		button.icon = browseFilesIcon();
 		button.label = t( 'Open file manager' );
 		button.tooltip = true;
 
@@ -105,7 +108,7 @@ export default class CKBoxUI extends Plugin {
 
 		const button = this._createButton( ButtonView );
 
-		button.icon = IconImageAssetManager;
+		button.icon = imageAssetManagerIcon();
 		button.bind( 'label' ).to(
 			imageInsertUI,
 			'isImageSelected',
@@ -125,7 +128,7 @@ export default class CKBoxUI extends Plugin {
 
 		const button = this._createButton( ButtonView );
 
-		button.icon = IconImageAssetManager;
+		button.icon = imageAssetManagerIcon();
 		button.withText = true;
 		button.bind( 'label' ).to(
 			imageInsertUI,
@@ -147,7 +150,7 @@ export default class CKBoxUI extends Plugin {
 		const t = this.editor.locale.t;
 		const button = this._createButton( MenuBarMenuListItemButtonView );
 
-		button.icon = IconBrowseFiles;
+		button.icon = browseFilesIcon();
 		button.withText = true;
 		button.label = t( 'File' );
 
@@ -163,7 +166,7 @@ export default class CKBoxUI extends Plugin {
 		const t = this.editor.locale.t;
 		const button = this._createButton( MenuBarMenuListItemButtonView );
 
-		button.icon = IconImageAssetManager;
+		button.icon = imageAssetManagerIcon();
 		button.withText = true;
 
 		switch ( type ) {

--- a/packages/ckeditor5-ckfinder/src/ckfinderui.ts
+++ b/packages/ckeditor5-ckfinder/src/ckfinderui.ts
@@ -8,11 +8,14 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 import { IconBrowseFiles, IconImageAssetManager } from 'ckeditor5/src/icons.js';
 import type { ImageInsertUI } from '@ckeditor/ckeditor5-image';
-
 import type CKFinderCommand from './ckfindercommand.js';
+
+const browseFilesIcon = /* #__PURE__ */ registerIcon( 'browseFiles', IconBrowseFiles );
+const imageAssetManagerIcon = /* #__PURE__ */ registerIcon( 'imageAssetManager', IconImageAssetManager );
 
 /**
  * Introduces UI components for `CKFinder` plugin.
@@ -85,7 +88,7 @@ export default class CKFinderUI extends Plugin {
 		const t = this.editor.locale.t;
 		const button = this._createButton( ButtonView );
 
-		button.icon = IconBrowseFiles;
+		button.icon = browseFilesIcon();
 		button.label = t( 'Insert image or file' );
 		button.tooltip = true;
 
@@ -101,7 +104,7 @@ export default class CKFinderUI extends Plugin {
 
 		const button = this._createButton( ButtonView );
 
-		button.icon = IconImageAssetManager;
+		button.icon = imageAssetManagerIcon();
 		button.bind( 'label' ).to(
 			imageInsertUI,
 			'isImageSelected',
@@ -121,7 +124,7 @@ export default class CKFinderUI extends Plugin {
 
 		const button = this._createButton( ButtonView );
 
-		button.icon = IconImageAssetManager;
+		button.icon = imageAssetManagerIcon();
 		button.withText = true;
 		button.bind( 'label' ).to(
 			imageInsertUI,
@@ -143,7 +146,7 @@ export default class CKFinderUI extends Plugin {
 		const t = this.editor.locale.t;
 		const button = this._createButton( MenuBarMenuListItemButtonView );
 
-		button.icon = IconBrowseFiles;
+		button.icon = browseFilesIcon();
 		button.withText = true;
 		button.label = t( 'File' );
 
@@ -159,7 +162,7 @@ export default class CKFinderUI extends Plugin {
 		const t = this.editor.locale.t;
 		const button = this._createButton( MenuBarMenuListItemButtonView );
 
-		button.icon = IconImageAssetManager;
+		button.icon = imageAssetManagerIcon();
 		button.withText = true;
 
 		switch ( type ) {

--- a/packages/ckeditor5-code-block/src/codeblockui.ts
+++ b/packages/ckeditor5-code-block/src/codeblockui.ts
@@ -8,7 +8,7 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core.js';
-import { Collection } from 'ckeditor5/src/utils.js';
+import { registerIcon, Collection } from 'ckeditor5/src/utils.js';
 import {
 	ViewModel,
 	SplitButtonView,
@@ -21,13 +21,13 @@ import {
 	type ListDropdownButtonDefinition
 } from 'ckeditor5/src/ui.js';
 import { IconCodeBlock } from 'ckeditor5/src/icons.js';
-
 import { getNormalizedAndLocalizedLanguageDefinitions } from './utils.js';
-
 import type { CodeBlockLanguageDefinition } from './codeblockconfig.js';
 import type CodeBlockCommand from './codeblockcommand.js';
 
 import '../theme/codeblock.css';
+
+const codeBlockIcon = /* #__PURE__ */ registerIcon( 'codeBlock', IconCodeBlock );
 
 /**
  * The code block UI plugin.
@@ -68,7 +68,7 @@ export default class CodeBlockUI extends Plugin {
 			splitButtonView.set( {
 				label: accessibleLabel,
 				tooltip: true,
-				icon: IconCodeBlock,
+				icon: codeBlockIcon(),
 				isToggleable: true
 			} );
 

--- a/packages/ckeditor5-code-block/src/codeblockui.ts
+++ b/packages/ckeditor5-code-block/src/codeblockui.ts
@@ -108,7 +108,7 @@ export default class CodeBlockUI extends Plugin {
 			menuView.buttonView.set( {
 				role: 'menuitem',
 				label: t( 'Code block' ),
-				icon: IconCodeBlock
+				icon: codeBlockIcon()
 			} );
 
 			menuView.bind( 'isEnabled' ).to( command );

--- a/packages/ckeditor5-core/src/editor/editor.ts
+++ b/packages/ckeditor5-core/src/editor/editor.ts
@@ -19,6 +19,7 @@ import {
 	toArray,
 	uid,
 	crc32,
+	registerIcon,
 	type Locale,
 	type LocaleTranslate,
 	type ObservableChangeEvent,
@@ -320,8 +321,9 @@ export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 		const { translations: defaultTranslations, ...defaultConfig } = constructor.defaultConfig || {};
 		const { translations = defaultTranslations, ...rest } = config;
 
-		// Prefer the language passed as the argument to the constructor instead of the constructor's `defaultConfig`, if both are set.
+		// Prefer values passed to the constructor instead of the `defaultConfig`, if both are set.
 		const language = config.language || defaultConfig.language;
+		const icons = config.icons || defaultConfig.icons;
 
 		this._context = config.context || new Context( { language, translations } );
 		this._context._addEditor( this, !config.context );
@@ -340,6 +342,12 @@ export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 
 		this.locale = this._context.locale;
 		this.t = this.locale.t;
+
+		if ( icons ) {
+			for ( const [ name, value ] of Object.entries( icons ) ) {
+				registerIcon( name, value, true );
+			}
+		}
 
 		this._readOnlyLocks = new Set();
 

--- a/packages/ckeditor5-core/src/editor/editorconfig.ts
+++ b/packages/ckeditor5-core/src/editor/editorconfig.ts
@@ -7,7 +7,7 @@
  * @module core/editor/editorconfig
  */
 
-import type { ArrayOrItem, Translations } from '@ckeditor/ckeditor5-utils';
+import type { ArrayOrItem, Icons, Translations } from '@ckeditor/ckeditor5-utils';
 import type Context from '../context.js';
 import type { PluginConstructor } from '../plugin.js';
 import type Editor from './editor.js';
@@ -823,6 +823,11 @@ export interface EditorConfig {
 	 * Translations to be used in the editor.
 	 */
 	translations?: ArrayOrItem<Translations>;
+
+	/**
+	 * Custom icons to be used in the editor instead of the defaults.
+	 */
+	icons?: Icons;
 
 	/**
 	 * Label text for the `aria-label` attribute set on editor editing area. Used by assistive technologies

--- a/packages/ckeditor5-core/tests/editor/editor.js
+++ b/packages/ckeditor5-core/tests/editor/editor.js
@@ -121,7 +121,6 @@ describe( 'Editor', () => {
 	afterEach( () => {
 		delete TestEditor.builtinPlugins;
 		delete TestEditor.defaultConfig;
-		delete window.CKEDITOR_ICONS;
 
 		sinon.restore();
 	} );
@@ -399,52 +398,45 @@ describe( 'Editor', () => {
 	} );
 
 	describe( 'icons', () => {
-		it( 'should not register any icons by default', () => {
-			// eslint-disable-next-line no-unused-vars
-			const editor = new TestEditor();
-
-			expect( window.CKEDITOR_ICONS ).to.be.undefined;
-		} );
-
 		it( 'should use icons passed as the argument to the constructor', () => {
 		// eslint-disable-next-line no-unused-vars
 			const editor = new TestEditor( {
 				icons: {
-					foo: 'bar'
+					editor_icons_test1: 'bar'
 				}
 			} );
 
-			expect( window.CKEDITOR_ICONS ).to.deep.equals( { foo: 'bar' } );
+			expect( window.CKEDITOR_ICONS.editor_icons_test1 ).to.equal( 'bar' );
 		} );
 
 		it( 'should use icons set as the defaultConfig option on the constructor', () => {
 			TestEditor.defaultConfig = {
 				icons: {
-					foo: 'bar'
+					editor_icons_test2: 'bar'
 				}
 			};
 
 			// eslint-disable-next-line no-unused-vars
 			const editor = new TestEditor();
 
-			expect( window.CKEDITOR_ICONS ).to.deep.equals( { foo: 'bar' } );
+			expect( window.CKEDITOR_ICONS.editor_icons_test2 ).to.equal( 'bar' );
 		} );
 
 		it( 'should prefer icons passed as the argument to the constructor instead of the defaultConfig if both are set', () => {
 			TestEditor.defaultConfig = {
 				icons: {
-					foo: 'bar'
+					editor_icons_test3: 'bar'
 				}
 			};
 
 			// eslint-disable-next-line no-unused-vars
 			const editor = new TestEditor( {
 				icons: {
-					foo: 'baz'
+					editor_icons_test3: 'baz'
 				}
 			} );
 
-			expect( window.CKEDITOR_ICONS ).to.deep.equals( { foo: 'baz' } );
+			expect( window.CKEDITOR_ICONS.editor_icons_test3 ).to.equal( 'baz' );
 		} );
 	} );
 

--- a/packages/ckeditor5-core/tests/editor/editor.js
+++ b/packages/ckeditor5-core/tests/editor/editor.js
@@ -121,6 +121,7 @@ describe( 'Editor', () => {
 	afterEach( () => {
 		delete TestEditor.builtinPlugins;
 		delete TestEditor.defaultConfig;
+		delete window.CKEDITOR_ICONS;
 
 		sinon.restore();
 	} );
@@ -394,6 +395,56 @@ describe( 'Editor', () => {
 
 			expect( editor.locale ).to.have.property( 'uiLanguage', 'pl' );
 			expect( editor.locale ).to.have.property( 'contentLanguage', 'pl' );
+		} );
+	} );
+
+	describe( 'icons', () => {
+		it( 'should not register any icons by default', () => {
+			// eslint-disable-next-line no-unused-vars
+			const editor = new TestEditor();
+
+			expect( window.CKEDITOR_ICONS ).to.be.undefined;
+		} );
+
+		it( 'should use icons passed as the argument to the constructor', () => {
+		// eslint-disable-next-line no-unused-vars
+			const editor = new TestEditor( {
+				icons: {
+					foo: 'bar'
+				}
+			} );
+
+			expect( window.CKEDITOR_ICONS ).to.deep.equals( { foo: 'bar' } );
+		} );
+
+		it( 'should use icons set as the defaultConfig option on the constructor', () => {
+			TestEditor.defaultConfig = {
+				icons: {
+					foo: 'bar'
+				}
+			};
+
+			// eslint-disable-next-line no-unused-vars
+			const editor = new TestEditor();
+
+			expect( window.CKEDITOR_ICONS ).to.deep.equals( { foo: 'bar' } );
+		} );
+
+		it( 'should prefer icons passed as the argument to the constructor instead of the defaultConfig if both are set', () => {
+			TestEditor.defaultConfig = {
+				icons: {
+					foo: 'bar'
+				}
+			};
+
+			// eslint-disable-next-line no-unused-vars
+			const editor = new TestEditor( {
+				icons: {
+					foo: 'baz'
+				}
+			} );
+
+			expect( window.CKEDITOR_ICONS ).to.deep.equals( { foo: 'baz' } );
 		} );
 	} );
 

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceui.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceui.ts
@@ -9,6 +9,7 @@
 
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
 import { IconFindReplace } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import {
 	ButtonView,
 	MenuBarMenuListItemButtonView,
@@ -26,6 +27,8 @@ import type FindNextCommand from './findnextcommand.js';
 import type FindPreviousCommand from './findpreviouscommand.js';
 import type ReplaceCommand from './replacecommand.js';
 import type ReplaceAllCommand from './replaceallcommand.js';
+
+const findReplaceIcon = /* #__PURE__ */ registerIcon( 'findReplace', IconFindReplace );
 
 /**
  * The default find and replace UI.
@@ -176,7 +179,7 @@ export default class FindAndReplaceUI extends Plugin {
 		}, { priority: 'low' } );
 
 		dropdownView.buttonView.set( {
-			icon: IconFindReplace,
+			icon: findReplaceIcon(),
 			label: t( 'Find and replace' ),
 			keystroke: 'CTRL+F',
 			tooltip: true
@@ -257,7 +260,7 @@ export default class FindAndReplaceUI extends Plugin {
 		buttonView.bind( 'isEnabled' ).to( findCommand );
 
 		buttonView.set( {
-			icon: IconFindReplace,
+			icon: findReplaceIcon(),
 			label: t( 'Find and replace' ),
 			keystroke: 'CTRL+F'
 		} );

--- a/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.ts
+++ b/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.ts
@@ -11,32 +11,32 @@ import {
 	View,
 	ButtonView,
 	LabeledFieldView,
-
 	FocusCycler,
 	createLabeledInputText,
 	submitHandler,
 	ViewCollection,
-
+	CollapsibleView,
+	SwitchButtonView,
 	type Template,
 	type InputView,
-	type FocusableView,
-	SwitchButtonView,
-	CollapsibleView
+	type FocusableView
 } from 'ckeditor5/src/ui.js';
-
 import {
 	FocusTracker,
 	KeystrokeHandler,
 	Rect,
 	isVisible,
+	registerIcon,
 	type Locale
 } from 'ckeditor5/src/utils.js';
+import { IconPreviousArrow } from 'ckeditor5/src/icons.js';
 
 // See: #8833.
 // eslint-disable-next-line ckeditor5-rules/ckeditor-imports
 import '@ckeditor/ckeditor5-ui/theme/components/responsive-form/responsiveform.css';
 import '../../theme/findandreplaceform.css';
-import { IconPreviousArrow } from 'ckeditor5/src/icons.js';
+
+const previousArrowIcon = /* #__PURE__ */ registerIcon( 'previousArrow', IconPreviousArrow );
 
 /**
  * The find and replace form view class.
@@ -257,7 +257,7 @@ export default class FindAndReplaceFormView extends View {
 		this._findPrevButtonView = this._createButton( {
 			label: t( 'Previous result' ),
 			class: 'ck-button-prev',
-			icon: IconPreviousArrow,
+			icon: previousArrowIcon(),
 			keystroke: 'Shift+F3',
 			tooltip: true
 		} );
@@ -265,7 +265,7 @@ export default class FindAndReplaceFormView extends View {
 		this._findNextButtonView = this._createButton( {
 			label: t( 'Next result' ),
 			class: 'ck-button-next',
-			icon: IconPreviousArrow,
+			icon: previousArrowIcon(),
 			keystroke: 'F3',
 			tooltip: true
 		} );

--- a/packages/ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorui.ts
+++ b/packages/ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorui.ts
@@ -7,10 +7,13 @@
  * @module font/fontbackgroundcolor/fontbackgroundcolorui
  */
 
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { IconFontBackground } from 'ckeditor5/src/icons.js';
 import ColorUI from '../ui/colorui.js';
 import { FONT_BACKGROUND_COLOR } from '../utils.js';
 import type { Editor } from 'ckeditor5/src/core.js';
+
+const fontBackgroundIcon = /* #__PURE__ */ registerIcon( 'fontBackground', IconFontBackground );
 
 /**
  * The font background color UI plugin. It introduces the `'fontBackgroundColor'` dropdown.
@@ -25,7 +28,7 @@ export default class FontBackgroundColorUI extends ColorUI {
 		super( editor, {
 			commandName: FONT_BACKGROUND_COLOR,
 			componentName: FONT_BACKGROUND_COLOR,
-			icon: IconFontBackground,
+			icon: fontBackgroundIcon(),
 			dropdownLabel: t( 'Font Background Color' )
 		} );
 	}

--- a/packages/ckeditor5-font/src/fontcolor/fontcolorui.ts
+++ b/packages/ckeditor5-font/src/fontcolor/fontcolorui.ts
@@ -7,10 +7,13 @@
  * @module font/fontcolor/fontcolorui
  */
 
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { IconFontColor } from 'ckeditor5/src/icons.js';
 import ColorUI from '../ui/colorui.js';
 import { FONT_COLOR } from '../utils.js';
 import type { Editor } from 'ckeditor5/src/core.js';
+
+const fontColorIcon = /* #__PURE__ */ registerIcon( 'fontColor', IconFontColor );
 
 /**
  * The font color UI plugin. It introduces the `'fontColor'` dropdown.
@@ -25,7 +28,7 @@ export default class FontColorUI extends ColorUI {
 		super( editor, {
 			commandName: FONT_COLOR,
 			componentName: FONT_COLOR,
-			icon: IconFontColor,
+			icon: fontColorIcon(),
 			dropdownLabel: t( 'Font Color' )
 		} );
 	}

--- a/packages/ckeditor5-font/src/fontfamily/fontfamilyui.ts
+++ b/packages/ckeditor5-font/src/fontfamily/fontfamilyui.ts
@@ -8,7 +8,7 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core.js';
-import { Collection } from 'ckeditor5/src/utils.js';
+import { registerIcon, Collection } from 'ckeditor5/src/utils.js';
 import { IconFontFamily } from 'ckeditor5/src/icons.js';
 import {
 	ViewModel,
@@ -20,12 +20,12 @@ import {
 	MenuBarMenuListItemButtonView,
 	type ListDropdownButtonDefinition
 } from 'ckeditor5/src/ui.js';
-
 import { normalizeOptions } from './utils.js';
 import { FONT_FAMILY } from '../utils.js';
-
 import type { FontFamilyOption } from '../fontconfig.js';
 import type FontFamilyCommand from './fontfamilycommand.js';
+
+const fontFamilyIcon = /* #__PURE__ */ registerIcon( 'fontFamily', IconFontFamily );
 
 /**
  * The font family UI plugin. It introduces the `'fontFamily'` dropdown.
@@ -69,7 +69,7 @@ export default class FontFamilyUI extends Plugin {
 
 			dropdownView.buttonView.set( {
 				label: accessibleLabel,
-				icon: IconFontFamily,
+				icon: fontFamilyIcon(),
 				tooltip: true
 			} );
 
@@ -95,7 +95,7 @@ export default class FontFamilyUI extends Plugin {
 
 			menuView.buttonView.set( {
 				label: accessibleLabel,
-				icon: IconFontFamily
+				icon: fontFamilyIcon()
 			} );
 
 			menuView.bind( 'isEnabled' ).to( command );

--- a/packages/ckeditor5-font/src/fontsize/fontsizeui.ts
+++ b/packages/ckeditor5-font/src/fontsize/fontsizeui.ts
@@ -19,14 +19,15 @@ import {
 	MenuBarMenuListItemView,
 	MenuBarMenuListItemButtonView
 } from 'ckeditor5/src/ui.js';
-import { Collection } from 'ckeditor5/src/utils.js';
-
+import { Collection, registerIcon } from 'ckeditor5/src/utils.js';
 import { normalizeOptions } from './utils.js';
 import { FONT_SIZE } from '../utils.js';
-
-import '../../theme/fontsize.css';
 import type { FontSizeOption } from '../fontconfig.js';
 import type FontSizeCommand from './fontsizecommand.js';
+
+import '../../theme/fontsize.css';
+
+const fontSizeIcon = /* #__PURE__ */ registerIcon( 'fontSize', IconFontSize );
 
 /**
  * The font size UI plugin. It introduces the `'fontSize'` dropdown.
@@ -72,7 +73,7 @@ export default class FontSizeUI extends Plugin {
 			// Create dropdown model.
 			dropdownView.buttonView.set( {
 				label: accessibleLabel,
-				icon: IconFontSize,
+				icon: fontSizeIcon(),
 				tooltip: true
 			} );
 
@@ -100,7 +101,7 @@ export default class FontSizeUI extends Plugin {
 
 			menuView.buttonView.set( {
 				label: accessibleLabel,
-				icon: IconFontSize
+				icon: fontSizeIcon()
 			} );
 
 			menuView.bind( 'isEnabled' ).to( command );

--- a/packages/ckeditor5-heading/src/headingbuttonsui.ts
+++ b/packages/ckeditor5-heading/src/headingbuttonsui.ts
@@ -7,22 +7,20 @@
  * @module heading/headingbuttonsui
  */
 
-import { Plugin } from 'ckeditor5/src/core.js';
+import { Plugin, type Editor } from 'ckeditor5/src/core.js';
 import { ButtonView } from 'ckeditor5/src/ui.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { IconHeading1, IconHeading2, IconHeading3, IconHeading4, IconHeading5, IconHeading6 } from 'ckeditor5/src/icons.js';
-
 import { getLocalizedOptions } from './utils.js';
 import type { HeadingOption } from './headingconfig.js';
 import type HeadingCommand from './headingcommand.js';
 
-const defaultIcons: Record<string, string> = /* #__PURE__ */ ( () => ( {
-	heading1: IconHeading1,
-	heading2: IconHeading2,
-	heading3: IconHeading3,
-	heading4: IconHeading4,
-	heading5: IconHeading5,
-	heading6: IconHeading6
-} ) )();
+const heading1Icon = /* #__PURE__ */ registerIcon( 'heading1', IconHeading1 );
+const heading2Icon = /* #__PURE__ */ registerIcon( 'heading2', IconHeading2 );
+const heading3Icon = /* #__PURE__ */ registerIcon( 'heading3', IconHeading3 );
+const heading4Icon = /* #__PURE__ */ registerIcon( 'heading4', IconHeading4 );
+const heading5Icon = /* #__PURE__ */ registerIcon( 'heading5', IconHeading5 );
+const heading6Icon = /* #__PURE__ */ registerIcon( 'heading6', IconHeading6 );
 
 /**
  * The `HeadingButtonsUI` plugin defines a set of UI buttons that can be used instead of the
@@ -58,6 +56,21 @@ const defaultIcons: Record<string, string> = /* #__PURE__ */ ( () => ( {
  * For the default configuration standard icons are used.
  */
 export default class HeadingButtonsUI extends Plugin {
+	private icons: Record<string, string>;
+
+	constructor( editor: Editor ) {
+		super( editor );
+
+		this.icons = {
+			heading1: heading1Icon(),
+			heading2: heading2Icon(),
+			heading3: heading3Icon(),
+			heading4: heading4Icon(),
+			heading5: heading5Icon(),
+			heading6: heading6Icon()
+		};
+	}
+
 	/**
 	 * @inheritDoc
 	 */
@@ -80,7 +93,7 @@ export default class HeadingButtonsUI extends Plugin {
 			const command: HeadingCommand = editor.commands.get( 'heading' )!;
 
 			view.label = option.title;
-			view.icon = option.icon || defaultIcons[ option.model ];
+			view.icon = option.icon || this.icons[ option.model ];
 			view.tooltip = true;
 			view.isToggleable = true;
 			view.bind( 'isEnabled' ).to( command );

--- a/packages/ckeditor5-highlight/package.json
+++ b/packages/ckeditor5-highlight/package.json
@@ -16,6 +16,7 @@
     "@ckeditor/ckeditor5-core": "44.1.0",
     "@ckeditor/ckeditor5-icons": "0.0.1",
     "@ckeditor/ckeditor5-ui": "44.1.0",
+    "@ckeditor/ckeditor5-utils": "44.1.0",
     "ckeditor5": "44.1.0"
   },
   "devDependencies": {
@@ -30,7 +31,6 @@
     "@ckeditor/ckeditor5-paragraph": "44.1.0",
     "@ckeditor/ckeditor5-theme-lark": "44.1.0",
     "@ckeditor/ckeditor5-typing": "44.1.0",
-    "@ckeditor/ckeditor5-utils": "44.1.0",
     "typescript": "5.0.4",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4"

--- a/packages/ckeditor5-highlight/src/highlightui.ts
+++ b/packages/ckeditor5-highlight/src/highlightui.ts
@@ -8,6 +8,7 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { IconEraser, IconMarker, IconPen } from 'ckeditor5/src/icons.js';
 import {
 	addToolbarToDropdown,
@@ -22,11 +23,14 @@ import {
 	ToolbarSeparatorView,
 	type DropdownView
 } from 'ckeditor5/src/ui.js';
-
 import type { HighlightOption } from './highlightconfig.js';
 import type HighlightCommand from './highlightcommand.js';
 
 import './../theme/highlight.css';
+
+const eraserIcon = /* #__PURE__ */ registerIcon( 'eraser', IconEraser );
+const markerIcon = /* #__PURE__ */ registerIcon( 'marker', IconMarker );
+const penIcon = /* #__PURE__ */ registerIcon( 'pen', IconPen );
 
 /**
  * The default highlight UI plugin. It introduces:
@@ -111,7 +115,7 @@ export default class HighlightUI extends Plugin {
 		const t = this.editor.t;
 		const command: HighlightCommand = this.editor.commands.get( 'highlight' )!;
 
-		this._addButton( 'removeHighlight', t( 'Remove highlight' ), IconEraser, null, button => {
+		this._addButton( 'removeHighlight', t( 'Remove highlight' ), eraserIcon(), null, button => {
 			button.bind( 'isEnabled' ).to( command, 'isEnabled' );
 		} );
 	}
@@ -319,7 +323,7 @@ export default class HighlightUI extends Plugin {
 
 			buttonView.set( {
 				label: t( 'Remove highlight' ),
-				icon: IconEraser
+				icon: eraserIcon()
 			} );
 
 			buttonView.delegate( 'execute' ).to( menuView );
@@ -352,8 +356,8 @@ function bindToolbarIconStyleToActiveColor( dropdownView: DropdownView ): void {
 /**
  * Returns icon for given highlighter type.
  */
-function getIconForType( type: 'marker' | 'pen' ) {
-	return type === 'marker' ? IconMarker : IconPen;
+function getIconForType( type: 'marker' | 'pen' ): string {
+	return type === 'marker' ? markerIcon() : penIcon();
 }
 
 type HighlightSplitButtonView = SplitButtonView & {

--- a/packages/ckeditor5-horizontal-line/package.json
+++ b/packages/ckeditor5-horizontal-line/package.json
@@ -16,6 +16,7 @@
     "@ckeditor/ckeditor5-core": "44.1.0",
     "@ckeditor/ckeditor5-icons": "0.0.1",
     "@ckeditor/ckeditor5-ui": "44.1.0",
+    "@ckeditor/ckeditor5-utils": "44.1.0",
     "@ckeditor/ckeditor5-widget": "44.1.0",
     "ckeditor5": "44.1.0"
   },
@@ -28,7 +29,6 @@
     "@ckeditor/ckeditor5-image": "44.1.0",
     "@ckeditor/ckeditor5-paragraph": "44.1.0",
     "@ckeditor/ckeditor5-theme-lark": "44.1.0",
-    "@ckeditor/ckeditor5-utils": "44.1.0",
     "typescript": "5.0.4",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4"

--- a/packages/ckeditor5-horizontal-line/src/horizontallineui.ts
+++ b/packages/ckeditor5-horizontal-line/src/horizontallineui.ts
@@ -8,10 +8,12 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { IconHorizontalLine } from 'ckeditor5/src/icons.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
-
 import type HorizontalLineCommand from './horizontallinecommand.js';
+
+const horizontalLineIcon = /* #__PURE__ */ registerIcon( 'horizontalLine', IconHorizontalLine );
 
 /**
  * The horizontal line UI plugin.
@@ -65,7 +67,7 @@ export default class HorizontalLineUI extends Plugin {
 
 		view.set( {
 			label: t( 'Horizontal line' ),
-			icon: IconHorizontalLine
+			icon: horizontalLineIcon()
 		} );
 
 		view.bind( 'isEnabled' ).to( command, 'isEnabled' );

--- a/packages/ckeditor5-html-embed/src/htmlembedediting.ts
+++ b/packages/ckeditor5-html-embed/src/htmlembedediting.ts
@@ -10,13 +10,16 @@
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
 import { ButtonView } from 'ckeditor5/src/ui.js';
 import { toWidget } from 'ckeditor5/src/widget.js';
-import { logWarning, createElement } from 'ckeditor5/src/utils.js';
+import { logWarning, createElement, registerIcon } from 'ckeditor5/src/utils.js';
 import { IconCancel, IconCheck, IconPencil } from 'ckeditor5/src/icons.js';
-
-import type { HtmlEmbedConfig } from './htmlembedconfig.js';
 import HtmlEmbedCommand from './htmlembedcommand.js';
+import type { HtmlEmbedConfig } from './htmlembedconfig.js';
 
 import '../theme/htmlembed.css';
+
+const cancelIcon = /* #__PURE__ */ registerIcon( 'cancel', IconCancel );
+const checkIcon = /* #__PURE__ */ registerIcon( 'check', IconCheck );
+const pencilIcon = /* #__PURE__ */ registerIcon( 'pencil', IconPencil );
 
 /**
  * The HTML embed editing feature.
@@ -409,7 +412,7 @@ function createUIButton( editor: Editor, type: 'edit' | 'save' | 'cancel', onCli
 
 	buttonView.set( {
 		class: `raw-html-embed__${ type }-button`,
-		icon: IconPencil,
+		icon: pencilIcon(),
 		tooltip: true,
 		tooltipPosition: editor.locale.uiLanguageDirection === 'rtl' ? 'e' : 'w'
 	} );
@@ -418,21 +421,21 @@ function createUIButton( editor: Editor, type: 'edit' | 'save' | 'cancel', onCli
 
 	if ( type === 'edit' ) {
 		buttonView.set( {
-			icon: IconPencil,
+			icon: pencilIcon(),
 			label: t( 'Edit source' )
 		} );
 
 		buttonView.bind( 'isEnabled' ).to( command );
 	} else if ( type === 'save' ) {
 		buttonView.set( {
-			icon: IconCheck,
+			icon: checkIcon(),
 			label: t( 'Save changes' )
 		} );
 
 		buttonView.bind( 'isEnabled' ).to( command );
 	} else {
 		buttonView.set( {
-			icon: IconCancel,
+			icon: cancelIcon(),
 			label: t( 'Cancel' )
 		} );
 	}

--- a/packages/ckeditor5-html-embed/src/htmlembedui.ts
+++ b/packages/ckeditor5-html-embed/src/htmlembedui.ts
@@ -9,9 +9,12 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import { IconHtml } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 import type { RawHtmlApi } from './htmlembedediting.js';
 import type HtmlEmbedCommand from './htmlembedcommand.js';
+
+const htmlIcon = /* #__PURE__ */ registerIcon( 'html', IconHtml );
 
 /**
  * The HTML embed UI plugin.
@@ -71,7 +74,7 @@ export default class HtmlEmbedUI extends Plugin {
 		const view = new ButtonClass( editor.locale ) as InstanceType<T>;
 
 		view.set( {
-			icon: IconHtml
+			icon: htmlIcon()
 		} );
 
 		view.bind( 'isEnabled' ).to( command, 'isEnabled' );

--- a/packages/ckeditor5-icons/package.json
+++ b/packages/ckeditor5-icons/package.json
@@ -30,7 +30,6 @@
     "src/**/*.js",
     "src/**/*.d.ts",
     "theme",
-    "build",
     "CHANGELOG.md"
   ],
   "scripts": {

--- a/packages/ckeditor5-image/src/imagecaption/imagecaptionui.ts
+++ b/packages/ckeditor5-image/src/imagecaption/imagecaptionui.ts
@@ -10,8 +10,11 @@
 import { Plugin } from 'ckeditor5/src/core.js';
 import { ButtonView } from 'ckeditor5/src/ui.js';
 import { IconCaption } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import ImageCaptionUtils from './imagecaptionutils.js';
 import type ToggleImageCaptionCommand from './toggleimagecaptioncommand.js';
+
+const captionIcon = /* #__PURE__ */ registerIcon( 'caption', IconCaption );
 
 /**
  * The image caption UI plugin. It introduces the `'toggleImageCaption'` UI button.
@@ -52,7 +55,7 @@ export default class ImageCaptionUI extends Plugin {
 			const view = new ButtonView( locale );
 
 			view.set( {
-				icon: IconCaption,
+				icon: captionIcon(),
 				tooltip: true,
 				isToggleable: true
 			} );

--- a/packages/ckeditor5-image/src/imageinsert/imageinsertui.ts
+++ b/packages/ckeditor5-image/src/imageinsert/imageinsertui.ts
@@ -10,6 +10,7 @@
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
 import {
 	logWarning,
+	registerIcon,
 	type Locale,
 	type Observable
 } from 'ckeditor5/src/utils.js';
@@ -27,9 +28,10 @@ import {
 	type View
 } from 'ckeditor5/src/ui.js';
 import { IconImage } from 'ckeditor5/src/icons.js';
-
-import ImageInsertFormView from './ui/imageinsertformview.js';
 import ImageUtils from '../imageutils.js';
+import ImageInsertFormView from './ui/imageinsertformview.js';
+
+const imageIcon = /* #__PURE__ */ registerIcon( 'image', IconImage );
 
 /**
  * The image insert dropdown plugin.
@@ -232,7 +234,7 @@ export default class ImageInsertUI extends Plugin {
 			resultView.panelView.children.add( listView );
 
 			resultView.buttonView.set( {
-				icon: IconImage,
+				icon: imageIcon(),
 				label: t( 'Image' )
 			} );
 

--- a/packages/ckeditor5-image/src/imageinsert/imageinsertviaurlui.ts
+++ b/packages/ckeditor5-image/src/imageinsert/imageinsertviaurlui.ts
@@ -8,11 +8,13 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core.js';
-import { ButtonView, Dialog, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 import { IconImageUrl } from 'ckeditor5/src/icons.js';
-
+import { registerIcon } from 'ckeditor5/src/utils.js';
+import { ButtonView, Dialog, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 import ImageInsertUI from './imageinsertui.js';
 import ImageInsertUrlView from './ui/imageinserturlview.js';
+
+const imageUrlIcon = /* #__PURE__ */ registerIcon( 'imageUrl', IconImageUrl );
 
 /**
  * The image insert via URL plugin (UI part).
@@ -78,7 +80,7 @@ export default class ImageInsertViaUrlUI extends Plugin {
 	): InstanceType<T> {
 		const button = new ButtonClass( this.editor.locale ) as InstanceType<T>;
 
-		button.icon = IconImageUrl;
+		button.icon = imageUrlIcon();
 		button.on( 'execute', () => {
 			this._showModal();
 		} );

--- a/packages/ckeditor5-image/src/imageresize/imageresizebuttons.ts
+++ b/packages/ckeditor5-image/src/imageresize/imageresizebuttons.ts
@@ -34,14 +34,30 @@ const objectSizeLargeIcon = /* #__PURE__ */ registerIcon( 'objectSizeLarge', Ico
 const objectSizeMediumIcon = /* #__PURE__ */ registerIcon( 'objectSizeMedium', IconObjectSizeMedium );
 const objectSizeSmallIcon = /* #__PURE__ */ registerIcon( 'objectSizeSmall', IconObjectSizeSmall );
 
+const RESIZE_ICONS: Record<string, string> = {
+	get small() {
+		return objectSizeSmallIcon();
+	},
+	get medium() {
+		return objectSizeMediumIcon();
+	},
+	get large() {
+		return objectSizeLargeIcon();
+	},
+	get custom() {
+		return objectSizeCustomIcon();
+	},
+	get original() {
+		return objectSizeFullIcon();
+	}
+};
+
 /**
  * The image resize buttons plugin.
  *
  * It adds a possibility to resize images using the toolbar dropdown or individual buttons, depending on the plugin configuration.
  */
 export default class ImageResizeButtons extends Plugin {
-	private icons: Record<string, string>;
-
 	/**
 	 * @inheritDoc
 	 */
@@ -74,14 +90,6 @@ export default class ImageResizeButtons extends Plugin {
 	 */
 	constructor( editor: Editor ) {
 		super( editor );
-
-		this.icons = {
-			custom: objectSizeCustomIcon(),
-			original: objectSizeFullIcon(),
-			large: objectSizeLargeIcon(),
-			medium: objectSizeMediumIcon(),
-			small: objectSizeSmallIcon()
-		};
 
 		this._resizeUnit = editor.config.get( 'image.resizeUnit' )!;
 	}
@@ -117,7 +125,7 @@ export default class ImageResizeButtons extends Plugin {
 			const command: ResizeImageCommand = editor.commands.get( 'resizeImage' )!;
 			const labelText = this._getOptionLabelValue( option, true );
 
-			if ( !this.icons[ icon as keyof typeof this.icons ] ) {
+			if ( !RESIZE_ICONS[ icon as keyof typeof RESIZE_ICONS ] ) {
 				/**
 				 * When configuring {@link module:image/imageconfig~ImageConfig#resizeOptions `config.image.resizeOptions`} for standalone
 				 * buttons, a valid `icon` token must be set for each option.
@@ -138,7 +146,7 @@ export default class ImageResizeButtons extends Plugin {
 			button.set( {
 				// Use the `label` property for a verbose description (because of ARIA).
 				label: labelText,
-				icon: this.icons[ icon as keyof typeof this.icons ],
+				icon: RESIZE_ICONS[ icon as keyof typeof RESIZE_ICONS ],
 				tooltip: labelText,
 				isToggleable: true
 			} );
@@ -186,7 +194,7 @@ export default class ImageResizeButtons extends Plugin {
 			dropdownButton.set( {
 				tooltip: accessibleLabel,
 				commandValue: originalSizeOption.value,
-				icon: this.icons.medium,
+				icon: RESIZE_ICONS.medium,
 				isToggleable: true,
 				label: this._getOptionLabelValue( originalSizeOption ),
 				withText: true,

--- a/packages/ckeditor5-image/src/imageresize/imageresizebuttons.ts
+++ b/packages/ckeditor5-image/src/imageresize/imageresizebuttons.ts
@@ -7,7 +7,6 @@
  * @module image/imageresize/imageresizebuttons
  */
 import { map } from 'lodash-es';
-
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
 import {
 	ButtonView,
@@ -17,7 +16,7 @@ import {
 	addListToDropdown,
 	type ListDropdownItemDefinition
 } from 'ckeditor5/src/ui.js';
-import { CKEditorError, Collection, type Locale } from 'ckeditor5/src/utils.js';
+import { CKEditorError, Collection, registerIcon, type Locale } from 'ckeditor5/src/utils.js';
 import {
 	IconObjectSizeCustom,
 	IconObjectSizeFull,
@@ -25,19 +24,15 @@ import {
 	IconObjectSizeMedium,
 	IconObjectSizeSmall
 } from 'ckeditor5/src/icons.js';
-
 import ImageResizeEditing from './imageresizeediting.js';
-
 import type ResizeImageCommand from './resizeimagecommand.js';
 import type { ImageResizeOption } from '../imageconfig.js';
 
-const RESIZE_ICONS = /* #__PURE__ */ ( () => ( {
-	small: IconObjectSizeSmall,
-	medium: IconObjectSizeMedium,
-	large: IconObjectSizeLarge,
-	custom: IconObjectSizeCustom,
-	original: IconObjectSizeFull
-} ) )();
+const objectSizeCustomIcon = /* #__PURE__ */ registerIcon( 'objectSizeCustom', IconObjectSizeCustom );
+const objectSizeFullIcon = /* #__PURE__ */ registerIcon( 'objectSizeFull', IconObjectSizeFull );
+const objectSizeLargeIcon = /* #__PURE__ */ registerIcon( 'objectSizeLarge', IconObjectSizeLarge );
+const objectSizeMediumIcon = /* #__PURE__ */ registerIcon( 'objectSizeMedium', IconObjectSizeMedium );
+const objectSizeSmallIcon = /* #__PURE__ */ registerIcon( 'objectSizeSmall', IconObjectSizeSmall );
 
 /**
  * The image resize buttons plugin.
@@ -45,6 +40,8 @@ const RESIZE_ICONS = /* #__PURE__ */ ( () => ( {
  * It adds a possibility to resize images using the toolbar dropdown or individual buttons, depending on the plugin configuration.
  */
 export default class ImageResizeButtons extends Plugin {
+	private icons: Record<string, string>;
+
 	/**
 	 * @inheritDoc
 	 */
@@ -77,6 +74,14 @@ export default class ImageResizeButtons extends Plugin {
 	 */
 	constructor( editor: Editor ) {
 		super( editor );
+
+		this.icons = {
+			custom: objectSizeCustomIcon(),
+			original: objectSizeFullIcon(),
+			large: objectSizeLargeIcon(),
+			medium: objectSizeMediumIcon(),
+			small: objectSizeSmallIcon()
+		};
 
 		this._resizeUnit = editor.config.get( 'image.resizeUnit' )!;
 	}
@@ -112,7 +117,7 @@ export default class ImageResizeButtons extends Plugin {
 			const command: ResizeImageCommand = editor.commands.get( 'resizeImage' )!;
 			const labelText = this._getOptionLabelValue( option, true );
 
-			if ( !RESIZE_ICONS[ icon as keyof typeof RESIZE_ICONS ] ) {
+			if ( !this.icons[ icon as keyof typeof this.icons ] ) {
 				/**
 				 * When configuring {@link module:image/imageconfig~ImageConfig#resizeOptions `config.image.resizeOptions`} for standalone
 				 * buttons, a valid `icon` token must be set for each option.
@@ -133,7 +138,7 @@ export default class ImageResizeButtons extends Plugin {
 			button.set( {
 				// Use the `label` property for a verbose description (because of ARIA).
 				label: labelText,
-				icon: RESIZE_ICONS[ icon as keyof typeof RESIZE_ICONS ],
+				icon: this.icons[ icon as keyof typeof this.icons ],
 				tooltip: labelText,
 				isToggleable: true
 			} );
@@ -181,7 +186,7 @@ export default class ImageResizeButtons extends Plugin {
 			dropdownButton.set( {
 				tooltip: accessibleLabel,
 				commandValue: originalSizeOption.value,
-				icon: RESIZE_ICONS.medium,
+				icon: this.icons.medium,
 				isToggleable: true,
 				label: this._getOptionLabelValue( originalSizeOption ),
 				withText: true,

--- a/packages/ckeditor5-image/src/imageresize/ui/imagecustomresizeformview.ts
+++ b/packages/ckeditor5-image/src/imageresize/ui/imagecustomresizeformview.ts
@@ -18,8 +18,7 @@ import {
 	type FocusableView,
 	type InputNumberView
 } from 'ckeditor5/src/ui.js';
-
-import { FocusTracker, KeystrokeHandler, type Locale } from 'ckeditor5/src/utils.js';
+import { FocusTracker, KeystrokeHandler, registerIcon, type Locale } from 'ckeditor5/src/utils.js';
 import { IconCancel, IconCheck } from 'ckeditor5/src/icons.js';
 
 import '../../../theme/imagecustomresizeform.css';
@@ -27,6 +26,9 @@ import '../../../theme/imagecustomresizeform.css';
 // See: #8833.
 // eslint-disable-next-line ckeditor5-rules/ckeditor-imports
 import '@ckeditor/ckeditor5-ui/theme/components/responsive-form/responsiveform.css';
+
+const cancelIcon = /* #__PURE__ */ registerIcon( 'cancel', IconCancel );
+const checkIcon = /* #__PURE__ */ registerIcon( 'check', IconCheck );
 
 /**
  * The ImageCustomResizeFormView class.
@@ -90,10 +92,10 @@ export default class ImageCustomResizeFormView extends View {
 
 		this.labeledInput = this._createLabeledInputView();
 
-		this.saveButtonView = this._createButton( t( 'Save' ), IconCheck, 'ck-button-save' );
+		this.saveButtonView = this._createButton( t( 'Save' ), checkIcon(), 'ck-button-save' );
 		this.saveButtonView.type = 'submit';
 
-		this.cancelButtonView = this._createButton( t( 'Cancel' ), IconCancel, 'ck-button-cancel', 'cancel' );
+		this.cancelButtonView = this._createButton( t( 'Cancel' ), cancelIcon(), 'ck-button-cancel', 'cancel' );
 
 		this._focusables = new ViewCollection();
 		this._validators = validators;

--- a/packages/ckeditor5-image/src/imagestyle/utils.ts
+++ b/packages/ckeditor5-image/src/imagestyle/utils.ts
@@ -7,7 +7,7 @@
  * @module image/imagestyle/utils
  */
 
-import { logWarning } from 'ckeditor5/src/utils.js';
+import { logWarning, registerIcon } from 'ckeditor5/src/utils.js';
 import {
 	IconObjectCenter,
 	IconObjectFullWidth,
@@ -19,6 +19,14 @@ import {
 } from 'ckeditor5/src/icons.js';
 import type { Editor, PluginCollection } from 'ckeditor5/src/core.js';
 import type { ImageStyleConfig, ImageStyleDropdownDefinition, ImageStyleOptionDefinition } from '../imageconfig.js';
+
+const objectCenterIcon = /* #__PURE__ */ registerIcon( 'objectCenter', IconObjectCenter );
+const objectFullWidthIcon = /* #__PURE__ */ registerIcon( 'objectFullWidth', IconObjectFullWidth );
+const objectInlineIcon = /* #__PURE__ */ registerIcon( 'objectInline', IconObjectInline );
+const objectInlineLeftIcon = /* #__PURE__ */ registerIcon( 'objectInlineLeft', IconObjectInlineLeft );
+const objectInlineRightIcon = /* #__PURE__ */ registerIcon( 'objectInlineRight', IconObjectInlineRight );
+const objectLeftIcon = /* #__PURE__ */ registerIcon( 'objectLeft', IconObjectLeft );
+const objectRightIcon = /* #__PURE__ */ registerIcon( 'objectRight', IconObjectRight );
 
 /**
  * Default image style options provided by the plugin that can be referred in the {@link module:image/imageconfig~ImageConfig#styles}
@@ -44,7 +52,7 @@ export const DEFAULT_OPTIONS: Record<string, ImageStyleOptionDefinition> = {
 		return {
 			name: 'inline',
 			title: 'In line',
-			icon: IconObjectInline,
+			icon: objectInlineIcon(),
 			modelElements: [ 'imageInline' ],
 			isDefault: true
 		};
@@ -55,7 +63,7 @@ export const DEFAULT_OPTIONS: Record<string, ImageStyleOptionDefinition> = {
 		return {
 			name: 'alignLeft',
 			title: 'Left aligned image',
-			icon: IconObjectInlineLeft,
+			icon: objectInlineLeftIcon(),
 			modelElements: [ 'imageBlock', 'imageInline' ],
 			className: 'image-style-align-left'
 		};
@@ -66,7 +74,7 @@ export const DEFAULT_OPTIONS: Record<string, ImageStyleOptionDefinition> = {
 		return {
 			name: 'alignBlockLeft',
 			title: 'Left aligned image',
-			icon: IconObjectLeft,
+			icon: objectLeftIcon(),
 			modelElements: [ 'imageBlock' ],
 			className: 'image-style-block-align-left'
 		};
@@ -77,7 +85,7 @@ export const DEFAULT_OPTIONS: Record<string, ImageStyleOptionDefinition> = {
 		return {
 			name: 'alignCenter',
 			title: 'Centered image',
-			icon: IconObjectCenter,
+			icon: objectCenterIcon(),
 			modelElements: [ 'imageBlock' ],
 			className: 'image-style-align-center'
 		};
@@ -88,7 +96,7 @@ export const DEFAULT_OPTIONS: Record<string, ImageStyleOptionDefinition> = {
 		return {
 			name: 'alignRight',
 			title: 'Right aligned image',
-			icon: IconObjectInlineRight,
+			icon: objectInlineRightIcon(),
 			modelElements: [ 'imageBlock', 'imageInline' ],
 			className: 'image-style-align-right'
 		};
@@ -99,7 +107,7 @@ export const DEFAULT_OPTIONS: Record<string, ImageStyleOptionDefinition> = {
 		return {
 			name: 'alignBlockRight',
 			title: 'Right aligned image',
-			icon: IconObjectRight,
+			icon: objectRightIcon(),
 			modelElements: [ 'imageBlock' ],
 			className: 'image-style-block-align-right'
 		};
@@ -110,7 +118,7 @@ export const DEFAULT_OPTIONS: Record<string, ImageStyleOptionDefinition> = {
 		return {
 			name: 'block',
 			title: 'Centered image',
-			icon: IconObjectCenter,
+			icon: objectCenterIcon(),
 			modelElements: [ 'imageBlock' ],
 			isDefault: true
 		};
@@ -121,7 +129,7 @@ export const DEFAULT_OPTIONS: Record<string, ImageStyleOptionDefinition> = {
 		return {
 			name: 'side',
 			title: 'Side image',
-			icon: IconObjectInlineRight,
+			icon: objectInlineRightIcon(),
 			modelElements: [ 'imageBlock' ],
 			className: 'image-style-side'
 		};
@@ -136,14 +144,14 @@ export const DEFAULT_OPTIONS: Record<string, ImageStyleOptionDefinition> = {
  *
  * There are 7 default icons available: `'full'`, `'left'`, `'inlineLeft'`, `'center'`, `'right'`, `'inlineRight'`, and `'inline'`.
  */
-export const DEFAULT_ICONS: Record<string, string> = /* #__PURE__ */ ( () => ( {
-	full: IconObjectFullWidth,
-	left: IconObjectLeft,
-	right: IconObjectRight,
-	center: IconObjectCenter,
-	inlineLeft: IconObjectInlineLeft,
-	inlineRight: IconObjectInlineRight,
-	inline: IconObjectInline
+export const DEFAULT_ICONS: Record<string, () => string> = /* #__PURE__ */ ( () => ( {
+	full: objectFullWidthIcon,
+	left: objectLeftIcon,
+	right: objectRightIcon,
+	center: objectCenterIcon,
+	inlineLeft: objectInlineLeftIcon,
+	inlineRight: objectInlineRightIcon,
+	inline: objectInlineIcon
 } ) )();
 
 /**
@@ -271,7 +279,7 @@ function normalizeDefinition( definition: string | Partial<ImageStyleOptionDefin
 	// If an icon is defined as a string and correspond with a name
 	// in default icons, use the default icon provided by the plugin.
 	if ( typeof definition.icon === 'string' ) {
-		definition.icon = DEFAULT_ICONS[ definition.icon ] || definition.icon;
+		definition.icon = DEFAULT_ICONS[ definition.icon ] ? DEFAULT_ICONS[ definition.icon ]() : definition.icon;
 	}
 
 	return definition as ImageStyleOptionDefinition;

--- a/packages/ckeditor5-image/src/imagestyle/utils.ts
+++ b/packages/ckeditor5-image/src/imagestyle/utils.ts
@@ -144,15 +144,29 @@ export const DEFAULT_OPTIONS: Record<string, ImageStyleOptionDefinition> = {
  *
  * There are 7 default icons available: `'full'`, `'left'`, `'inlineLeft'`, `'center'`, `'right'`, `'inlineRight'`, and `'inline'`.
  */
-export const DEFAULT_ICONS: Record<string, () => string> = /* #__PURE__ */ ( () => ( {
-	full: objectFullWidthIcon,
-	left: objectLeftIcon,
-	right: objectRightIcon,
-	center: objectCenterIcon,
-	inlineLeft: objectInlineLeftIcon,
-	inlineRight: objectInlineRightIcon,
-	inline: objectInlineIcon
-} ) )();
+export const DEFAULT_ICONS: Record<string, string> = {
+	get full() {
+		return objectFullWidthIcon();
+	},
+	get left() {
+		return objectLeftIcon();
+	},
+	get right() {
+		return objectRightIcon();
+	},
+	get center() {
+		return objectCenterIcon();
+	},
+	get inlineLeft() {
+		return objectInlineLeftIcon();
+	},
+	get inlineRight() {
+		return objectInlineRightIcon();
+	},
+	get inline() {
+		return objectInlineIcon();
+	}
+};
 
 /**
  * Default drop-downs provided by the plugin that can be referred in the {@link module:image/imageconfig~ImageConfig#toolbar}
@@ -279,7 +293,7 @@ function normalizeDefinition( definition: string | Partial<ImageStyleOptionDefin
 	// If an icon is defined as a string and correspond with a name
 	// in default icons, use the default icon provided by the plugin.
 	if ( typeof definition.icon === 'string' ) {
-		definition.icon = DEFAULT_ICONS[ definition.icon ] ? DEFAULT_ICONS[ definition.icon ]() : definition.icon;
+		definition.icon = DEFAULT_ICONS[ definition.icon ] || definition.icon;
 	}
 
 	return definition as ImageStyleOptionDefinition;

--- a/packages/ckeditor5-image/src/imagetextalternative/imagetextalternativeui.ts
+++ b/packages/ckeditor5-image/src/imagetextalternative/imagetextalternativeui.ts
@@ -15,8 +15,8 @@ import {
 	CssTransitionDisablerMixin,
 	type ViewWithCssTransitionDisabler
 } from 'ckeditor5/src/ui.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { IconTextAlternative } from 'ckeditor5/src/icons.js';
-
 import TextAlternativeFormView, {
 	type TextAlternativeFormViewCancelEvent,
 	type TextAlternativeFormViewSubmitEvent
@@ -24,6 +24,8 @@ import TextAlternativeFormView, {
 import { repositionContextualBalloon, getBalloonPositionData } from '../image/ui/utils.js';
 import type ImageTextAlternativeCommand from './imagetextalternativecommand.js';
 import type ImageUtils from '../imageutils.js';
+
+const textAlternativeIcon = /* #__PURE__ */ registerIcon( 'textAlternative', IconTextAlternative );
 
 /**
  * The image text alternative UI plugin.
@@ -95,7 +97,7 @@ export default class ImageTextAlternativeUI extends Plugin {
 
 			view.set( {
 				label: t( 'Change image text alternative' ),
-				icon: IconTextAlternative,
+				icon: textAlternativeIcon(),
 				tooltip: true
 			} );
 

--- a/packages/ckeditor5-image/src/imagetextalternative/ui/textalternativeformview.ts
+++ b/packages/ckeditor5-image/src/imagetextalternative/ui/textalternativeformview.ts
@@ -18,7 +18,7 @@ import {
 	type InputView,
 	type FocusableView
 } from 'ckeditor5/src/ui.js';
-import { FocusTracker, KeystrokeHandler, type Locale } from 'ckeditor5/src/utils.js';
+import { FocusTracker, KeystrokeHandler, registerIcon, type Locale } from 'ckeditor5/src/utils.js';
 import { IconCancel, IconCheck } from 'ckeditor5/src/icons.js';
 
 import '../../../theme/textalternativeform.css';
@@ -26,6 +26,9 @@ import '../../../theme/textalternativeform.css';
 // See: #8833.
 // eslint-disable-next-line ckeditor5-rules/ckeditor-imports
 import '@ckeditor/ckeditor5-ui/theme/components/responsive-form/responsiveform.css';
+
+const cancelIcon = /* #__PURE__ */ registerIcon( 'cancel', IconCancel );
+const checkIcon = /* #__PURE__ */ registerIcon( 'check', IconCheck );
 
 /**
  * The TextAlternativeFormView class.
@@ -79,10 +82,10 @@ export default class TextAlternativeFormView extends View {
 
 		this.labeledInput = this._createLabeledInputView();
 
-		this.saveButtonView = this._createButton( t( 'Save' ), IconCheck, 'ck-button-save' );
+		this.saveButtonView = this._createButton( t( 'Save' ), checkIcon(), 'ck-button-save' );
 		this.saveButtonView.type = 'submit';
 
-		this.cancelButtonView = this._createButton( t( 'Cancel' ), IconCancel, 'ck-button-cancel', 'cancel' );
+		this.cancelButtonView = this._createButton( t( 'Cancel' ), cancelIcon(), 'ck-button-cancel', 'cancel' );
 
 		this._focusables = new ViewCollection();
 

--- a/packages/ckeditor5-image/src/imageupload/imageuploadui.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadui.ts
@@ -14,9 +14,12 @@ import {
 	type ButtonView,
 	type MenuBarMenuListItemButtonView
 } from 'ckeditor5/src/ui.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { IconImageUpload } from 'ckeditor5/src/icons.js';
 import { createImageTypeRegExp } from './utils.js';
 import type ImageInsertUI from '../imageinsert/imageinsertui.js';
+
+const imageUploadIcon = /* #__PURE__ */ registerIcon( 'imageUpload', IconImageUpload );
 
 /**
  * The image upload button plugin.
@@ -88,7 +91,7 @@ export default class ImageUploadUI extends Plugin {
 			acceptedType: imageTypes.map( type => `image/${ type }` ).join( ',' ),
 			allowMultipleFiles: true,
 			label: t( 'Upload from computer' ),
-			icon: IconImageUpload
+			icon: imageUploadIcon()
 		} );
 
 		view.bind( 'isEnabled' ).to( command );

--- a/packages/ckeditor5-image/tests/imagestyle/utils.js
+++ b/packages/ckeditor5-image/tests/imagestyle/utils.js
@@ -164,7 +164,7 @@ describe( 'ImageStyle utils', () => {
 					for ( const icon in DEFAULT_ICONS ) {
 						const style = { name: 'custom', modelElements: [ 'imageBlock' ], icon };
 
-						expect( normalizeStyles( [ style ] ) ).to.deep.equal( [ { ...style, icon: DEFAULT_ICONS[ icon ]() } ] );
+						expect( normalizeStyles( [ style ] ) ).to.deep.equal( [ { ...style, icon: DEFAULT_ICONS[ icon ] } ] );
 					}
 
 					sinon.assert.notCalled( console.warn );
@@ -232,7 +232,7 @@ describe( 'ImageStyle utils', () => {
 					const normalizedStyles = normalizeStyles( [ style ] );
 
 					expect( normalizedStyles[ 0 ] ).to.not.equal( DEFAULT_OPTIONS.alignLeft );
-					expect( normalizedStyles ).to.deep.equal( [ { ...style, icon: DEFAULT_ICONS.inline() } ] );
+					expect( normalizedStyles ).to.deep.equal( [ { ...style, icon: DEFAULT_ICONS.inline } ] );
 
 					sinon.assert.notCalled( console.warn );
 				} );

--- a/packages/ckeditor5-image/tests/imagestyle/utils.js
+++ b/packages/ckeditor5-image/tests/imagestyle/utils.js
@@ -164,7 +164,7 @@ describe( 'ImageStyle utils', () => {
 					for ( const icon in DEFAULT_ICONS ) {
 						const style = { name: 'custom', modelElements: [ 'imageBlock' ], icon };
 
-						expect( normalizeStyles( [ style ] ) ).to.deep.equal( [ { ...style, icon: DEFAULT_ICONS[ icon ] } ] );
+						expect( normalizeStyles( [ style ] ) ).to.deep.equal( [ { ...style, icon: DEFAULT_ICONS[ icon ]() } ] );
 					}
 
 					sinon.assert.notCalled( console.warn );
@@ -232,7 +232,7 @@ describe( 'ImageStyle utils', () => {
 					const normalizedStyles = normalizeStyles( [ style ] );
 
 					expect( normalizedStyles[ 0 ] ).to.not.equal( DEFAULT_OPTIONS.alignLeft );
-					expect( normalizedStyles ).to.deep.equal( [ { ...style, icon: DEFAULT_ICONS.inline } ] );
+					expect( normalizedStyles ).to.deep.equal( [ { ...style, icon: DEFAULT_ICONS.inline() } ] );
 
 					sinon.assert.notCalled( console.warn );
 				} );

--- a/packages/ckeditor5-indent/src/indentui.ts
+++ b/packages/ckeditor5-indent/src/indentui.ts
@@ -9,7 +9,11 @@
 
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 import { Plugin } from 'ckeditor5/src/core.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { IconIndent, IconOutdent } from 'ckeditor5/src/icons.js';
+
+const indentIcon = /* #__PURE__ */ registerIcon( 'indent', IconIndent );
+const outdentIcon = /* #__PURE__ */ registerIcon( 'outdent', IconOutdent );
 
 /**
  * The indent UI feature.
@@ -42,8 +46,8 @@ export default class IndentUI extends Plugin {
 		const locale = editor.locale;
 		const t = editor.t;
 
-		const localizedIndentIcon = locale.uiLanguageDirection == 'ltr' ? IconIndent : IconOutdent;
-		const localizedOutdentIcon = locale.uiLanguageDirection == 'ltr' ? IconOutdent : IconIndent;
+		const localizedIndentIcon: string = locale.uiLanguageDirection == 'ltr' ? indentIcon() : outdentIcon();
+		const localizedOutdentIcon: string = locale.uiLanguageDirection == 'ltr' ? outdentIcon() : indentIcon();
 
 		this._defineButton( 'indent', t( 'Increase indent' ), localizedIndentIcon );
 		this._defineButton( 'outdent', t( 'Decrease indent' ), localizedOutdentIcon );

--- a/packages/ckeditor5-link/src/linkimageui.ts
+++ b/packages/ckeditor5-link/src/linkimageui.ts
@@ -10,19 +10,15 @@
 import { ButtonView } from 'ckeditor5/src/ui.js';
 import { Plugin } from 'ckeditor5/src/core.js';
 import { IconLink } from 'ckeditor5/src/icons.js';
-import type {
-	DocumentSelection,
-	Selection,
-	ViewDocumentClickEvent
-} from 'ckeditor5/src/engine.js';
-
-import type { ImageUtils } from '@ckeditor/ckeditor5-image';
-
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import LinkUI from './linkui.js';
 import LinkEditing from './linkediting.js';
+import { LINK_KEYSTROKE } from './utils.js';
+import type { ImageUtils } from '@ckeditor/ckeditor5-image';
+import type { DocumentSelection, Selection, ViewDocumentClickEvent } from 'ckeditor5/src/engine.js';
 import type LinkCommand from './linkcommand.js';
 
-import { LINK_KEYSTROKE } from './utils.js';
+const linkIcon = /* #__PURE__ */ registerIcon( 'link', IconLink );
 
 /**
  * The link image UI plugin.
@@ -92,7 +88,7 @@ export default class LinkImageUI extends Plugin {
 			button.set( {
 				isEnabled: true,
 				label: t( 'Link image' ),
-				icon: IconLink,
+				icon: linkIcon(),
 				keystroke: LINK_KEYSTROKE,
 				tooltip: true,
 				isToggleable: true

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -9,6 +9,7 @@
 
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
 import { IconLink } from 'ckeditor5/src/icons.js';
+import { registerIcon, type PositionOptions } from 'ckeditor5/src/utils.js';
 import {
 	ClickObserver,
 	type ViewAttributeElement,
@@ -24,19 +25,19 @@ import {
 	MenuBarMenuListItemButtonView,
 	type ViewWithCssTransitionDisabler
 } from 'ckeditor5/src/ui.js';
-import type { PositionOptions } from 'ckeditor5/src/utils.js';
 import { isWidget } from 'ckeditor5/src/widget.js';
-
 import LinkFormView, { type LinkFormValidatorCallback } from './ui/linkformview.js';
 import LinkActionsView from './ui/linkactionsview.js';
-import type LinkCommand from './linkcommand.js';
-import type UnlinkCommand from './unlinkcommand.js';
 import {
 	addLinkProtocolIfApplicable,
 	isLinkElement,
 	createBookmarkCallbacks,
 	LINK_KEYSTROKE
 } from './utils.js';
+import type LinkCommand from './linkcommand.js';
+import type UnlinkCommand from './unlinkcommand.js';
+
+const linkIcon = /* #__PURE__ */ registerIcon( 'link', IconLink );
 
 const VISUAL_SELECTION_MARKER_NAME = 'link-ui';
 
@@ -300,7 +301,7 @@ export default class LinkUI extends Plugin {
 
 		view.set( {
 			label: t( 'Link' ),
-			icon: IconLink,
+			icon: linkIcon(),
 			keystroke: LINK_KEYSTROKE,
 			isToggleable: true
 		} );

--- a/packages/ckeditor5-link/src/ui/linkactionsview.ts
+++ b/packages/ckeditor5-link/src/ui/linkactionsview.ts
@@ -9,16 +9,17 @@
 
 import { IconUnlink, IconPencil } from 'ckeditor5/src/icons.js';
 import { ButtonView, View, ViewCollection, FocusCycler, type FocusableView } from 'ckeditor5/src/ui.js';
-import { FocusTracker, KeystrokeHandler, type LocaleTranslate, type Locale } from 'ckeditor5/src/utils.js';
-
+import { FocusTracker, KeystrokeHandler, registerIcon, type LocaleTranslate, type Locale } from 'ckeditor5/src/utils.js';
 import { ensureSafeUrl, openLink } from '../utils.js';
+import type { LinkConfig } from '../linkconfig.js';
 
 // See: #8833.
 // eslint-disable-next-line ckeditor5-rules/ckeditor-imports
 import '@ckeditor/ckeditor5-ui/theme/components/responsive-form/responsiveform.css';
 import '../../theme/linkactions.css';
 
-import type { LinkConfig } from '../linkconfig.js';
+const unlinkIcon = /* #__PURE__ */ registerIcon( 'unlink', IconUnlink );
+const pencilIcon = /* #__PURE__ */ registerIcon( 'pencil', IconPencil );
 
 /**
  * The link actions view class. This view displays the link preview, allows
@@ -83,8 +84,8 @@ export default class LinkActionsView extends View {
 
 		this._options = options;
 		this.previewButtonView = this._createPreviewButton();
-		this.unlinkButtonView = this._createButton( t( 'Unlink' ), IconUnlink, 'unlink' );
-		this.editButtonView = this._createButton( t( 'Edit link' ), IconPencil, 'edit' );
+		this.unlinkButtonView = this._createButton( t( 'Unlink' ), unlinkIcon(), 'unlink' );
+		this.editButtonView = this._createButton( t( 'Edit link' ), pencilIcon(), 'edit' );
 
 		this.set( 'href', undefined );
 

--- a/packages/ckeditor5-link/src/ui/linkformview.ts
+++ b/packages/ckeditor5-link/src/ui/linkformview.ts
@@ -22,11 +22,11 @@ import {
 import {
 	FocusTracker,
 	KeystrokeHandler,
+	registerIcon,
 	type Collection,
 	type Locale
 } from 'ckeditor5/src/utils.js';
 import { IconCancel, IconCheck } from 'ckeditor5/src/icons.js';
-
 import type LinkCommand from '../linkcommand.js';
 import type ManualDecorator from '../utils/manualdecorator.js';
 
@@ -34,6 +34,9 @@ import type ManualDecorator from '../utils/manualdecorator.js';
 // eslint-disable-next-line ckeditor5-rules/ckeditor-imports
 import '@ckeditor/ckeditor5-ui/theme/components/responsive-form/responsiveform.css';
 import '../../theme/linkform.css';
+
+const cancelIcon = /* #__PURE__ */ registerIcon( 'cancel', IconCancel );
+const checkIcon = /* #__PURE__ */ registerIcon( 'check', IconCheck );
 
 /**
  * The link form view controller class.
@@ -109,9 +112,9 @@ export default class LinkFormView extends View {
 
 		this._validators = validators;
 		this.urlInputView = this._createUrlInput();
-		this.saveButtonView = this._createButton( t( 'Save' ), IconCheck, 'ck-button-save' );
+		this.saveButtonView = this._createButton( t( 'Save' ), checkIcon(), 'ck-button-save' );
 		this.saveButtonView.type = 'submit';
-		this.cancelButtonView = this._createButton( t( 'Cancel' ), IconCancel, 'ck-button-cancel', 'cancel' );
+		this.cancelButtonView = this._createButton( t( 'Cancel' ), cancelIcon(), 'ck-button-cancel', 'cancel' );
 		this._manualDecoratorSwitches = this._createManualDecoratorSwitches( linkCommand );
 		this.children = this._createFormChildren( linkCommand.manualDecorators );
 

--- a/packages/ckeditor5-list/src/list/listui.ts
+++ b/packages/ckeditor5-list/src/list/listui.ts
@@ -7,9 +7,13 @@
  * @module list/list/listui
  */
 
-import { createUIComponents } from './utils.js';
 import { Plugin } from 'ckeditor5/src/core.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { IconBulletedList, IconNumberedList } from 'ckeditor5/src/icons.js';
+import { createUIComponents } from './utils.js';
+
+const bulletedListIcon = /* #__PURE__ */ registerIcon( 'bulletedList', IconBulletedList );
+const numberedListIcon = /* #__PURE__ */ registerIcon( 'numberedList', IconNumberedList );
 
 /**
  * The list UI feature. It introduces the `'numberedList'` and `'bulletedList'` buttons that
@@ -38,12 +42,12 @@ export default class ListUI extends Plugin {
 
 		// Create button numberedList.
 		if ( !this.editor.ui.componentFactory.has( 'numberedList' ) ) {
-			createUIComponents( this.editor, 'numberedList', t( 'Numbered List' ), IconNumberedList );
+			createUIComponents( this.editor, 'numberedList', t( 'Numbered List' ), numberedListIcon() );
 		}
 
 		// Create button bulletedList.
 		if ( !this.editor.ui.componentFactory.has( 'bulletedList' ) ) {
-			createUIComponents( this.editor, 'bulletedList', t( 'Bulleted List' ), IconBulletedList );
+			createUIComponents( this.editor, 'bulletedList', t( 'Bulleted List' ), bulletedListIcon() );
 		}
 	}
 }

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
@@ -8,6 +8,7 @@
  */
 
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
+import { registerIcon, type Locale } from 'ckeditor5/src/utils.js';
 import {
 	IconBulletedList,
 	IconNumberedList,
@@ -29,22 +30,29 @@ import {
 	MenuBarMenuView,
 	type DropdownView
 } from 'ckeditor5/src/ui.js';
-
-import type { Locale } from 'ckeditor5/src/utils.js';
-
+import { getNormalizedConfig, type NormalizedListPropertiesConfig } from './utils/config.js';
 import ListPropertiesView from './ui/listpropertiesview.js';
-
 import type LegacyListStyleCommand from '../legacylistproperties/legacyliststylecommand.js';
 import type ListStyleCommand from '../listproperties/liststylecommand.js';
 import type LegacyListStartCommand from '../legacylistproperties/legacyliststartcommand.js';
 import type ListStartCommand from '../listproperties/liststartcommand.js';
 import type LegacyListReversedCommand from '../legacylistproperties/legacylistreversedcommand.js';
 import type ListReversedCommand from '../listproperties/listreversedcommand.js';
-
-import { getNormalizedConfig, type NormalizedListPropertiesConfig } from './utils/config.js';
-import { type ListPropertiesStyleListType } from '../listconfig.js';
+import type { ListPropertiesStyleListType } from '../listconfig.js';
 
 import '../../theme/liststyles.css';
+
+const bulletedListIcon = /* #__PURE__ */ registerIcon( 'bulletedList', IconBulletedList );
+const numberedListIcon = /* #__PURE__ */ registerIcon( 'numberedList', IconNumberedList );
+const listStyleCircleIcon = /* #__PURE__ */ registerIcon( 'listStyleCircle', IconListStyleCircle );
+const listStyleDecimalIcon = /* #__PURE__ */ registerIcon( 'listStyleDecimal', IconListStyleDecimal );
+const listStyleDecimalLeadingZeroIcon = /* #__PURE__ */ registerIcon( 'listStyleDecimalLeadingZero ', IconListStyleDecimalLeadingZero );
+const listStyleDiscIcon = /* #__PURE__ */ registerIcon( 'listStyleDisc', IconListStyleDisc );
+const listStyleLowerLatinIcon = /* #__PURE__ */ registerIcon( 'listStyleLowerLatin', IconListStyleLowerLatin );
+const listStyleLowerRomanIcon = /* #__PURE__ */ registerIcon( 'listStyleLowerRoman', IconListStyleLowerRoman );
+const listStyleSquareIcon = /* #__PURE__ */ registerIcon( 'listStyleSquare', IconListStyleSquare );
+const listStyleUpperLatinIcon = /* #__PURE__ */ registerIcon( 'listStyleUpperLatin', IconListStyleUpperLatin );
+const listStyleUpperRomanIcon = /* #__PURE__ */ registerIcon( 'listStyleUpperRoman', IconListStyleUpperRoman );
 
 /**
  * The list properties UI plugin. It introduces the extended `'bulletedList'` and `'numberedList'` toolbar
@@ -84,19 +92,19 @@ export default class ListPropertiesUI extends Plugin {
 					label: t( 'Toggle the disc list style' ),
 					tooltip: t( 'Disc' ),
 					type: 'disc',
-					icon: IconListStyleDisc
+					icon: listStyleDiscIcon()
 				},
 				{
 					label: t( 'Toggle the circle list style' ),
 					tooltip: t( 'Circle' ),
 					type: 'circle',
-					icon: IconListStyleCircle
+					icon: listStyleCircleIcon()
 				},
 				{
 					label: t( 'Toggle the square list style' ),
 					tooltip: t( 'Square' ),
 					type: 'square',
-					icon: IconListStyleSquare
+					icon: listStyleSquareIcon()
 				}
 			];
 			const buttonLabel = t( 'Bulleted List' );
@@ -108,7 +116,7 @@ export default class ListPropertiesUI extends Plugin {
 				normalizedConfig,
 				parentCommandName: commandName,
 				buttonLabel,
-				buttonIcon: IconBulletedList,
+				buttonIcon: bulletedListIcon(),
 				styleGridAriaLabel,
 				styleDefinitions
 			} ) );
@@ -133,37 +141,37 @@ export default class ListPropertiesUI extends Plugin {
 					label: t( 'Toggle the decimal list style' ),
 					tooltip: t( 'Decimal' ),
 					type: 'decimal',
-					icon: IconListStyleDecimal
+					icon: listStyleDecimalIcon()
 				},
 				{
 					label: t( 'Toggle the decimal with leading zero list style' ),
 					tooltip: t( 'Decimal with leading zero' ),
 					type: 'decimal-leading-zero',
-					icon: IconListStyleDecimalLeadingZero
+					icon: listStyleDecimalLeadingZeroIcon()
 				},
 				{
 					label: t( 'Toggle the lower–roman list style' ),
 					tooltip: t( 'Lower–roman' ),
 					type: 'lower-roman',
-					icon: IconListStyleLowerRoman
+					icon: listStyleLowerRomanIcon()
 				},
 				{
 					label: t( 'Toggle the upper–roman list style' ),
 					tooltip: t( 'Upper-roman' ),
 					type: 'upper-roman',
-					icon: IconListStyleUpperRoman
+					icon: listStyleUpperRomanIcon()
 				},
 				{
 					label: t( 'Toggle the lower–latin list style' ),
 					tooltip: t( 'Lower-latin' ),
 					type: 'lower-latin',
-					icon: IconListStyleLowerLatin
+					icon: listStyleLowerLatinIcon()
 				},
 				{
 					label: t( 'Toggle the upper–latin list style' ),
 					tooltip: t( 'Upper-latin' ),
 					type: 'upper-latin',
-					icon: IconListStyleUpperLatin
+					icon: listStyleUpperLatinIcon()
 				}
 			];
 			const buttonLabel = t( 'Numbered List' );
@@ -175,7 +183,7 @@ export default class ListPropertiesUI extends Plugin {
 				normalizedConfig,
 				parentCommandName: commandName,
 				buttonLabel,
-				buttonIcon: IconNumberedList,
+				buttonIcon: numberedListIcon(),
 				styleGridAriaLabel,
 				styleDefinitions
 			} ) );
@@ -474,7 +482,7 @@ function getMenuBarStylesMenuCreator(
 
 		menuView.buttonView.set( {
 			label: buttonLabel,
-			icon: parentCommandName === 'bulletedList' ? IconBulletedList : IconNumberedList
+			icon: parentCommandName === 'bulletedList' ? bulletedListIcon() : numberedListIcon()
 		} );
 		menuView.panelView.children.add( listPropertiesView );
 		menuView.bind( 'isEnabled' ).to( listCommand, 'isEnabled' );

--- a/packages/ckeditor5-list/src/todolist/todolistui.ts
+++ b/packages/ckeditor5-list/src/todolist/todolistui.ts
@@ -7,9 +7,12 @@
  * @module list/todolist/todolistui
  */
 
-import { createUIComponents } from '../list/utils.js';
 import { Plugin } from 'ckeditor5/src/core.js';
 import { IconTodoList } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
+import { createUIComponents } from '../list/utils.js';
+
+const todoListIcon = /* #__PURE__ */ registerIcon( 'todoList', IconTodoList );
 
 /**
  * The to-do list UI feature. It introduces the `'todoList'` button that
@@ -36,6 +39,6 @@ export default class TodoListUI extends Plugin {
 	public init(): void {
 		const t = this.editor.t;
 
-		createUIComponents( this.editor, 'todoList', t( 'To-do List' ), IconTodoList );
+		createUIComponents( this.editor, 'todoList', t( 'To-do List' ), todoListIcon() );
 	}
 }

--- a/packages/ckeditor5-media-embed/src/mediaembedui.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedui.ts
@@ -9,12 +9,13 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import { IconMedia } from 'ckeditor5/src/icons.js';
+import { registerIcon, type LocaleTranslate } from 'ckeditor5/src/utils.js';
 import { ButtonView, CssTransitionDisablerMixin, MenuBarMenuListItemButtonView, Dialog } from 'ckeditor5/src/ui.js';
-
 import MediaFormView from './ui/mediaformview.js';
 import MediaEmbedEditing from './mediaembedediting.js';
-import type { LocaleTranslate } from 'ckeditor5/src/utils.js';
 import type MediaRegistry from './mediaregistry.js';
+
+const mediaIcon = /* #__PURE__ */ registerIcon( 'media', IconMedia );
 
 /**
  * The media embed UI plugin.
@@ -78,7 +79,7 @@ export default class MediaEmbedUI extends Plugin {
 		const command = editor.commands.get( 'mediaEmbed' )!;
 		const dialogPlugin = this.editor.plugins.get( 'Dialog' );
 
-		buttonView.icon = IconMedia;
+		buttonView.icon = mediaIcon();
 
 		buttonView.bind( 'isEnabled' ).to( command, 'isEnabled' );
 

--- a/packages/ckeditor5-media-embed/src/mediaregistry.ts
+++ b/packages/ckeditor5-media-embed/src/mediaregistry.ts
@@ -9,13 +9,12 @@
 
 import { IconView, Template } from 'ckeditor5/src/ui.js';
 import { IconMediaPlaceholder } from 'ckeditor5/src/icons.js';
-import { logWarning, toArray, type Locale } from 'ckeditor5/src/utils.js';
-
+import { logWarning, toArray, registerIcon, type Locale } from 'ckeditor5/src/utils.js';
 import type { DowncastWriter, ViewElement } from 'ckeditor5/src/engine.js';
 import type { MediaEmbedConfig, MediaEmbedProvider } from './mediaembedconfig.js';
 import type { MediaOptions } from './utils.js';
 
-const mediaPlaceholderIconViewBox = '0 0 64 42';
+const mediaPlaceholderIcon = /* #__PURE__ */ registerIcon( 'mediaPlaceholder', IconMediaPlaceholder );
 
 /**
  * A bridge between the raw media content provider definitions and the editor view content.
@@ -255,10 +254,11 @@ class Media {
 	 * Returns the placeholder HTML when the media has no content preview.
 	 */
 	private _getPlaceholderHtml(): string {
+		const mediaPlaceholderIconViewBox = '0 0 64 42';
 		const icon = new IconView();
 		const t = this._locale.t;
 
-		icon.content = IconMediaPlaceholder;
+		icon.content = mediaPlaceholderIcon();
 		icon.viewBox = mediaPlaceholderIconViewBox;
 
 		const placeholder = new Template( {

--- a/packages/ckeditor5-page-break/package.json
+++ b/packages/ckeditor5-page-break/package.json
@@ -16,6 +16,7 @@
     "@ckeditor/ckeditor5-core": "44.1.0",
     "@ckeditor/ckeditor5-icons": "0.0.1",
     "@ckeditor/ckeditor5-ui": "44.1.0",
+    "@ckeditor/ckeditor5-utils": "44.1.0",
     "@ckeditor/ckeditor5-widget": "44.1.0",
     "ckeditor5": "44.1.0"
   },
@@ -28,7 +29,6 @@
     "@ckeditor/ckeditor5-image": "44.1.0",
     "@ckeditor/ckeditor5-paragraph": "44.1.0",
     "@ckeditor/ckeditor5-theme-lark": "44.1.0",
-    "@ckeditor/ckeditor5-utils": "44.1.0",
     "typescript": "5.0.4",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4"

--- a/packages/ckeditor5-page-break/src/pagebreakui.ts
+++ b/packages/ckeditor5-page-break/src/pagebreakui.ts
@@ -9,7 +9,10 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import { IconPageBreak } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
+
+const pageBreakIcon = /* #__PURE__ */ registerIcon( 'pageBreak', IconPageBreak );
 
 /**
  * The page break UI plugin.
@@ -61,7 +64,7 @@ export default class PageBreakUI extends Plugin {
 
 		view.set( {
 			label: t( 'Page break' ),
-			icon: IconPageBreak
+			icon: pageBreakIcon()
 		} );
 
 		view.bind( 'isEnabled' ).to( command, 'isEnabled' );

--- a/packages/ckeditor5-paragraph/src/paragraphbuttonui.ts
+++ b/packages/ckeditor5-paragraph/src/paragraphbuttonui.ts
@@ -10,9 +10,11 @@
 import { Plugin } from '@ckeditor/ckeditor5-core';
 import { ButtonView } from '@ckeditor/ckeditor5-ui';
 import { IconParagraph } from '@ckeditor/ckeditor5-icons';
-
+import { registerIcon } from '@ckeditor/ckeditor5-utils';
 import Paragraph from './paragraph.js';
 import type ParagraphCommand from './paragraphcommand.js';
+
+const paragraphIcon = /* #__PURE__ */ registerIcon( 'paragraph', IconParagraph );
 
 /**
  * This plugin defines the `'paragraph'` button. It can be used together with
@@ -51,7 +53,7 @@ export default class ParagraphButtonUI extends Plugin {
 			const command: ParagraphCommand = editor.commands.get( 'paragraph' )!;
 
 			view.label = t( 'Paragraph' );
-			view.icon = IconParagraph;
+			view.icon = paragraphIcon();
 			view.tooltip = true;
 			view.isToggleable = true;
 			view.bind( 'isEnabled' ).to( command );

--- a/packages/ckeditor5-remove-format/src/removeformatui.ts
+++ b/packages/ckeditor5-remove-format/src/removeformatui.ts
@@ -9,9 +9,11 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import { IconRemoveFormat } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
-
 import type RemoveFormatCommand from './removeformatcommand.js';
+
+const removeFormatIcon = /* #__PURE__ */ registerIcon( 'removeFormat', IconRemoveFormat );
 
 const REMOVE_FORMAT = 'removeFormat';
 
@@ -65,7 +67,7 @@ export default class RemoveFormatUI extends Plugin {
 
 		view.set( {
 			label: t( 'Remove Format' ),
-			icon: IconRemoveFormat
+			icon: removeFormatIcon()
 		} );
 
 		view.bind( 'isEnabled' ).to( command, 'isEnabled' );

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
@@ -9,6 +9,7 @@
 
 import { Plugin, type Command } from 'ckeditor5/src/core.js';
 import { IconContentLock } from 'ckeditor5/src/icons.js';
+import { registerIcon, Collection } from 'ckeditor5/src/utils.js';
 import {
 	ViewModel,
 	createDropdown,
@@ -17,7 +18,8 @@ import {
 	type ButtonExecuteEvent,
 	type ListDropdownItemDefinition, MenuBarMenuView, MenuBarMenuListView, MenuBarMenuListItemView
 } from 'ckeditor5/src/ui.js';
-import { Collection } from 'ckeditor5/src/utils.js';
+
+const contentLockIcon = /* #__PURE__ */ registerIcon( 'contentLock', IconContentLock );
 
 /**
  * The restricted editing mode UI feature.
@@ -61,7 +63,7 @@ export default class RestrictedEditingModeUI extends Plugin {
 
 			dropdownView.buttonView.set( {
 				label: t( 'Navigate editable regions' ),
-				icon: IconContentLock,
+				icon: contentLockIcon(),
 				tooltip: true,
 				isEnabled: true,
 				isOn: false
@@ -87,7 +89,7 @@ export default class RestrictedEditingModeUI extends Plugin {
 
 			menuView.buttonView.set( {
 				label: t( 'Navigate editable regions' ),
-				icon: IconContentLock
+				icon: contentLockIcon()
 			} );
 
 			menuView.panelView.children.add( listView );

--- a/packages/ckeditor5-restricted-editing/src/standardeditingmodeui.ts
+++ b/packages/ckeditor5-restricted-editing/src/standardeditingmodeui.ts
@@ -9,7 +9,10 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import { IconContentUnlock } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
+
+const contentUnlockIcon = /* #__PURE__ */ registerIcon( 'contentUnlock', IconContentUnlock );
 
 /**
  * The standard editing mode UI feature.
@@ -63,7 +66,7 @@ export default class StandardEditingModeUI extends Plugin {
 		const view = new ButtonClass( locale ) as InstanceType<T>;
 		const t = locale.t;
 
-		view.icon = IconContentUnlock;
+		view.icon = contentUnlockIcon();
 
 		view.bind( 'isOn', 'isEnabled' ).to( command, 'value', 'isEnabled' );
 		view.bind( 'label' ).to( command, 'value', value => {

--- a/packages/ckeditor5-select-all/src/selectallui.ts
+++ b/packages/ckeditor5-select-all/src/selectallui.ts
@@ -9,7 +9,10 @@
 
 import { Plugin } from '@ckeditor/ckeditor5-core';
 import { IconSelectAll } from '@ckeditor/ckeditor5-icons';
+import { registerIcon } from '@ckeditor/ckeditor5-utils';
 import { ButtonView, MenuBarMenuListItemButtonView } from '@ckeditor/ckeditor5-ui';
+
+const selectAllIcon = /* #__PURE__ */ registerIcon( 'selectAll', IconSelectAll );
 
 /**
  * The select all UI feature.
@@ -66,7 +69,7 @@ export default class SelectAllUI extends Plugin {
 
 		view.set( {
 			label: t( 'Select all' ),
-			icon: IconSelectAll,
+			icon: selectAllIcon(),
 			keystroke: 'Ctrl+A'
 		} );
 

--- a/packages/ckeditor5-show-blocks/package.json
+++ b/packages/ckeditor5-show-blocks/package.json
@@ -16,6 +16,7 @@
     "@ckeditor/ckeditor5-core": "44.1.0",
     "@ckeditor/ckeditor5-icons": "0.0.1",
     "@ckeditor/ckeditor5-ui": "44.1.0",
+    "@ckeditor/ckeditor5-utils": "44.1.0",
     "ckeditor5": "44.1.0"
   },
   "devDependencies": {
@@ -29,7 +30,6 @@
     "@ckeditor/ckeditor5-paragraph": "44.1.0",
     "@ckeditor/ckeditor5-theme-lark": "44.1.0",
     "@ckeditor/ckeditor5-heading": "44.1.0",
-    "@ckeditor/ckeditor5-utils": "44.1.0",
     "@ckeditor/ckeditor5-image": "44.1.0",
     "@ckeditor/ckeditor5-easy-image": "44.1.0",
     "@ckeditor/ckeditor5-cloud-services": "44.1.0",

--- a/packages/ckeditor5-show-blocks/src/showblocksui.ts
+++ b/packages/ckeditor5-show-blocks/src/showblocksui.ts
@@ -9,9 +9,12 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import { IconShowBlocks } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 
 import '../theme/showblocks.css';
+
+const showBlocksIcon = /* #__PURE__ */ registerIcon( 'showBlocks', IconShowBlocks );
 
 /**
  * The UI plugin of the show blocks feature.
@@ -45,7 +48,7 @@ export default class ShowBlocksUI extends Plugin {
 
 			buttonView.set( {
 				tooltip: true,
-				icon: IconShowBlocks
+				icon: showBlocksIcon()
 			} );
 
 			return buttonView;

--- a/packages/ckeditor5-source-editing/src/sourceediting.ts
+++ b/packages/ckeditor5-source-editing/src/sourceediting.ts
@@ -12,10 +12,12 @@
 import { Plugin, PendingActions, type Editor } from 'ckeditor5/src/core.js';
 import { IconSourceEditing } from 'ckeditor5/src/icons.js';
 import { ButtonView, MenuBarMenuListItemButtonView, type Dialog } from 'ckeditor5/src/ui.js';
-import { CKEditorError, createElement, ElementReplacer } from 'ckeditor5/src/utils.js';
+import { CKEditorError, createElement, ElementReplacer, registerIcon } from 'ckeditor5/src/utils.js';
 import { formatHtml } from './utils/formathtml.js';
 
 import '../theme/sourceediting.css';
+
+const sourceEditingIcon = /* #__PURE__ */ registerIcon( 'sourceEditing', IconSourceEditing );
 
 const COMMAND_FORCE_DISABLE_ID = 'SourceEditingMode';
 
@@ -99,7 +101,7 @@ export default class SourceEditing extends Plugin {
 
 			buttonView.set( {
 				label: t( 'Source' ),
-				icon: IconSourceEditing,
+				icon: sourceEditingIcon(),
 				tooltip: true,
 				class: 'ck-source-editing-button'
 			} );

--- a/packages/ckeditor5-special-characters/src/specialcharacters.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharacters.ts
@@ -11,7 +11,7 @@ import { Plugin, type Editor } from 'ckeditor5/src/core.js';
 import { Typing } from 'ckeditor5/src/typing.js';
 import { IconSpecialCharacters } from 'ckeditor5/src/icons.js';
 import { ButtonView, MenuBarMenuListItemButtonView, DialogViewPosition, Dialog } from 'ckeditor5/src/ui.js';
-import { CKEditorError, type Locale } from 'ckeditor5/src/utils.js';
+import { CKEditorError, registerIcon, type Locale } from 'ckeditor5/src/utils.js';
 import CharacterGridView, {
 	type CharacterGridViewExecuteEvent,
 	type CharacterGridViewTileFocusEvent,
@@ -19,9 +19,11 @@ import CharacterGridView, {
 } from './ui/charactergridview.js';
 import CharacterInfoView from './ui/characterinfoview.js';
 import SpecialCharactersView from './ui/specialcharactersview.js';
+import SpecialCharactersCategoriesView from './ui/specialcharacterscategoriesview.js';
 
 import '../theme/specialcharacters.css';
-import SpecialCharactersCategoriesView from './ui/specialcharacterscategoriesview.js';
+
+const specialCharactersIcon = /* #__PURE__ */ registerIcon( 'specialCharacters', IconSpecialCharacters );
 
 const ALL_SPECIAL_CHARACTERS_GROUP = 'All';
 
@@ -265,7 +267,7 @@ export default class SpecialCharacters extends Plugin {
 
 		buttonView.set( {
 			label: t( 'Special characters' ),
-			icon: IconSpecialCharacters,
+			icon: specialCharactersIcon(),
 			isToggleable: true
 		} );
 

--- a/packages/ckeditor5-table/src/tablecaption/tablecaptionui.ts
+++ b/packages/ckeditor5-table/src/tablecaption/tablecaptionui.ts
@@ -9,9 +9,11 @@
 import { Plugin } from 'ckeditor5/src/core.js';
 import { ButtonView } from 'ckeditor5/src/ui.js';
 import { IconCaption } from 'ckeditor5/src/icons.js';
+import { registerIcon } from 'ckeditor5/src/utils.js';
+import { getCaptionFromModelSelection } from './utils.js';
 import type ToggleTableCaptionCommand from './toggletablecaptioncommand.js';
 
-import { getCaptionFromModelSelection } from './utils.js';
+const captionIcon = /* #__PURE__ */ registerIcon( 'caption', IconCaption );
 
 /**
   * The table caption UI plugin. It introduces the `'toggleTableCaption'` UI button.
@@ -44,7 +46,7 @@ export default class TableCaptionUI extends Plugin {
 			const view = new ButtonView( locale );
 
 			view.set( {
-				icon: IconCaption,
+				icon: captionIcon(),
 				tooltip: true,
 				isToggleable: true
 			} );

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesui.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesui.ts
@@ -7,8 +7,10 @@
  * @module table/tablecellproperties/tablecellpropertiesui
  */
 
+import { debounce } from 'lodash-es';
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
 import { IconTableCellProperties } from 'ckeditor5/src/icons.js';
+import { registerIcon, type GetCallback, type ObservableChangeEvent } from 'ckeditor5/src/utils.js';
 import {
 	ButtonView,
 	clickOutsideHandler,
@@ -17,8 +19,6 @@ import {
 	normalizeColorOptions,
 	type View
 } from 'ckeditor5/src/ui.js';
-import type { Batch } from 'ckeditor5/src/engine.js';
-
 import TableCellPropertiesView from './ui/tablecellpropertiesview.js';
 import {
 	colorFieldValidator,
@@ -28,15 +28,13 @@ import {
 	lengthFieldValidator,
 	lineWidthFieldValidator
 } from '../utils/ui/table-properties.js';
-import { debounce } from 'lodash-es';
 import { getTableWidgetAncestor } from '../utils/ui/widget.js';
 import { getBalloonCellPositionData, repositionContextualBalloon } from '../utils/ui/contextualballoon.js';
 import { getNormalizedDefaultCellProperties, type NormalizedDefaultProperties } from '../utils/table-properties.js';
-import type { GetCallback, ObservableChangeEvent } from 'ckeditor5/src/utils.js';
-
+import type { Batch } from 'ckeditor5/src/engine.js';
 import type TableCellBorderStyleCommand from './commands/tablecellborderstylecommand.js';
 
-const ERROR_TEXT_TIMEOUT = 500;
+const tableCellPropertiesIcon = /* #__PURE__ */ registerIcon( 'tableCellProperties', IconTableCellProperties );
 
 // Map of view properties and related commands.
 const propertyToCommandMap = {
@@ -144,7 +142,7 @@ export default class TableCellPropertiesUI extends Plugin {
 
 			view.set( {
 				label: t( 'Cell properties' ),
-				icon: IconTableCellProperties,
+				icon: tableCellPropertiesIcon(),
 				tooltip: true
 			} );
 
@@ -442,6 +440,7 @@ export default class TableCellPropertiesUI extends Plugin {
 			errorText: string;
 		}
 	): GetCallback<ObservableChangeEvent<string>> {
+		const ERROR_TEXT_TIMEOUT = 500;
 		const { commandName, viewField, validator, errorText } = options;
 		const setErrorTextDebounced = debounce( () => {
 			viewField.errorText = errorText;

--- a/packages/ckeditor5-table/src/tablecellproperties/ui/tablecellpropertiesview.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/ui/tablecellpropertiesview.ts
@@ -25,6 +25,7 @@ import {
 	type ColorPickerConfig
 } from 'ckeditor5/src/ui.js';
 import {
+	registerIcon,
 	KeystrokeHandler,
 	FocusTracker,
 	type Locale,
@@ -41,7 +42,6 @@ import {
 	IconCancel,
 	IconCheck
 } from 'ckeditor5/src/icons.js';
-
 import {
 	fillToolbar,
 	getBorderStyleDefinitions,
@@ -55,6 +55,16 @@ import type { TableCellPropertiesOptions } from '../../tableconfig.js';
 import '../../../theme/form.css';
 import '../../../theme/tableform.css';
 import '../../../theme/tablecellproperties.css';
+
+const alignBottomIcon = /* #__PURE__ */ registerIcon( 'alignBottom', IconAlignBottom );
+const alignCenterIcon = /* #__PURE__ */ registerIcon( 'alignCenter', IconAlignCenter );
+const alignJustifyIcon = /* #__PURE__ */ registerIcon( 'alignJustify', IconAlignJustify );
+const alignLeftIcon = /* #__PURE__ */ registerIcon( 'alignLeft', IconAlignLeft );
+const alignMiddleIcon = /* #__PURE__ */ registerIcon( 'alignMiddle', IconAlignMiddle );
+const alignRightIcon = /* #__PURE__ */ registerIcon( 'alignRight', IconAlignRight );
+const alignTopIcon = /* #__PURE__ */ registerIcon( 'alignTop', IconAlignTop );
+const cancelIcon = /* #__PURE__ */ registerIcon( 'cancel', IconCancel );
+const checkIcon = /* #__PURE__ */ registerIcon( 'check', IconCheck );
 
 export interface TableCellPropertiesViewOptions {
 	borderColors: Array<NormalizedColorOption>;
@@ -707,13 +717,13 @@ export default class TableCellPropertiesView extends View {
 		const alignmentLabel = new LabelView( locale );
 
 		const ALIGNMENT_ICONS = {
-			left: IconAlignLeft,
-			center: IconAlignCenter,
-			right: IconAlignRight,
-			justify: IconAlignJustify,
-			top: IconAlignTop,
-			middle: IconAlignMiddle,
-			bottom: IconAlignBottom
+			left: alignLeftIcon(),
+			center: alignCenterIcon(),
+			right: alignRightIcon(),
+			justify: alignJustifyIcon(),
+			top: alignTopIcon(),
+			middle: alignMiddleIcon(),
+			bottom: alignBottomIcon()
 		};
 
 		alignmentLabel.text = t( 'Table cell text alignment' );
@@ -794,7 +804,7 @@ export default class TableCellPropertiesView extends View {
 
 		saveButtonView.set( {
 			label: t( 'Save' ),
-			icon: IconCheck,
+			icon: checkIcon(),
 			class: 'ck-button-save',
 			type: 'submit',
 			withText: true
@@ -806,7 +816,7 @@ export default class TableCellPropertiesView extends View {
 
 		cancelButtonView.set( {
 			label: t( 'Cancel' ),
-			icon: IconCancel,
+			icon: cancelIcon(),
 			class: 'ck-button-cancel',
 			withText: true
 		} );

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesui.ts
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesui.ts
@@ -7,8 +7,10 @@
  * @module table/tableproperties/tablepropertiesui
  */
 
+import { debounce } from 'lodash-es';
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
 import { IconTableProperties } from 'ckeditor5/src/icons.js';
+import { registerIcon, type EventInfo, type ObservableChangeEvent } from 'ckeditor5/src/utils.js';
 import {
 	ButtonView,
 	ContextualBalloon,
@@ -17,9 +19,6 @@ import {
 	normalizeColorOptions,
 	type LabeledFieldView
 } from 'ckeditor5/src/ui.js';
-
-import { debounce } from 'lodash-es';
-
 import TablePropertiesView from './ui/tablepropertiesview.js';
 import {
 	colorFieldValidator,
@@ -33,11 +32,9 @@ import { getSelectionAffectedTableWidget } from '../utils/ui/widget.js';
 import { getBalloonTablePositionData, repositionContextualBalloon } from '../utils/ui/contextualballoon.js';
 import { getNormalizedDefaultTableProperties, type NormalizedDefaultProperties } from '../utils/table-properties.js';
 import type { Batch } from 'ckeditor5/src/engine.js';
-import type { EventInfo, ObservableChangeEvent } from 'ckeditor5/src/utils.js';
-
 import type TableBorderStyleCommand from './commands/tableborderstylecommand.js';
 
-const ERROR_TEXT_TIMEOUT = 500;
+const tablePropertiesIcon = /* #__PURE__ */ registerIcon( 'tableProperties', IconTableProperties );
 
 // Map of view properties and related commands.
 const propertyToCommandMap = {
@@ -138,7 +135,7 @@ export default class TablePropertiesUI extends Plugin {
 
 			view.set( {
 				label: t( 'Table properties' ),
-				icon: IconTableProperties,
+				icon: tablePropertiesIcon(),
 				tooltip: true
 			} );
 
@@ -424,6 +421,7 @@ export default class TablePropertiesUI extends Plugin {
 			errorText: string;
 		}
 	) {
+		const ERROR_TEXT_TIMEOUT = 500;
 		const { commandName, viewField, validator, errorText } = options;
 		const setErrorTextDebounced = debounce( () => {
 			viewField.errorText = errorText;

--- a/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.ts
+++ b/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.ts
@@ -26,7 +26,13 @@ import {
 	type ColorPickerConfig,
 	type FocusableView
 } from 'ckeditor5/src/ui.js';
-import { FocusTracker, KeystrokeHandler, type ObservableChangeEvent, type Locale } from 'ckeditor5/src/utils.js';
+import {
+	registerIcon,
+	FocusTracker,
+	KeystrokeHandler,
+	type ObservableChangeEvent,
+	type Locale
+} from 'ckeditor5/src/utils.js';
 import {
 	IconCancel,
 	IconCheck,
@@ -34,7 +40,6 @@ import {
 	IconObjectInlineLeft,
 	IconObjectInlineRight
 } from 'ckeditor5/src/icons.js';
-
 import {
 	fillToolbar,
 	getBorderStyleDefinitions,
@@ -42,12 +47,18 @@ import {
 	getLabeledColorInputCreator
 } from '../../utils/ui/table-properties.js';
 import FormRowView from '../../ui/formrowview.js';
+import type ColorInputView from '../../ui/colorinputview.js';
+import type { TablePropertiesOptions } from '../../tableconfig.js';
 
 import '../../../theme/form.css';
 import '../../../theme/tableform.css';
 import '../../../theme/tableproperties.css';
-import type ColorInputView from '../../ui/colorinputview.js';
-import type { TablePropertiesOptions } from '../../tableconfig.js';
+
+const cancelIcon = /* #__PURE__ */ registerIcon( 'cancel', IconCancel );
+const checkIcon = /* #__PURE__ */ registerIcon( 'check', IconCheck );
+const objectCenterIcon = /* #__PURE__ */ registerIcon( 'objectCenter', IconObjectCenter );
+const objectInlineLeftIcon = /* #__PURE__ */ registerIcon( 'objectInlineLeft', IconObjectInlineLeft );
+const objectInlineRightIcon = /* #__PURE__ */ registerIcon( 'objectInlineRight', IconObjectInlineRight );
 
 /**
  * Additional configuration of the view.
@@ -652,9 +663,9 @@ export default class TablePropertiesView extends View {
 		fillToolbar( {
 			view: this,
 			icons: {
-				left: IconObjectInlineLeft,
-				center: IconObjectCenter,
-				right: IconObjectInlineRight
+				left: objectInlineLeftIcon(),
+				center: objectCenterIcon(),
+				right: objectInlineRightIcon()
 			},
 			toolbar: alignmentToolbar,
 			labels: this._alignmentLabels,
@@ -693,7 +704,7 @@ export default class TablePropertiesView extends View {
 
 		saveButtonView.set( {
 			label: t( 'Save' ),
-			icon: IconCheck,
+			icon: checkIcon(),
 			class: 'ck-button-save',
 			type: 'submit',
 			withText: true
@@ -705,7 +716,7 @@ export default class TablePropertiesView extends View {
 
 		cancelButtonView.set( {
 			label: t( 'Cancel' ),
-			icon: IconCancel,
+			icon: cancelIcon(),
 			class: 'ck-button-cancel',
 			withText: true
 		} );

--- a/packages/ckeditor5-table/src/tableui.ts
+++ b/packages/ckeditor5-table/src/tableui.ts
@@ -9,22 +9,25 @@
 
 import { Plugin, type Command, type Editor } from 'ckeditor5/src/core.js';
 import { IconTable, IconTableColumn, IconTableRow, IconTableMergeCell } from 'ckeditor5/src/icons.js';
+import { registerIcon, Collection, type ObservableChangeEvent, type Locale } from 'ckeditor5/src/utils.js';
 import {
 	addListToDropdown,
 	createDropdown,
 	ViewModel,
 	SplitButtonView,
 	SwitchButtonView,
+	MenuBarMenuView,
 	type DropdownView,
-	type ListDropdownItemDefinition,
-	MenuBarMenuView
+	type ListDropdownItemDefinition
 } from 'ckeditor5/src/ui.js';
-import { Collection, type ObservableChangeEvent, type Locale } from 'ckeditor5/src/utils.js';
-
 import InsertTableView from './ui/inserttableview.js';
-
 import type InsertTableCommand from './commands/inserttablecommand.js';
 import type MergeCellsCommand from './commands/mergecellscommand.js';
+
+const tableIcon = /* #__PURE__ */ registerIcon( 'table', IconTable );
+const tableColumnIcon = /* #__PURE__ */ registerIcon( 'tableColumn', IconTableColumn );
+const tableRowIcon = /* #__PURE__ */ registerIcon( 'tableRow', IconTableRow );
+const tableMergeCellIcon = /* #__PURE__ */ registerIcon( 'tableMergeCell', IconTableMergeCell );
 
 /**
  * The table UI plugin. It introduces:
@@ -69,7 +72,7 @@ export default class TableUI extends Plugin {
 
 			// Decorate dropdown's button.
 			dropdownView.buttonView.set( {
-				icon: IconTable,
+				icon: tableIcon(),
 				label: t( 'Insert table' ),
 				tooltip: true
 			} );
@@ -116,7 +119,7 @@ export default class TableUI extends Plugin {
 
 			menuView.buttonView.set( {
 				label: t( 'Table' ),
-				icon: IconTable
+				icon: tableIcon()
 			} );
 
 			menuView.panelView.children.add( insertTableView );
@@ -167,7 +170,7 @@ export default class TableUI extends Plugin {
 				}
 			] as Array<ListDropdownItemDefinition>;
 
-			return this._prepareDropdown( t( 'Column' ), IconTableColumn, options, locale );
+			return this._prepareDropdown( t( 'Column' ), tableColumnIcon(), options, locale );
 		} );
 
 		editor.ui.componentFactory.add( 'tableRow', locale => {
@@ -211,7 +214,7 @@ export default class TableUI extends Plugin {
 				}
 			] as Array<ListDropdownItemDefinition>;
 
-			return this._prepareDropdown( t( 'Row' ), IconTableRow, options, locale );
+			return this._prepareDropdown( t( 'Row' ), tableRowIcon(), options, locale );
 		} );
 
 		editor.ui.componentFactory.add( 'mergeTableCells', locale => {
@@ -261,7 +264,7 @@ export default class TableUI extends Plugin {
 				}
 			] as Array<ListDropdownItemDefinition>;
 
-			return this._prepareMergeSplitButtonDropdown( t( 'Merge cells' ), IconTableMergeCell, options, locale );
+			return this._prepareMergeSplitButtonDropdown( t( 'Merge cells' ), tableMergeCellIcon(), options, locale );
 		} );
 	}
 

--- a/packages/ckeditor5-ui/src/button/listitembuttonview.ts
+++ b/packages/ckeditor5-ui/src/button/listitembuttonview.ts
@@ -7,17 +7,18 @@
  * @module ui/button/listitembuttonview
  */
 
-import type { ObservableChangeEvent, Locale } from '@ckeditor/ckeditor5-utils';
-import type ButtonLabel from './buttonlabel.js';
-import type ViewCollection from '../viewcollection.js';
-
 import { IconCheck } from '@ckeditor/ckeditor5-icons';
+import { registerIcon, type ObservableChangeEvent, type Locale } from '@ckeditor/ckeditor5-utils';
 import ButtonView from './buttonview.js';
 import ButtonLabelView from './buttonlabelview.js';
 import IconView from '../icon/iconview.js';
 import View from '../view.js';
+import type ButtonLabel from './buttonlabel.js';
+import type ViewCollection from '../viewcollection.js';
 
 import '../../theme/components/button/listitembutton.css';
+
+const checkIcon = /* #__PURE__ */ registerIcon( 'check', IconCheck );
 
 /**
  * Button that is used as dropdown list item entry.
@@ -183,7 +184,7 @@ export class CheckIconHolderView extends View {
 	private _createCheckIconView() {
 		const iconView = new IconView();
 
-		iconView.content = IconCheck;
+		iconView.content = checkIcon();
 		iconView.extendTemplate( {
 			attributes: {
 				class: 'ck-list-item-button__check-icon'

--- a/packages/ckeditor5-ui/src/collapsible/collapsibleview.ts
+++ b/packages/ckeditor5-ui/src/collapsible/collapsibleview.ts
@@ -8,13 +8,15 @@
  */
 
 import { IconDropdownArrow } from '@ckeditor/ckeditor5-icons';
+import { registerIcon, type Locale } from '@ckeditor/ckeditor5-utils';
 import View from '../view.js';
 import ButtonView from '../button/buttonview.js';
 import type ViewCollection from '../viewcollection.js';
 import type { FocusableView } from '../focuscycler.js';
-import type { Locale } from '@ckeditor/ckeditor5-utils';
 
 import '../../theme/components/collapsible/collapsible.css';
+
+const dropdownArrowIcon = /* #__PURE__ */ registerIcon( 'dropdownArrow', IconDropdownArrow );
 
 /**
  * A collapsible UI component. Consists of a labeled button and a container which can be collapsed
@@ -134,7 +136,7 @@ export default class CollapsibleView extends View {
 
 		buttonView.set( {
 			withText: true,
-			icon: IconDropdownArrow
+			icon: dropdownArrowIcon()
 		} );
 
 		buttonView.extendTemplate( {

--- a/packages/ckeditor5-ui/src/colorgrid/colortileview.ts
+++ b/packages/ckeditor5-ui/src/colorgrid/colortileview.ts
@@ -8,8 +8,10 @@
  */
 
 import { IconColorTileCheck } from '@ckeditor/ckeditor5-icons';
-import { env, type Locale } from '@ckeditor/ckeditor5-utils';
+import { env, registerIcon, type Locale } from '@ckeditor/ckeditor5-utils';
 import ButtonView from '../button/buttonview.js';
+
+const colorTileCheckIcon = /* #__PURE__ */ registerIcon( 'colorTileCheck', IconColorTileCheck );
 
 /**
  * This class represents a single color tile in the {@link module:ui/colorgrid/colorgridview~ColorGridView}.
@@ -34,7 +36,7 @@ export default class ColorTileView extends ButtonView {
 		this.set( 'color', undefined );
 		this.set( 'hasBorder', false );
 
-		this.icon = IconColorTileCheck;
+		this.icon = colorTileCheckIcon();
 
 		this.extendTemplate( {
 			attributes: {

--- a/packages/ckeditor5-ui/src/colorselector/colorgridsfragmentview.ts
+++ b/packages/ckeditor5-ui/src/colorselector/colorgridsfragmentview.ts
@@ -7,21 +7,21 @@
  * @module ui/colorselector/colorgridsfragmentview
  */
 
+import { IconEraser, IconColorPalette } from '@ckeditor/ckeditor5-icons';
+import { registerIcon, type FocusTracker, type Locale } from '@ckeditor/ckeditor5-utils';
 import View from '../view.js';
 import ButtonView from '../button/buttonview.js';
 import ColorGridView, { type ColorDefinition } from '../colorgrid/colorgridview.js';
 import ColorTileView from '../colorgrid/colortileview.js';
 import Template from '../template.js';
-
 import DocumentColorCollection from './documentcolorcollection.js';
-
 import type { Model } from '@ckeditor/ckeditor5-engine';
-import type { FocusTracker, Locale } from '@ckeditor/ckeditor5-utils';
 import type ViewCollection from '../viewcollection.js';
 import type { FocusableView } from '../focuscycler.js';
 import type { ColorSelectorExecuteEvent, ColorSelectorColorPickerShowEvent } from './colorselectorview.js';
 
-import { IconEraser, IconColorPalette } from '@ckeditor/ckeditor5-icons';
+const eraserIcon = /* #__PURE__ */ registerIcon( 'eraser', IconEraser );
+const colorPaletteIcon = /* #__PURE__ */ registerIcon( 'colorPalette', IconColorPalette );
 
 /**
  * One of the fragments of {@link module:ui/colorselector/colorselectorview~ColorSelectorView}.
@@ -337,7 +337,7 @@ export default class ColorGridsFragmentView extends View {
 		this.colorPickerButtonView.set( {
 			label: this._colorPickerLabel,
 			withText: true,
-			icon: IconColorPalette,
+			icon: colorPaletteIcon(),
 			class: 'ck-color-selector__color-picker'
 		} );
 
@@ -354,7 +354,7 @@ export default class ColorGridsFragmentView extends View {
 
 		buttonView.set( {
 			withText: true,
-			icon: IconEraser,
+			icon: eraserIcon(),
 			label: this._removeButtonLabel
 		} );
 

--- a/packages/ckeditor5-ui/src/colorselector/colorpickerfragmentview.ts
+++ b/packages/ckeditor5-ui/src/colorselector/colorpickerfragmentview.ts
@@ -7,22 +7,28 @@
  * @module ui/colorselector/colorpickerfragmentview
  */
 
+import { IconCancel, IconCheck } from '@ckeditor/ckeditor5-icons';
+import {
+	registerIcon,
+	type FocusTracker,
+	type KeystrokeHandler,
+	type Locale
+} from '@ckeditor/ckeditor5-utils';
 import View from '../view.js';
 import ButtonView from '../button/buttonview.js';
-import type ViewCollection from '../viewcollection.js';
-import type { FocusableView } from '../focuscycler.js';
-import type LabeledFieldView from '../labeledfield/labeledfieldview.js';
-import type InputTextView from '../inputtext/inputtextview.js';
 import {
 	default as ColorPickerView,
 	type ColorPickerColorSelectedEvent
 } from '../colorpicker/colorpickerview.js';
-
-import type { FocusTracker, KeystrokeHandler, Locale } from '@ckeditor/ckeditor5-utils';
+import type ViewCollection from '../viewcollection.js';
+import type { FocusableView } from '../focuscycler.js';
+import type LabeledFieldView from '../labeledfield/labeledfieldview.js';
+import type InputTextView from '../inputtext/inputtextview.js';
 import type { ColorPickerViewConfig } from '../colorpicker/utils.js';
 import type { ColorSelectorColorPickerCancelEvent, ColorSelectorExecuteEvent } from './colorselectorview.js';
-import { IconCancel, IconCheck } from '@ckeditor/ckeditor5-icons';
 
+const cancelIcon = /* #__PURE__ */ registerIcon( 'cancel', IconCancel );
+const checkIcon = /* #__PURE__ */ registerIcon( 'check', IconCheck );
 /**
  * One of the fragments of {@link module:ui/colorselector/colorselectorview~ColorSelectorView}.
  *
@@ -290,7 +296,7 @@ export default class ColorPickerFragmentView extends View {
 		const cancelButtonView = new ButtonView( locale );
 
 		saveButtonView.set( {
-			icon: IconCheck,
+			icon: checkIcon(),
 			class: 'ck-button-save',
 			type: 'button',
 			withText: false,
@@ -298,7 +304,7 @@ export default class ColorPickerFragmentView extends View {
 		} );
 
 		cancelButtonView.set( {
-			icon: IconCancel,
+			icon: cancelIcon(),
 			class: 'ck-button-cancel',
 			type: 'button',
 			withText: false,

--- a/packages/ckeditor5-ui/src/dialog/dialogview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogview.ts
@@ -13,6 +13,7 @@ import {
 	Rect,
 	global,
 	toUnit,
+	registerIcon,
 	type EventInfo,
 	type Locale,
 	type DecoratedMethodEvent
@@ -35,6 +36,8 @@ import type EditorUI from '../editorui/editorui.js';
 
 import '../../theme/components/dialog/dialog.css';
 // @if CK_DEBUG_DIALOG // const RectDrawer = require( '@ckeditor/ckeditor5-utils/tests/_utils/rectdrawer' ).default;
+
+const cancelIcon = /* #__PURE__ */ registerIcon( 'cancel', IconCancel );
 
 /**
  * Available dialog view positions:
@@ -696,7 +699,7 @@ export default class DialogView extends /* #__PURE__ */ DraggableViewMixin( View
 		buttonView.set( {
 			label: t( 'Close' ),
 			tooltip: true,
-			icon: IconCancel
+			icon: cancelIcon()
 		} );
 
 		buttonView.on<ButtonExecuteEvent>( 'execute', () => this.fire<DialogViewCloseEvent>( 'close', { source: 'closeButton' } ) );

--- a/packages/ckeditor5-ui/src/dropdown/button/dropdownbuttonview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/button/dropdownbuttonview.ts
@@ -8,11 +8,12 @@
  */
 
 import { IconDropdownArrow } from '@ckeditor/ckeditor5-icons';
+import { registerIcon, type Locale } from '@ckeditor/ckeditor5-utils';
 import ButtonView from '../../button/buttonview.js';
 import type DropdownButton from './dropdownbutton.js';
 import IconView from '../../icon/iconview.js';
 
-import type { Locale } from '@ckeditor/ckeditor5-utils';
+const dropdownArrowIcon = /* #__PURE__ */ registerIcon( 'dropdownArrow', IconDropdownArrow );
 
 /**
  * The default dropdown button view class.
@@ -73,7 +74,7 @@ export default class DropdownButtonView extends ButtonView implements DropdownBu
 	private _createArrowView() {
 		const arrowView = new IconView();
 
-		arrowView.content = IconDropdownArrow;
+		arrowView.content = dropdownArrowIcon();
 
 		arrowView.extendTemplate( {
 			attributes: {

--- a/packages/ckeditor5-ui/src/dropdown/button/splitbuttonview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/button/splitbuttonview.ts
@@ -9,6 +9,7 @@
 
 import { IconDropdownArrow } from '@ckeditor/ckeditor5-icons';
 import {
+	registerIcon,
 	KeystrokeHandler,
 	FocusTracker,
 	type Locale
@@ -21,6 +22,8 @@ import type DropdownButton from './dropdownbutton.js';
 import type { FocusableView } from '../../focuscycler.js';
 
 import '../../../theme/components/dropdown/splitbutton.css';
+
+const dropdownArrowIcon = /* #__PURE__ */ registerIcon( 'dropdownArrow', IconDropdownArrow );
 
 /**
  * The split button view class.
@@ -306,7 +309,7 @@ export default class SplitButtonView extends View<HTMLDivElement> implements Dro
 		const arrowView = new ButtonView();
 		const bind = arrowView.bindTemplate;
 
-		arrowView.icon = IconDropdownArrow;
+		arrowView.icon = dropdownArrowIcon();
 
 		arrowView.extendTemplate( {
 			attributes: {

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenubuttonview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenubuttonview.ts
@@ -7,12 +7,14 @@
  * @module ui/dropdown/menu/dropdownmenubuttonview
  */
 
+import { registerIcon, type Locale } from '@ckeditor/ckeditor5-utils';
 import { IconDropdownArrow } from '@ckeditor/ckeditor5-icons';
 import IconView from '../../icon/iconview.js';
 import ListItemButtonView from '../../button/listitembuttonview.js';
-import type { Locale } from '@ckeditor/ckeditor5-utils';
 
 import '../../../theme/components/dropdown/menu/dropdownmenubutton.css';
+
+const dropdownArrowIcon = /* #__PURE__ */ registerIcon( 'dropdownArrow', IconDropdownArrow );
 
 /**
  * Represents a view for a dropdown menu button.
@@ -72,7 +74,7 @@ export default class DropdownMenuButtonView extends ListItemButtonView {
 	private _createArrowView() {
 		const arrowView = new IconView();
 
-		arrowView.content = IconDropdownArrow;
+		arrowView.content = dropdownArrowIcon();
 		arrowView.extendTemplate( {
 			attributes: {
 				class: 'ck-dropdown-menu-list__nested-menu__button__arrow'

--- a/packages/ckeditor5-ui/src/editorui/accessibilityhelp/accessibilityhelp.ts
+++ b/packages/ckeditor5-ui/src/editorui/accessibilityhelp/accessibilityhelp.ts
@@ -9,16 +9,18 @@
 
 import { Plugin } from '@ckeditor/ckeditor5-core';
 import { IconAccessibility } from '@ckeditor/ckeditor5-icons';
+import { getEnvKeystrokeText, registerIcon } from '@ckeditor/ckeditor5-utils';
 import ButtonView from '../../button/buttonview.js';
 import Dialog from '../../dialog/dialog.js';
 import MenuBarMenuListItemButtonView from '../../menubar/menubarmenulistitembuttonview.js';
 import AccessibilityHelpContentView from './accessibilityhelpcontentview.js';
-import { getEnvKeystrokeText } from '@ckeditor/ckeditor5-utils';
 import type { EditorUIReadyEvent } from '../../editorui/editorui.js';
 import type { AddRootEvent } from '@ckeditor/ckeditor5-editor-multi-root';
 import type { DowncastWriter, ViewRootEditableElement } from '@ckeditor/ckeditor5-engine';
 
 import '../../../theme/components/editorui/accessibilityhelp.css';
+
+const accessibilityIcon = /* #__PURE__ */ registerIcon( 'accessibility', IconAccessibility );
 
 /**
  * A plugin that brings the accessibility help dialog to the editor available under the <kbd>Alt</kbd>+<kbd>0</kbd>
@@ -102,7 +104,7 @@ export default class AccessibilityHelp extends Plugin {
 
 		view.set( {
 			keystroke: 'Alt+0',
-			icon: IconAccessibility,
+			icon: accessibilityIcon(),
 			isToggleable: true
 		} );
 
@@ -164,7 +166,7 @@ export default class AccessibilityHelp extends Plugin {
 				id: 'accessibilityHelp',
 				className: 'ck-accessibility-help-dialog',
 				title: t( 'Accessibility help' ),
-				icon: IconAccessibility,
+				icon: accessibilityIcon(),
 				hasCloseButton: true,
 				content: this.contentView
 			} );

--- a/packages/ckeditor5-ui/src/editorui/poweredby.ts
+++ b/packages/ckeditor5-ui/src/editorui/poweredby.ts
@@ -8,16 +8,15 @@
  */
 
 import { IconProjectLogo } from '@ckeditor/ckeditor5-icons';
-import { parseBase64EncodedObject, type Locale } from '@ckeditor/ckeditor5-utils';
-
+import { parseBase64EncodedObject, registerIcon, type Locale } from '@ckeditor/ckeditor5-utils';
 import View from '../view.js';
 import Badge from '../badge/badge.js';
 import IconView from '../icon/iconview.js';
 import type { Editor, UiConfig } from '@ckeditor/ckeditor5-core';
 
-const DEFAULT_LABEL = 'Powered by';
-
 type PoweredByConfig = Required<UiConfig>[ 'poweredBy' ];
+
+const projectLogoIcon = /* #__PURE__ */ registerIcon( 'projectLogo', IconProjectLogo );
 
 /**
  * A helper that enables the "powered by" feature in the editor and renders a link to the project's
@@ -68,6 +67,7 @@ export default class PoweredBy extends Badge {
 	 * It takes the user configuration into account and falls back to the default one.
 	 */
 	protected override _getNormalizedConfig(): Required<PoweredByConfig> {
+		const DEFAULT_LABEL = 'Powered by';
 		const badgeConfig = super._getNormalizedConfig();
 		const userConfig = this.editor.config.get( 'ui.poweredBy' ) || {};
 		const position = userConfig.position || badgeConfig.position;
@@ -101,7 +101,7 @@ class PoweredByView extends View<HTMLDivElement> {
 		const bind = this.bindTemplate;
 
 		iconView.set( {
-			content: IconProjectLogo,
+			content: projectLogoIcon(),
 			isColorInherited: false
 		} );
 

--- a/packages/ckeditor5-ui/src/menubar/menubarmenubuttonview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenubuttonview.ts
@@ -8,11 +8,13 @@
  */
 
 import { IconDropdownArrow } from '@ckeditor/ckeditor5-icons';
+import { registerIcon, type Locale } from '@ckeditor/ckeditor5-utils';
 import IconView from '../icon/iconview.js';
 import ListItemButtonView from '../button/listitembuttonview.js';
-import type { Locale } from '@ckeditor/ckeditor5-utils';
 
 import '../../theme/components/menubar/menubarmenubutton.css';
+
+const dropdownArrowIcon = /* #__PURE__ */ registerIcon( 'dropdownArrow', IconDropdownArrow );
 
 /**
  * A menu {@link module:ui/menubar/menubarmenuview~MenuBarMenuView#buttonView} class. Buttons like this one
@@ -71,7 +73,7 @@ export default class MenuBarMenuButtonView extends ListItemButtonView {
 	private _createArrowView() {
 		const arrowView = new IconView();
 
-		arrowView.content = IconDropdownArrow;
+		arrowView.content = dropdownArrowIcon();
 		arrowView.extendTemplate( {
 			attributes: {
 				class: 'ck-menu-bar__menu__button__arrow'

--- a/packages/ckeditor5-ui/src/panel/balloon/contextualballoon.ts
+++ b/packages/ckeditor5-ui/src/panel/balloon/contextualballoon.ts
@@ -7,29 +7,31 @@
  * @module ui/panel/balloon/contextualballoon
  */
 
-import BalloonPanelView from './balloonpanelview.js';
-import View from '../../view.js';
-import ButtonView from '../../button/buttonview.js';
-import type { ButtonExecuteEvent } from '../../button/button.js';
-import type ViewCollection from '../../viewcollection.js';
-
 import { Plugin, type Editor } from '@ckeditor/ckeditor5-core';
 import {
 	CKEditorError,
 	FocusTracker,
 	Rect,
 	toUnit,
+	registerIcon,
 	type Locale,
 	type ObservableChangeEvent,
 	type PositionOptions,
 	type DecoratedMethodEvent
 } from '@ckeditor/ckeditor5-utils';
 import { IconNextArrow, IconPreviousArrow } from '@ckeditor/ckeditor5-icons';
+import BalloonPanelView from './balloonpanelview.js';
+import View from '../../view.js';
+import ButtonView from '../../button/buttonview.js';
+import type { ButtonExecuteEvent } from '../../button/button.js';
+import type ViewCollection from '../../viewcollection.js';
 
 import '../../../theme/components/panel/balloonrotator.css';
 import '../../../theme/components/panel/fakepanel.css';
 
 const toPx = /* #__PURE__ */ toUnit( 'px' );
+const nextArrowIcon = /* #__PURE__ */ registerIcon( 'nextArrow', IconNextArrow );
+const previousArrowIcon = /* #__PURE__ */ registerIcon( 'previousArrow', IconPreviousArrow );
 
 /**
  * Provides the common contextual balloon for the editor.
@@ -640,8 +642,8 @@ export class RotatorView extends View {
 		this.set( 'isNavigationVisible', true );
 
 		this.focusTracker = new FocusTracker();
-		this.buttonPrevView = this._createButtonView( t( 'Previous' ), IconPreviousArrow );
-		this.buttonNextView = this._createButtonView( t( 'Next' ), IconNextArrow );
+		this.buttonPrevView = this._createButtonView( t( 'Previous' ), previousArrowIcon() );
+		this.buttonNextView = this._createButtonView( t( 'Next' ), nextArrowIcon() );
 		this.content = this.createCollection();
 
 		this.setTemplate( {

--- a/packages/ckeditor5-ui/src/search/text/searchtextqueryview.ts
+++ b/packages/ckeditor5-ui/src/search/text/searchtextqueryview.ts
@@ -7,12 +7,15 @@
  * @module ui/search/text/searchtextqueryview
  */
 import { IconCancel, IconLoupe } from '@ckeditor/ckeditor5-icons';
+import { registerIcon, type Locale } from '@ckeditor/ckeditor5-utils';
 import ButtonView from '../../button/buttonview.js';
 import IconView from '../../icon/iconview.js';
 import LabeledFieldView, { type LabeledFieldViewCreator } from '../../labeledfield/labeledfieldview.js';
 import { createLabeledInputText } from '../../labeledfield/utils.js';
 import type InputBase from '../../input/inputbase.js';
-import type { Locale } from '@ckeditor/ckeditor5-utils';
+
+const cancelIcon = /* #__PURE__ */ registerIcon( 'cancel', IconCancel );
+const loupeIcon = /* #__PURE__ */ registerIcon( 'loupe', IconLoupe );
 
 /**
  * A search input field for the {@link module:ui/search/text/searchtextview~SearchTextView} component.
@@ -56,7 +59,7 @@ export default class SearchTextQueryView<
 
 		if ( this._viewConfig.showIcon ) {
 			this.iconView = new IconView();
-			this.iconView.content = IconLoupe;
+			this.iconView.content = loupeIcon();
 			this.fieldWrapperChildren.add( this.iconView, 0 );
 
 			this.extendTemplate( {
@@ -70,7 +73,7 @@ export default class SearchTextQueryView<
 			this.resetButtonView = new ButtonView( locale );
 			this.resetButtonView.set( {
 				label: t( 'Clear' ),
-				icon: IconCancel,
+				icon: cancelIcon(),
 				class: 'ck-search__reset',
 				isVisible: false,
 				tooltip: true

--- a/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.ts
+++ b/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.ts
@@ -276,10 +276,7 @@ export default class BlockToolbar extends Plugin {
 		const t = editor.t;
 		const buttonView = new BlockButtonView( editor.locale );
 		const iconFromConfig = this._blockToolbarConfig.icon;
-
-		const icon: string = NESTED_TOOLBAR_ICONS[ iconFromConfig! ] ?
-			NESTED_TOOLBAR_ICONS[ iconFromConfig! ]() :
-			iconFromConfig || NESTED_TOOLBAR_ICONS.dragIndicator();
+		const icon: string = NESTED_TOOLBAR_ICONS[ iconFromConfig! ] || iconFromConfig || NESTED_TOOLBAR_ICONS.dragIndicator;
 
 		buttonView.set( {
 			label: t( 'Edit block' ),

--- a/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.ts
+++ b/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.ts
@@ -277,7 +277,9 @@ export default class BlockToolbar extends Plugin {
 		const buttonView = new BlockButtonView( editor.locale );
 		const iconFromConfig = this._blockToolbarConfig.icon;
 
-		const icon = NESTED_TOOLBAR_ICONS[ iconFromConfig! ] || iconFromConfig || NESTED_TOOLBAR_ICONS.dragIndicator;
+		const icon: string = NESTED_TOOLBAR_ICONS[ iconFromConfig! ] ?
+			NESTED_TOOLBAR_ICONS[ iconFromConfig! ]() :
+			iconFromConfig || NESTED_TOOLBAR_ICONS.dragIndicator();
 
 		buttonView.set( {
 			label: t( 'Edit block' ),

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.ts
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.ts
@@ -7,19 +7,7 @@
  * @module ui/toolbar/toolbarview
  */
 
-import View from '../view.js';
-import FocusCycler, { isFocusable, type FocusableView } from '../focuscycler.js';
-import ToolbarSeparatorView from './toolbarseparatorview.js';
-import ToolbarLineBreakView from './toolbarlinebreakview.js';
-import preventDefault from '../bindings/preventdefault.js';
-import { createDropdown, addToolbarToDropdown } from '../dropdown/utils.js';
-import normalizeToolbarConfig from './normalizetoolbarconfig.js';
-
-import type ComponentFactory from '../componentfactory.js';
-import type ViewCollection from '../viewcollection.js';
-import type DropdownView from '../dropdown/dropdownview.js';
-import type DropdownPanelFocusable from '../dropdown/dropdownpanelfocusable.js';
-
+import { isObject } from 'lodash-es';
 import {
 	FocusTracker,
 	KeystrokeHandler,
@@ -28,6 +16,7 @@ import {
 	global,
 	isVisible,
 	logWarning,
+	registerIcon,
 	type CollectionAddEvent,
 	type CollectionChangeEvent,
 	type CollectionRemoveEvent,
@@ -46,21 +35,40 @@ import {
 	IconDragIndicator
 } from '@ckeditor/ckeditor5-icons';
 import type { ToolbarConfig, ToolbarConfigItem } from '@ckeditor/ckeditor5-core';
-
-import { isObject } from 'lodash-es';
+import View from '../view.js';
+import FocusCycler, { isFocusable, type FocusableView } from '../focuscycler.js';
+import ToolbarSeparatorView from './toolbarseparatorview.js';
+import ToolbarLineBreakView from './toolbarlinebreakview.js';
+import preventDefault from '../bindings/preventdefault.js';
+import { createDropdown, addToolbarToDropdown } from '../dropdown/utils.js';
+import normalizeToolbarConfig from './normalizetoolbarconfig.js';
+import type ComponentFactory from '../componentfactory.js';
+import type ViewCollection from '../viewcollection.js';
+import type DropdownView from '../dropdown/dropdownview.js';
+import type DropdownPanelFocusable from '../dropdown/dropdownpanelfocusable.js';
 
 import '../../theme/components/toolbar/toolbar.css';
 
-export const NESTED_TOOLBAR_ICONS: Record<string, string | undefined> = /* #__PURE__ */ ( () => ( {
-	alignLeft: IconAlignLeft,
-	bold: IconBold,
-	importExport: IconImportExport,
-	paragraph: IconParagraph,
-	plus: IconPlus,
-	text: IconText,
-	threeVerticalDots: IconThreeVerticalDots,
-	pilcrow: IconPilcrow,
-	dragIndicator: IconDragIndicator
+const alignLeftIcon = /* #__PURE__ */ registerIcon( 'alignLeft', IconAlignLeft );
+const boldIcon = /* #__PURE__ */ registerIcon( 'bold', IconBold );
+const importExportIcon = /* #__PURE__ */ registerIcon( 'importExport', IconImportExport );
+const paragraphIcon = /* #__PURE__ */ registerIcon( 'paragraph', IconParagraph );
+const plusIcon = /* #__PURE__ */ registerIcon( 'plus', IconPlus );
+const textIcon = /* #__PURE__ */ registerIcon( 'text', IconText );
+const threeVerticalDotsIcon = /* #__PURE__ */ registerIcon( 'threeVerticalDots', IconThreeVerticalDots );
+const pilcrowIcon = /* #__PURE__ */ registerIcon( 'pilcrow', IconPilcrow );
+const dragIndicatorIcon = /* #__PURE__ */ registerIcon( 'dragIndicator', IconDragIndicator );
+
+export const NESTED_TOOLBAR_ICONS: Record<string, () => string> = /* #__PURE__ */ ( () => ( {
+	alignLeft: alignLeftIcon,
+	bold: boldIcon,
+	importExport: importExportIcon,
+	paragraph: paragraphIcon,
+	plus: plusIcon,
+	text: textIcon,
+	threeVerticalDots: threeVerticalDotsIcon,
+	pilcrow: pilcrowIcon,
+	dragIndicator: dragIndicatorIcon
 } ) )();
 
 /**
@@ -546,7 +554,9 @@ export default class ToolbarView extends View implements DropdownPanelFocusable 
 		// Allow disabling icon by passing false.
 		if ( icon !== false ) {
 			// A pre-defined icon picked by name, SVG string, a fallback (default) icon.
-			dropdownView.buttonView.icon = NESTED_TOOLBAR_ICONS[ icon! ] || icon || IconThreeVerticalDots;
+			dropdownView.buttonView.icon = NESTED_TOOLBAR_ICONS[ icon! ] ?
+				NESTED_TOOLBAR_ICONS[ icon! ]() :
+				icon || IconThreeVerticalDots;
 		}
 		// If the icon is disabled, display the label automatically.
 		else {

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.ts
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.ts
@@ -59,17 +59,35 @@ const threeVerticalDotsIcon = /* #__PURE__ */ registerIcon( 'threeVerticalDots',
 const pilcrowIcon = /* #__PURE__ */ registerIcon( 'pilcrow', IconPilcrow );
 const dragIndicatorIcon = /* #__PURE__ */ registerIcon( 'dragIndicator', IconDragIndicator );
 
-export const NESTED_TOOLBAR_ICONS: Record<string, () => string> = /* #__PURE__ */ ( () => ( {
-	alignLeft: alignLeftIcon,
-	bold: boldIcon,
-	importExport: importExportIcon,
-	paragraph: paragraphIcon,
-	plus: plusIcon,
-	text: textIcon,
-	threeVerticalDots: threeVerticalDotsIcon,
-	pilcrow: pilcrowIcon,
-	dragIndicator: dragIndicatorIcon
-} ) )();
+export const NESTED_TOOLBAR_ICONS: Record<string, string> = {
+	get alignLeft() {
+		return alignLeftIcon();
+	},
+	get bold() {
+		return boldIcon();
+	},
+	get importExport() {
+		return importExportIcon();
+	},
+	get paragraph() {
+		return paragraphIcon();
+	},
+	get plus() {
+		return plusIcon();
+	},
+	get text() {
+		return textIcon();
+	},
+	get threeVerticalDots() {
+		return threeVerticalDotsIcon();
+	},
+	get pilcrow() {
+		return pilcrowIcon();
+	},
+	get dragIndicator() {
+		return dragIndicatorIcon();
+	}
+};
 
 /**
  * The toolbar view class.
@@ -554,9 +572,7 @@ export default class ToolbarView extends View implements DropdownPanelFocusable 
 		// Allow disabling icon by passing false.
 		if ( icon !== false ) {
 			// A pre-defined icon picked by name, SVG string, a fallback (default) icon.
-			dropdownView.buttonView.icon = NESTED_TOOLBAR_ICONS[ icon! ] ?
-				NESTED_TOOLBAR_ICONS[ icon! ]() :
-				icon || IconThreeVerticalDots;
+			dropdownView.buttonView.icon = NESTED_TOOLBAR_ICONS[ icon! ] || icon || IconThreeVerticalDots;
 		}
 		// If the icon is disabled, display the label automatically.
 		else {

--- a/packages/ckeditor5-undo/package.json
+++ b/packages/ckeditor5-undo/package.json
@@ -16,7 +16,8 @@
     "@ckeditor/ckeditor5-core": "44.1.0",
     "@ckeditor/ckeditor5-engine": "44.1.0",
     "@ckeditor/ckeditor5-icons": "0.0.1",
-    "@ckeditor/ckeditor5-ui": "44.1.0"
+    "@ckeditor/ckeditor5-ui": "44.1.0",
+    "@ckeditor/ckeditor5-utils": "44.1.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "44.1.0",
@@ -27,7 +28,6 @@
     "@ckeditor/ckeditor5-paragraph": "44.1.0",
     "@ckeditor/ckeditor5-typing": "44.1.0",
     "@ckeditor/ckeditor5-table": "44.1.0",
-    "@ckeditor/ckeditor5-utils": "44.1.0",
     "typescript": "5.0.4",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4"

--- a/packages/ckeditor5-undo/src/undoui.ts
+++ b/packages/ckeditor5-undo/src/undoui.ts
@@ -9,6 +9,10 @@
 import { Plugin } from '@ckeditor/ckeditor5-core';
 import { ButtonView, MenuBarMenuListItemButtonView } from '@ckeditor/ckeditor5-ui';
 import { IconUndo, IconRedo } from '@ckeditor/ckeditor5-icons';
+import { registerIcon } from '@ckeditor/ckeditor5-utils';
+
+const undoIcon = /* #__PURE__ */ registerIcon( 'undo', IconUndo );
+const redoIcon = /* #__PURE__ */ registerIcon( 'redo', IconRedo );
 
 /**
  * The undo UI feature. It introduces the `'undo'` and `'redo'` buttons to the editor.
@@ -36,8 +40,8 @@ export default class UndoUI extends Plugin {
 		const locale = editor.locale;
 		const t = editor.t;
 
-		const localizedUndoIcon = locale.uiLanguageDirection == 'ltr' ? IconUndo : IconRedo;
-		const localizedRedoIcon = locale.uiLanguageDirection == 'ltr' ? IconRedo : IconUndo;
+		const localizedUndoIcon: string = locale.uiLanguageDirection == 'ltr' ? undoIcon() : redoIcon();
+		const localizedRedoIcon: string = locale.uiLanguageDirection == 'ltr' ? redoIcon() : undoIcon();
 
 		this._addButtonsToFactory( 'undo', t( 'Undo' ), 'CTRL+Z', localizedUndoIcon );
 		this._addButtonsToFactory( 'redo', t( 'Redo' ), 'CTRL+Y', localizedRedoIcon );

--- a/packages/ckeditor5-utils/src/icons.ts
+++ b/packages/ckeditor5-utils/src/icons.ts
@@ -7,6 +7,8 @@
  * @module utils/icons
  */
 
+import global from './dom/global.js';
+
 export type Icons = Record<string, string>;
 
 declare global {
@@ -21,18 +23,18 @@ export function registerIcon(
 ): () => string {
 	// Create icons object if it doesn't exist yet.
 	// TODO: Replace with `globalThis.CKEDITOR_ICONS ||= {};` when we migrate to ES2022.
-	if ( !globalThis.CKEDITOR_ICONS ) {
-		globalThis.CKEDITOR_ICONS = {};
+	if ( !global.window.CKEDITOR_ICONS ) {
+		global.window.CKEDITOR_ICONS = {};
 	}
 
 	// If icon is provided and it's not already registered, then register it.
-	if ( !globalThis.CKEDITOR_ICONS[ name ] || force ) {
-		globalThis.CKEDITOR_ICONS[ name ] = icon;
+	if ( !global.window.CKEDITOR_ICONS[ name ] || force ) {
+		global.window.CKEDITOR_ICONS[ name ] = icon;
 	}
 
 	return () => useIcon( name )!;
 }
 
 export function useIcon( name: string ): string | undefined {
-	return globalThis.CKEDITOR_ICONS && globalThis.CKEDITOR_ICONS[ name ];
+	return global.window.CKEDITOR_ICONS && global.window.CKEDITOR_ICONS[ name ];
 }

--- a/packages/ckeditor5-utils/src/icons.ts
+++ b/packages/ckeditor5-utils/src/icons.ts
@@ -1,0 +1,34 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+export type Icons = Record<string, string>;
+
+declare global {
+  // eslint-disable-next-line no-var
+  var CKEDITOR_ICONS: Icons;
+}
+
+export function registerIcon(
+	name: string,
+	icon: string,
+	force: boolean = false
+): () => string {
+	// Create icons object if it doesn't exist yet.
+	// TODO: Replace with `globalThis.CKEDITOR_ICONS ||= {};` when we migrate to ES2022.
+	if ( !globalThis.CKEDITOR_ICONS ) {
+		globalThis.CKEDITOR_ICONS = {};
+	}
+
+	// If icon is provided and it's not already registered, then register it.
+	if ( !globalThis.CKEDITOR_ICONS[ name ] || force ) {
+		globalThis.CKEDITOR_ICONS[ name ] = icon;
+	}
+
+	return () => useIcon( name )!;
+}
+
+export function useIcon( name: string ): string | undefined {
+	return globalThis.CKEDITOR_ICONS && globalThis.CKEDITOR_ICONS[ name ];
+}

--- a/packages/ckeditor5-utils/src/icons.ts
+++ b/packages/ckeditor5-utils/src/icons.ts
@@ -3,6 +3,10 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
+/**
+ * @module utils/icons
+ */
+
 export type Icons = Record<string, string>;
 
 declare global {

--- a/packages/ckeditor5-utils/src/index.ts
+++ b/packages/ckeditor5-utils/src/index.ts
@@ -80,6 +80,7 @@ export {
 	type CollectionRemoveEvent
 } from './collection.js';
 export { default as first } from './first.js';
+export { useIcon, registerIcon, type Icons } from './icons.js';
 export { default as FocusTracker, type ViewWithFocusTracker, isViewWithFocusTracker } from './focustracker.js';
 export { default as KeystrokeHandler, type KeystrokeHandlerOptions } from './keystrokehandler.js';
 export { default as toArray, type ArrayOrItem, type ReadonlyArrayOrItem } from './toarray.js';

--- a/packages/ckeditor5-utils/tests/icons.js
+++ b/packages/ckeditor5-utils/tests/icons.js
@@ -3,60 +3,46 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-/* global globalThis */
-
 import { registerIcon, useIcon } from '../src/icons.js';
 
 describe( 'icons', () => {
-	beforeEach( () => {
-		delete globalThis.CKEDITOR_ICONS;
-	} );
-
 	describe( 'registerIcon', () => {
 		it( 'can register icons', () => {
-			registerIcon( 'foo', 'bar' );
+			registerIcon( 'icons_test1', 'bar' );
 
-			expect( useIcon( 'foo' ) ).to.equal( 'bar' );
+			expect( useIcon( 'icons_test1' ) ).to.equal( 'bar' );
 		} );
 
 		it( 'returns `useIcon` function', () => {
-			const icon = registerIcon( 'foo', 'bar' );
+			const icon = registerIcon( 'icons_test2', 'bar' );
 
-			expect( icon() ).to.equal( useIcon( 'foo' ) );
-		} );
-
-		it( 'registers `CKEDITOR_ICONS` if it doesnt exist yet', () => {
-			expect( globalThis.CKEDITOR_ICONS ).to.be.undefined;
-
-			registerIcon( 'foo', 'bar' );
-
-			expect( globalThis.CKEDITOR_ICONS ).to.deep.equal( { foo: 'bar' } );
+			expect( icon() ).to.equal( useIcon( 'icons_test2' ) );
 		} );
 
 		it( 'doesnt override existing icon by default', () => {
-			registerIcon( 'foo', 'bar' );
-			registerIcon( 'foo', 'baz' );
+			registerIcon( 'icons_test3', 'bar' );
+			registerIcon( 'icons_test3', 'baz' );
 
-			expect( useIcon( 'foo' ) ).to.equal( 'bar' );
+			expect( useIcon( 'icons_test3' ) ).to.equal( 'bar' );
 		} );
 
 		it( 'overrides existing icon if `force` is set to `true`', () => {
-			registerIcon( 'foo', 'bar' );
-			registerIcon( 'foo', 'baz', true );
+			registerIcon( 'icons_test4', 'bar' );
+			registerIcon( 'icons_test4', 'baz', true );
 
-			expect( useIcon( 'foo' ) ).to.equal( 'baz' );
+			expect( useIcon( 'icons_test4' ) ).to.equal( 'baz' );
 		} );
 	} );
 
 	describe( 'useIcon', () => {
 		it( 'returns `undefined` if icon is not registered', () => {
-			expect( useIcon( 'foo' ) ).to.be.undefined;
+			expect( useIcon( 'icons_test5' ) ).to.be.undefined;
 		} );
 
 		it( 'returns icon value if icon is registered', () => {
-			registerIcon( 'foo', 'bar' );
+			registerIcon( 'icons_test6', 'bar' );
 
-			expect( useIcon( 'foo' ) ).to.equal( 'bar' );
+			expect( useIcon( 'icons_test6' ) ).to.equal( 'bar' );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-utils/tests/icons.js
+++ b/packages/ckeditor5-utils/tests/icons.js
@@ -1,0 +1,62 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+/* global globalThis */
+
+import { registerIcon, useIcon } from '../src/icons.js';
+
+describe( 'icons', () => {
+	beforeEach( () => {
+		delete globalThis.CKEDITOR_ICONS;
+	} );
+
+	describe( 'registerIcon', () => {
+		it( 'can register icons', () => {
+			registerIcon( 'foo', 'bar' );
+
+			expect( useIcon( 'foo' ) ).to.equal( 'bar' );
+		} );
+
+		it( 'returns `useIcon` function', () => {
+			const icon = registerIcon( 'foo', 'bar' );
+
+			expect( icon() ).to.equal( useIcon( 'foo' ) );
+		} );
+
+		it( 'registers `CKEDITOR_ICONS` if it doesnt exist yet', () => {
+			expect( globalThis.CKEDITOR_ICONS ).to.be.undefined;
+
+			registerIcon( 'foo', 'bar' );
+
+			expect( globalThis.CKEDITOR_ICONS ).to.deep.equal( { foo: 'bar' } );
+		} );
+
+		it( 'doesnt override existing icon by default', () => {
+			registerIcon( 'foo', 'bar' );
+			registerIcon( 'foo', 'baz' );
+
+			expect( useIcon( 'foo' ) ).to.equal( 'bar' );
+		} );
+
+		it( 'overrides existing icon if `force` is set to `true`', () => {
+			registerIcon( 'foo', 'bar' );
+			registerIcon( 'foo', 'baz', true );
+
+			expect( useIcon( 'foo' ) ).to.equal( 'baz' );
+		} );
+	} );
+
+	describe( 'useIcon', () => {
+		it( 'returns `undefined` if icon is not registered', () => {
+			expect( useIcon( 'foo' ) ).to.be.undefined;
+		} );
+
+		it( 'returns icon value if icon is registered', () => {
+			registerIcon( 'foo', 'bar' );
+
+			expect( useIcon( 'foo' ) ).to.equal( 'bar' );
+		} );
+	} );
+} );

--- a/packages/ckeditor5-widget/src/utils.ts
+++ b/packages/ckeditor5-widget/src/utils.ts
@@ -12,6 +12,7 @@ import {
 	Rect,
 	CKEditorError,
 	toArray,
+	registerIcon,
 	type ObservableChangeEvent,
 	type GetCallback
 } from '@ckeditor/ckeditor5-utils';
@@ -36,6 +37,8 @@ import { IconView } from '@ckeditor/ckeditor5-ui';
 
 import HighlightStack, { type HighlightStackChangeEvent } from './highlightstack.js';
 import { getTypeAroundFakeCaretPosition } from './widgettypearound/utils.js';
+
+const dragHandleIcon = /* #__PURE__ */ registerIcon( 'dragHandle', IconDragHandle );
 
 /**
  * CSS class added to each widget element.
@@ -433,7 +436,7 @@ function addSelectionHandle( widgetElement: ViewContainerElement, writer: Downca
 
 		// Use the IconView from the ui library.
 		const icon = new IconView();
-		icon.set( 'content', IconDragHandle );
+		icon.set( 'content', dragHandleIcon() );
 
 		// Render the icon view right away to append its #element to the selectionHandle DOM element.
 		icon.render();

--- a/packages/ckeditor5-widget/src/widgettypearound/widgettypearound.ts
+++ b/packages/ckeditor5-widget/src/widgettypearound/widgettypearound.ts
@@ -27,6 +27,7 @@ import {
 import {
 	env,
 	isForwardArrowKeyCode,
+	registerIcon,
 	type BaseEvent,
 	type Emitter,
 	type GetCallback,
@@ -69,11 +70,8 @@ import type Widget from '../widget.js';
 
 import '../../theme/widgettypearound.css';
 
+const returnArrowIcon = /* #__PURE__ */ registerIcon( 'returnArrow', IconReturnArrow );
 const POSSIBLE_INSERTION_POSITIONS = [ 'before', 'after' ] as const;
-
-// Do the SVG parsing once and then clone the result <svg> DOM element for each new button.
-const RETURN_ARROW_ICON_ELEMENT = new DOMParser().parseFromString( IconReturnArrow, 'image/svg+xml' ).firstChild!;
-
 const PLUGIN_DISABLED_EDITING_ROOT_CLASS = 'ck-widget__type-around_disabled';
 
 /**
@@ -920,7 +918,10 @@ function injectButtons( wrapperDomElement: HTMLElement, buttonTitles: { before: 
 				'aria-hidden': 'true'
 			},
 			children: [
-				wrapperDomElement.ownerDocument.importNode( RETURN_ARROW_ICON_ELEMENT, true )
+				wrapperDomElement.ownerDocument.importNode(
+					new DOMParser().parseFromString( returnArrowIcon(), 'image/svg+xml' ).firstChild!,
+					true
+				)
 			]
 		} );
 

--- a/tests/manual/abbreviation-level-3.md
+++ b/tests/manual/abbreviation-level-3.md
@@ -59,7 +59,7 @@ module.exports = {
 	module: {
 		rules: [
 			{
-				test: /ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/,
+				test: /ckeditor5-icons\/theme\/icons\/[^/\\]+\.svg$/,
 				use: [ 'raw-loader' ]
 			},
 			{


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (core): Add a new `icons` configuration option to the editor. Related to #16546.

Feature (utils): Add `registerIcon` and `useIcon` helpers for registering and using customizable icons. Related to #16546.

Feature: Use `registerIcon` and `useIcon` helpers in all packages.

---

### Additional information

This is a follow-up to #17750.

:warning: TODO: Add docs explaining how to register, use, and override icons :warning: 
