### PR TITLE
Add clipboard integration to `EmptyBlock` plugin.

### DIFF
--- a/packages/ckeditor5-html-support/tests/emptyblock.js
+++ b/packages/ckeditor5-html-support/tests/emptyblock.js
@@ -359,7 +359,7 @@ describe( 'EmptyBlock', () => {
 		} );
 
 		describe( 'copying content', () => {
-			it( 'should not add block filler in copied model element with `htmlEmptyBlock` attribute', () => {
+			it( 'should not add block filler to copied empty paragraphs', () => {
 				const dataTransferMock = createDataTransfer();
 
 				setModelData( model,

--- a/packages/ckeditor5-html-support/tests/manual/emptyblock.html
+++ b/packages/ckeditor5-html-support/tests/manual/emptyblock.html
@@ -34,6 +34,21 @@
 			<p></p>
 			<p>&nbsp;</p>
 			<p>Some text</p>
+			<table>
+				<tr>
+					<td>Table cell 1</td>
+					<td>Table cell 2</td>
+				</tr>
+				<tr>
+					<td></td>
+					<td></td>
+				</tr>
+			</table>
+			<ul>
+				<li>Item 1</li>
+				<li></li>
+				<li>Item 3</li>
+			</ul>
 		</div>
 	</div>
 
@@ -44,6 +59,21 @@
 			<p></p>
 			<p>&nbsp;</p>
 			<p>Another text</p>
+			<table>
+				<tr>
+					<td>Table cell 1</td>
+					<td>Table cell 2</td>
+				</tr>
+				<tr>
+					<td></td>
+					<td></td>
+				</tr>
+			</table>
+			<ul>
+				<li>Item 1</li>
+				<li></li>
+				<li>Item 3</li>
+			</ul>
 		</div>
 	</div>
 </div>

--- a/packages/ckeditor5-html-support/tests/manual/emptyblock.html
+++ b/packages/ckeditor5-html-support/tests/manual/emptyblock.html
@@ -1,0 +1,54 @@
+<head>
+	<meta
+		http-equiv="Content-Security-Policy"
+		content="script-src 'self' https://ckeditor.com 'unsafe-inline' 'unsafe-eval'"
+	>
+
+	<style>
+		.editors-container {
+			display: flex;
+			gap: 20px;
+		}
+
+		.editor-wrapper {
+			flex: 1;
+		}
+
+		.clipboard-preview-wrapper {
+			margin-top: 20px;
+		}
+
+		.clipboard-preview {
+			padding: 10px;
+			background: #f0f0f0;
+			white-space: pre-wrap;
+		}
+	</style>
+</head>
+
+<div class="editors-container">
+	<div class="editor-wrapper">
+		<h2>Editor 1 (with EmptyBlocks)</h2>
+		<div id="editor1">
+			<p>This is editor 1</p>
+			<p></p>
+			<p>&nbsp;</p>
+			<p>Some text</p>
+		</div>
+	</div>
+
+	<div class="editor-wrapper">
+		<h2>Editor 2 (without EmptyBlocks)</h2>
+		<div id="editor2">
+			<p>This is editor 2</p>
+			<p></p>
+			<p>&nbsp;</p>
+			<p>Another text</p>
+		</div>
+	</div>
+</div>
+
+<div class="clipboard-preview-wrapper">
+	<h3>Clipboard Preview (text/html)</h3>
+	<pre id="clipboard-preview" class="clipboard-preview"></pre>
+</div>

--- a/packages/ckeditor5-html-support/tests/manual/emptyblock.js
+++ b/packages/ckeditor5-html-support/tests/manual/emptyblock.js
@@ -10,18 +10,20 @@ import { SourceEditing } from '@ckeditor/ckeditor5-source-editing';
 import { Essentials } from '@ckeditor/ckeditor5-essentials';
 import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
 import { Heading } from '@ckeditor/ckeditor5-heading';
+import { Table } from '@ckeditor/ckeditor5-table';
 import { List, ListProperties } from '@ckeditor/ckeditor5-list';
 import { Bold, Code, Italic } from '@ckeditor/ckeditor5-basic-styles';
 import EmptyBlock from '../../src/emptyblock.js';
 
-ClassicEditor.create( document.getElementById( 'editor1' ), {
-	plugins: [ Essentials, List, ListProperties, Bold, Italic, Code, Paragraph, Heading, SourceEditing, EmptyBlock ],
-	toolbar: [ 'sourceEditing', 'bulletedList', 'numberedList', 'bold', 'italic', 'heading' ]
-} );
+const config = {
+	plugins: [ Table, Essentials, List, ListProperties, Bold, Italic, Code, Paragraph, Heading, SourceEditing, EmptyBlock ],
+	toolbar: [ 'sourceEditing', '|', 'insertTable', 'bulletedList', 'numberedList', 'bold', 'italic', 'heading' ]
+};
 
+ClassicEditor.create( document.getElementById( 'editor1' ), config );
 ClassicEditor.create( document.getElementById( 'editor2' ), {
-	plugins: [ Essentials, List, ListProperties, Bold, Italic, Code, Paragraph, Heading, SourceEditing ],
-	toolbar: [ 'sourceEditing', 'bulletedList', 'numberedList', 'bold', 'italic', 'heading' ]
+	...config,
+	plugins: config.plugins.filter( plugin => plugin !== EmptyBlock )
 } );
 
 const clipboardPreview = document.getElementById( 'clipboard-preview' );

--- a/packages/ckeditor5-html-support/tests/manual/emptyblock.js
+++ b/packages/ckeditor5-html-support/tests/manual/emptyblock.js
@@ -28,12 +28,9 @@ ClassicEditor.create( document.getElementById( 'editor2' ), {
 
 const clipboardPreview = document.getElementById( 'clipboard-preview' );
 
-document.addEventListener( 'copy', evt => {
-	const html = evt.clipboardData.getData( 'text/html' );
-	clipboardPreview.textContent = html;
-} );
+function handleClipboardEvent( evt ) {
+	clipboardPreview.textContent = evt.clipboardData.getData( 'text/html' );
+}
 
-document.addEventListener( 'cut', evt => {
-	const html = evt.clipboardData.getData( 'text/html' );
-	clipboardPreview.textContent = html;
-} );
+document.addEventListener( 'copy', handleClipboardEvent );
+document.addEventListener( 'cut', handleClipboardEvent );

--- a/packages/ckeditor5-html-support/tests/manual/emptyblock.js
+++ b/packages/ckeditor5-html-support/tests/manual/emptyblock.js
@@ -1,0 +1,37 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+/* global document */
+
+import { ClassicEditor } from '@ckeditor/ckeditor5-editor-classic';
+import { SourceEditing } from '@ckeditor/ckeditor5-source-editing';
+import { Essentials } from '@ckeditor/ckeditor5-essentials';
+import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
+import { Heading } from '@ckeditor/ckeditor5-heading';
+import { List, ListProperties } from '@ckeditor/ckeditor5-list';
+import { Bold, Code, Italic } from '@ckeditor/ckeditor5-basic-styles';
+import EmptyBlock from '../../src/emptyblock.js';
+
+ClassicEditor.create( document.getElementById( 'editor1' ), {
+	plugins: [ Essentials, List, ListProperties, Bold, Italic, Code, Paragraph, Heading, SourceEditing, EmptyBlock ],
+	toolbar: [ 'sourceEditing', 'bulletedList', 'numberedList', 'bold', 'italic', 'heading' ]
+} );
+
+ClassicEditor.create( document.getElementById( 'editor2' ), {
+	plugins: [ Essentials, List, ListProperties, Bold, Italic, Code, Paragraph, Heading, SourceEditing ],
+	toolbar: [ 'sourceEditing', 'bulletedList', 'numberedList', 'bold', 'italic', 'heading' ]
+} );
+
+const clipboardPreview = document.getElementById( 'clipboard-preview' );
+
+document.addEventListener( 'copy', evt => {
+	const html = evt.clipboardData.getData( 'text/html' );
+	clipboardPreview.textContent = html;
+} );
+
+document.addEventListener( 'cut', evt => {
+	const html = evt.clipboardData.getData( 'text/html' );
+	clipboardPreview.textContent = html;
+} );

--- a/packages/ckeditor5-html-support/tests/manual/emptyblock.md
+++ b/packages/ckeditor5-html-support/tests/manual/emptyblock.md
@@ -8,7 +8,7 @@
 
 ### Things to check
 
-1. If you copy `<p>&nbsp;</p>` from the editor without EmptyBlock plugin, and then paste to the editor with the EmptyBlock plugin then the pasted content should be `<p>&nbsp;</p>`.
-2. If you copy `<p>&nbsp;</p>` from the editor with EmptyBlock plugin, and then paste to the editor without EmptyBlock plugin then the pasted content should be `<p>&nbsp;</p>`.
-3. If you copy `<p></p>` from the editor with EmptyBlock plugin, and then paste to the editor without EmptyBlock plugin then the pasted content should be `<p>&nbsp;</p>`.
-4. If you copy `<p></p>` from the editor with EmptyBlock plugin, and then paste to the same editor then the pasted content should be `<p></p>`.
+1. If you copy `<p>&nbsp;</p>` from the editor without the EmptyBlock plugin and then paste it to the editor with the EmptyBlock plugin, then the pasted content should be `<p>&nbsp;</p>`.
+2. If you copy `<p>&nbsp;</p>` from the editor with the EmptyBlock plugin and then paste it to the editor without the EmptyBlock plugin, then the pasted content should be `<p>&nbsp;</p>`.
+3. If you copy `<p></p>` from the editor with the EmptyBlock plugin and then paste it to the editor without the EmptyBlock plugin, then the pasted content should be `<p>&nbsp;</p>`.
+4. If you copy `<p></p>` from the editor with the EmptyBlock plugin and then paste it to the same editor, then the pasted content should be `<p></p>`.

--- a/packages/ckeditor5-html-support/tests/manual/emptyblock.md
+++ b/packages/ckeditor5-html-support/tests/manual/emptyblock.md
@@ -1,0 +1,14 @@
+# Empty Block Manual Test
+
+## Test scenario
+
+1. You should see two editors side by side and a clipboard preview area below them.
+2. Both editors have the source editing plugin enabled.
+3. The clipboard preview area shows the HTML content of the last clipboard operation (copy/cut).
+
+### Things to check
+
+1. If you copy `<p>&nbsp;</p>` from the editor without EmptyBlock plugin, and then paste to the editor with the EmptyBlock plugin then the pasted content should be `<p>&nbsp;</p>`.
+2. If you copy `<p>&nbsp;</p>` from the editor with EmptyBlock plugin, and then paste to the editor without EmptyBlock plugin then the pasted content should be `<p>&nbsp;</p>`.
+3. If you copy `<p></p>` from the editor with EmptyBlock plugin, and then paste to the editor without EmptyBlock plugin then the pasted content should be `<p>&nbsp;</p>`.
+4. If you copy `<p></p>` from the editor with EmptyBlock plugin, and then paste to the same editor then the pasted content should be `<p></p>`.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (html-support): Add clipboard integration to `EmptyBlock` plugin.

---

### Additional information

Original PR: https://github.com/ckeditor/ckeditor5/pull/17756
