### PR TITLE
`Code` conversion fix (removed: `word-wrap: break-word`).

### DIFF
--- a/packages/ckeditor5-basic-styles/src/code/codeediting.ts
+++ b/packages/ckeditor5-basic-styles/src/code/codeediting.ts
@@ -59,12 +59,7 @@ export default class CodeEditing extends Plugin {
 
 		editor.conversion.attributeToElement( {
 			model: CODE,
-			view: 'code',
-			upcastAlso: {
-				styles: {
-					'word-wrap': 'break-word'
-				}
-			}
+			view: 'code'
 		} );
 
 		// Create code command.

--- a/packages/ckeditor5-basic-styles/tests/code/codeediting.js
+++ b/packages/ckeditor5-basic-styles/tests/code/codeediting.js
@@ -95,13 +95,14 @@ describe( 'CodeEditing', () => {
 			expect( editor.getData() ).to.equal( '<p><code>foo</code>bar</p>' );
 		} );
 
-		it( 'should convert word-wrap:break-word to code attribute', () => {
+		// See: https://github.com/ckeditor/ckeditor5/issues/17789
+		it( 'should not convert word-wrap:break-word to code attribute', () => {
 			editor.setData( '<p><span style="word-wrap: break-word">foo</span>bar</p>' );
 
 			expect( getModelData( model, { withoutSelection: true } ) )
-				.to.equal( '<paragraph><$text code="true">foo</$text>bar</paragraph>' );
+				.to.equal( '<paragraph>foobar</paragraph>' );
 
-			expect( editor.getData() ).to.equal( '<p><code>foo</code>bar</p>' );
+			expect( editor.getData() ).to.equal( '<p>foobar</p>' );
 		} );
 
 		it( 'should be integrated with autoparagraphing', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix(basic-styles): Should not convert element with style `word-wrap: break-word` into `<code>` tag. Closes #17789.

MINOR BREAKING CHANGE (basic-styles): Elements which contains attribute `style` with `word-wrap: break-word` won't be converted to `<code>`. See #17789.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
