### PR TITLE
Add metadata for `ImageUtils` and `ImageEditing` plugins

### DIFF
--- a/packages/ckeditor5-image/ckeditor5-metadata.json
+++ b/packages/ckeditor5-image/ckeditor5-metadata.json
@@ -265,6 +265,20 @@
 					"iconPath": "@ckeditor/ckeditor5-core/theme/icons/image-url.svg"
 				}
 			]
+		},
+		{
+			"name": "Image utils",
+			"className": "ImageUtils",
+			"description": "Provides utility functions for image handling.",
+			"docs": "features/images/images-overview.html",
+			"path": "src/imageutils.js"
+		},
+		{
+			"name": "Image editing",
+			"className": "ImageEditing",
+			"description": "Provides basic common image engine features.",
+			"docs": "features/images/images-overview.html",
+			"path": "src/imageediting.js"
 		}
 	]
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (image): Add metadata for `ImageUtils` and `ImageEditing` plugins. Closes #17765.

---