### PR TITLE
Fix typo in list config `@default` jsdoc.

### DIFF
--- a/packages/ckeditor5-list/src/listconfig.ts
+++ b/packages/ckeditor5-list/src/listconfig.ts
@@ -212,10 +212,10 @@ export interface ListPropertiesStyleConfig {
 	 * **Note**: This configuration works only with
 	 * {@link module:list/listproperties~ListProperties list properties}.
 	 *
-	 * @default {
+	 * @default `{
 	 *   numbered: [ 'decimal', 'decimal-leading-zero', 'lower-roman', 'upper-roman', 'lower-latin', 'upper-latin' ],
 	 *   bulleted: [ 'disc', 'circle', 'square' ]
-	 * }
+	 * }`
 	 */
 	listStyleTypes?: ListStyleTypesConfig;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (list): Fix typo in list config `@default` jsdoc.

---

### Additional information

Caused by https://github.com/ckeditor/ckeditor5/pull/17734

