### PR TITLE
Added missing exports.

### DIFF
--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -106,6 +106,7 @@ export type {
 	SchemaChildCheckCallback,
 	AttributeProperties,
 	SchemaItemDefinition,
+	SchemaCompiledItemDefinition,
 	SchemaContext,
 	SchemaContextDefinition
 } from './model/schema.js';

--- a/packages/ckeditor5-font/src/index.ts
+++ b/packages/ckeditor5-font/src/index.ts
@@ -29,7 +29,8 @@ export type {
 	FONT_BACKGROUND_COLOR,
 	FONT_COLOR,
 	FONT_FAMILY,
-	FONT_SIZE
+	FONT_SIZE,
+	ColorSelectorDropdownView
 } from './utils.js';
 
 export type {

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -44,6 +44,8 @@ export {
 	type ColorSelectorColorPickerShowEvent
 } from './colorselector/colorselectorview.js';
 
+export { default as DocumentColorCollection } from './colorselector/documentcolorcollection.js';
+
 export { default as ComponentFactory } from './componentfactory.js';
 
 export { default as Dialog } from './dialog/dialog.js';

--- a/packages/ckeditor5-utils/src/index.ts
+++ b/packages/ckeditor5-utils/src/index.ts
@@ -84,6 +84,7 @@ export { default as FocusTracker, type ViewWithFocusTracker, isViewWithFocusTrac
 export { default as KeystrokeHandler, type KeystrokeHandlerOptions } from './keystrokehandler.js';
 export { default as toArray, type ArrayOrItem, type ReadonlyArrayOrItem } from './toarray.js';
 export { default as toMap } from './tomap.js';
+export { add } from './translation-service.js';
 export { default as priorities, type PriorityString } from './priorities.js';
 export { default as retry, exponentialDelay } from './retry.js';
 export { default as insertToPriorityArray } from './inserttopriorityarray.js';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (font): Export `ColorSelectorDropdownView` type. Closes #17783.

Other (ui): Export `DocumentColorCollection` class. Closes #17783.

Other (engine): Export `SchemaCompiledItemDefinition` type. Closes #17783.

Other (utils): Export `add` function. Closes #17783.

---

### Additional information

Two other exports from the #17783 are already exported (`ClassicEditorUIView` and `DowncastAttributeEvent`). So this PR closes the ticket.
