### PR TITLE
Fix path in image metadata

### DIFF
--- a/packages/ckeditor5-image/ckeditor5-metadata.json
+++ b/packages/ckeditor5-image/ckeditor5-metadata.json
@@ -278,7 +278,7 @@
 			"className": "ImageEditing",
 			"description": "Provides basic common image engine features.",
 			"docs": "features/images/images-overview.html",
-			"path": "src/imageediting.js"
+			"path": "src/image/imageediting.js"
 		}
 	]
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (image): Fix path to `ImageEditing` plugin in metadata.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
