### PR TITLE
Store tiles in a local cache to avoid re-creating them again

### DIFF
--- a/packages/ckeditor5-emoji/src/ui/emojicategoriesview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojicategoriesview.ts
@@ -111,6 +111,7 @@ export default class EmojiCategoriesView extends View {
 
 		this.focusTracker.destroy();
 		this.keystrokes.destroy();
+		this._buttonViews.destroy();
 	}
 
 	/**

--- a/packages/ckeditor5-emoji/src/ui/emojipickerview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojipickerview.ts
@@ -195,6 +195,7 @@ export default class EmojiPickerView extends View<HTMLDivElement> {
 
 		this.focusTracker.destroy();
 		this.keystrokes.destroy();
+		this.items.destroy();
 	}
 
 	/**

--- a/packages/ckeditor5-emoji/src/ui/emojisearchview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojisearchview.ts
@@ -64,6 +64,16 @@ export default class EmojiSearchView extends View {
 	}
 
 	/**
+	 * @inheritDoc
+	 */
+	public override destroy(): void {
+		super.destroy();
+
+		this.inputView.destroy();
+		this.gridView.destroy();
+	}
+
+	/**
 	 * Searches the {@link #gridView} for the given query.
 	 *
 	 * @param query The search query string.

--- a/packages/ckeditor5-emoji/src/ui/emojitoneview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojitoneview.ts
@@ -119,6 +119,15 @@ export default class EmojiToneView extends View {
 	/**
 	 * @inheritDoc
 	 */
+	public override destroy(): void {
+		super.destroy();
+
+		this.dropdownView.destroy();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
 	public focus(): void {
 		this.dropdownView.buttonView.focus();
 	}

--- a/packages/ckeditor5-emoji/tests/ui/emojigridview.js
+++ b/packages/ckeditor5-emoji/tests/ui/emojigridview.js
@@ -215,6 +215,7 @@ describe( 'EmojiGridView', () => {
 			const tile = view._createTile( '😊', 'smile' );
 
 			expect( tile ).to.be.instanceOf( ButtonView );
+			expect( tile.viewUid ).to.equal( '😊' );
 			expect( tile.label ).to.equal( '😊' );
 			expect( tile.withText ).to.be.true;
 			expect( tile.class ).to.equal( 'ck-emoji__tile' );
@@ -229,6 +230,15 @@ describe( 'EmojiGridView', () => {
 
 			sinon.assert.calledOnce( spy );
 			sinon.assert.calledWithExactly( spy, sinon.match.any, { name: 'smile', emoji: '😊' } );
+		} );
+
+		it( 'adds created tile to the collection of cached tiles', () => {
+			expect( view.cachedTiles.has( '😊' ) ).to.equal( false );
+
+			const tile = view._createTile( '😊', 'smile' );
+
+			expect( view.cachedTiles.has( '😊' ) ).to.equal( true );
+			expect( view.cachedTiles.get( '😊' ) ).to.equal( tile );
 		} );
 	} );
 
@@ -337,6 +347,38 @@ describe( 'EmojiGridView', () => {
 			expect( result ).to.deep.equal( { resultsCount: 0, totalItemsCount: 0 } );
 			expect( view.isEmpty ).is.equal( true );
 			sinon.assert.callCount( spy, 0 );
+		} );
+
+		it( 'should re-use cached tile if it exists', () => {
+			emojiGroups = [
+				{
+					title: 'faces',
+					icon: '😊',
+					items: [
+						{ 'annotation': 'grinning face', 'emoji': '😀', 'skins': { 'default': '😀' } },
+						{ 'annotation': 'thumbs up', 'emoji': '👍', 'skins': { 'default': '👍' } },
+						{ 'annotation': 'winking face', 'emoji': '😉', 'skins': { 'default': '😉' } }
+					]
+				}
+			];
+
+			const spy = sinon.stub().returns( [
+				{ 'annotation': 'grinning face', 'emoji': '😀', skins: { 'default': '😀' } }
+			] );
+
+			view = new EmojiGridView( locale, { emojiGroups, categoryName: 'faces', getEmojiBySearchQuery: spy } );
+
+			expect( view.cachedTiles.length ).to.equal( 0 );
+
+			view.filter( new RegExp( 'happy' ) );
+
+			expect( view.cachedTiles.length ).to.equal( 1 );
+			expect( view.cachedTiles.has( '😀' ) ).to.equal( true );
+
+			view.filter( new RegExp( 'smile' ) );
+
+			expect( view.cachedTiles.length ).to.equal( 1 );
+			expect( view.tiles.get( '😀' ) ).to.equal( view.cachedTiles.get( '😀' ) );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: The `EmojiGridView` class stores already created tile views in a local cache property for further usage to avoid re-creating them again. Closes #17776.

Internal: Added missing `destroy()` calls for view components.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
