### PR TITLE
Improved accessibility of the emoji picker

### DIFF
--- a/packages/ckeditor5-emoji/src/ui/emojicategoriesview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojicategoriesview.ts
@@ -7,7 +7,7 @@
  * @module emoji/ui/emojicategoriesview
  */
 
-import { ButtonView, View, ViewCollection, FocusCycler } from 'ckeditor5/src/ui.js';
+import { ButtonView, View, FocusCycler, type ViewCollection } from 'ckeditor5/src/ui.js';
 import { FocusTracker, KeystrokeHandler, type Locale, type ObservableChangeEvent } from 'ckeditor5/src/utils.js';
 import type { EmojiCategory } from '../emojidatabase.js';
 
@@ -51,7 +51,7 @@ export default class EmojiCategoriesView extends View {
 	constructor( locale: Locale, { emojiGroups, categoryName }: { emojiGroups: Array<EmojiCategory>; categoryName: string } ) {
 		super( locale );
 
-		this.buttonViews = new ViewCollection(
+		this.buttonViews = this.createCollection(
 			emojiGroups.map( emojiGroup => this._createCategoryButton( emojiGroup ) )
 		);
 

--- a/packages/ckeditor5-emoji/src/ui/emojicategoriesview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojicategoriesview.ts
@@ -13,8 +13,6 @@ import type { EmojiCategory } from '../emojidatabase.js';
 
 import '../../theme/emojicategories.css';
 
-const ACTIVE_CATEGORY_CLASS = 'ck-emoji__category-item_active';
-
 /**
  * A class representing the navigation part of the emoji UI.
  * It is responsible allowing the user to select a particular emoji category.
@@ -70,7 +68,7 @@ export default class EmojiCategoriesView extends View {
 		this.setTemplate( {
 			tag: 'div',
 			attributes: {
-				class: [ 'ck', 'ck-emoji__categories' ],
+				class: [ 'ck', 'ck-emoji__categories-list' ],
 				role: 'tablist'
 			},
 			children: this.buttonViews
@@ -155,7 +153,7 @@ export default class EmojiCategoriesView extends View {
 			attributes: {
 				'aria-selected': bind.to( 'isOn', value => value.toString() ),
 				class: [
-					bind.if( 'isOn', ACTIVE_CATEGORY_CLASS, value => value )
+					'ck-emoji__category-item'
 				]
 			}
 		} );

--- a/packages/ckeditor5-emoji/src/ui/emojicategoriesview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojicategoriesview.ts
@@ -8,7 +8,7 @@
  */
 
 import { ButtonView, View, ViewCollection, FocusCycler } from 'ckeditor5/src/ui.js';
-import { FocusTracker, KeystrokeHandler, type Locale } from 'ckeditor5/src/utils.js';
+import { FocusTracker, KeystrokeHandler, type Locale, type ObservableChangeEvent } from 'ckeditor5/src/utils.js';
 import type { EmojiCategory } from '../emojidatabase.js';
 
 import '../../theme/emojicategories.css';
@@ -43,7 +43,7 @@ export default class EmojiCategoriesView extends View {
 	/**
 	 * A collection of the categories buttons.
 	 */
-	private readonly _buttonViews: ViewCollection<ButtonView>;
+	public readonly buttonViews: ViewCollection<ButtonView>;
 
 	/**
 	 * @inheritDoc
@@ -51,14 +51,14 @@ export default class EmojiCategoriesView extends View {
 	constructor( locale: Locale, { emojiGroups, categoryName }: { emojiGroups: Array<EmojiCategory>; categoryName: string } ) {
 		super( locale );
 
-		this._buttonViews = new ViewCollection(
-			this._createCategoryButtons( emojiGroups )
+		this.buttonViews = new ViewCollection(
+			emojiGroups.map( emojiGroup => this._createCategoryButton( emojiGroup ) )
 		);
 
 		this.focusTracker = new FocusTracker();
 		this.keystrokes = new KeystrokeHandler();
 		this.focusCycler = new FocusCycler( {
-			focusables: this._buttonViews,
+			focusables: this.buttonViews,
 			focusTracker: this.focusTracker,
 			keystrokeHandler: this.keystrokes,
 			actions: {
@@ -73,18 +73,18 @@ export default class EmojiCategoriesView extends View {
 				class: [ 'ck', 'ck-emoji__categories' ],
 				role: 'tablist'
 			},
-			children: this._buttonViews
+			children: this.buttonViews
 		} );
 
-		this.on( 'change:categoryName', ( event, name, newValue, oldValue ) => {
-			const previousButton = this._buttonViews.find( button => button.tooltip === oldValue )!;
-			const newButton = this._buttonViews.find( button => button.tooltip === newValue )!;
+		this.on<ObservableChangeEvent<string>>( 'change:categoryName', ( event, name, newValue, oldValue ) => {
+			const oldCategoryButton = this.buttonViews.find( button => button.tooltip === oldValue );
 
-			if ( previousButton ) {
-				previousButton.class = '';
+			if ( oldCategoryButton ) {
+				oldCategoryButton.isOn = false;
 			}
 
-			newButton.class = ACTIVE_CATEGORY_CLASS;
+			const newCategoryButton = this.buttonViews.find( button => button.tooltip === newValue )!;
+			newCategoryButton.isOn = true;
 		} );
 
 		this.set( 'categoryName', categoryName );
@@ -96,7 +96,7 @@ export default class EmojiCategoriesView extends View {
 	public override render(): void {
 		super.render();
 
-		this._buttonViews.forEach( buttonView => {
+		this.buttonViews.forEach( buttonView => {
 			this.focusTracker.add( buttonView );
 		} );
 
@@ -111,21 +111,21 @@ export default class EmojiCategoriesView extends View {
 
 		this.focusTracker.destroy();
 		this.keystrokes.destroy();
-		this._buttonViews.destroy();
+		this.buttonViews.destroy();
 	}
 
 	/**
 	 * @inheritDoc
 	 */
 	public focus(): void {
-		this._buttonViews.first!.focus();
+		this.buttonViews.first!.focus();
 	}
 
 	/**
 	 * Marks all categories buttons as enabled (clickable).
 	 */
 	public enableCategories(): void {
-		this._buttonViews.forEach( buttonView => {
+		this.buttonViews.forEach( buttonView => {
 			buttonView.isEnabled = true;
 		} );
 	}
@@ -134,32 +134,53 @@ export default class EmojiCategoriesView extends View {
 	 * Marks all categories buttons as disabled (non-clickable).
 	 */
 	public disableCategories(): void {
-		this._buttonViews.forEach( buttonView => {
-			buttonView.isEnabled = false;
+		this.buttonViews.forEach( buttonView => {
+			buttonView.set( {
+				class: '',
+				isEnabled: false,
+				isOn: false
+			} );
 		} );
 	}
 
-	private _createCategoryButtons( emojiGroups: Array<EmojiCategory> ): Array<ButtonView> {
-		return emojiGroups.map( emojiGroup => {
-			const buttonView = new ButtonView();
+	/**
+	 * Creates a button representing a category item.
+	 */
+	private _createCategoryButton( emojiGroup: EmojiCategory ): ButtonView {
+		const buttonView = new ButtonView();
+		const bind = buttonView.bindTemplate;
 
-			buttonView.tooltip = emojiGroup.title;
-			buttonView.label = emojiGroup.icon;
-			buttonView.withText = true;
-
-			buttonView.on( 'execute', () => {
-				this.categoryName = buttonView.tooltip as string;
-			} );
-
-			buttonView.on( 'change:isEnabled', ( event, name, oldValue, newValue ) => {
-				if ( newValue ) {
-					buttonView.class = '';
-				} else if ( buttonView.tooltip === this.categoryName ) {
-					buttonView.class = ACTIVE_CATEGORY_CLASS;
-				}
-			} );
-
-			return buttonView;
+		// A `[role="tab"]` element requires also the `[aria-selected]` attribute with its state.
+		buttonView.extendTemplate( {
+			attributes: {
+				'aria-selected': bind.to( 'isOn', value => value.toString() ),
+				class: [
+					bind.if( 'isOn', ACTIVE_CATEGORY_CLASS, value => value )
+				]
+			}
 		} );
+
+		buttonView.set( {
+			ariaLabel: emojiGroup.title,
+			label: emojiGroup.icon,
+			role: 'tab',
+			tooltip: emojiGroup.title,
+			withText: true,
+			// To improve accessibility, disconnect a button and its label connection so that screen
+			// readers can read the `[aria-label]` attribute directly from the more descriptive button.
+			ariaLabelledBy: undefined
+		} );
+
+		buttonView.on( 'execute', () => {
+			this.categoryName = emojiGroup.title;
+		} );
+
+		buttonView.on<ObservableChangeEvent<boolean>>( 'change:isEnabled', () => {
+			if ( buttonView.isEnabled && buttonView.tooltip === this.categoryName ) {
+				buttonView.isOn = true;
+			}
+		} );
+
+		return buttonView;
 	}
 }

--- a/packages/ckeditor5-emoji/src/ui/emojigridview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojigridview.ts
@@ -245,12 +245,20 @@ export default class EmojiGridView extends View<HTMLDivElement> implements Filte
 	private _createTile( emoji: string, name: string ): ButtonView {
 		const tile = new ButtonView( this.locale );
 
+		tile.viewUid = emoji;
+
+		tile.extendTemplate( {
+			attributes: {
+				class: [
+					'ck-emoji__tile'
+				]
+			}
+		} );
+
 		tile.set( {
-			viewUid: emoji,
 			label: emoji,
 			tooltip: name,
 			withText: true,
-			class: 'ck-emoji__tile',
 			ariaLabel: name,
 			// To improve accessibility, disconnect a button and its label connection so that screen
 			// readers can read the `[aria-label]` attribute directly from the more descriptive button.

--- a/packages/ckeditor5-emoji/src/ui/emojigridview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojigridview.ts
@@ -66,7 +66,7 @@ export default class EmojiGridView extends View<HTMLDivElement> implements Filte
 
 	/**
 	 * A collection of all already created tile views. Each tile represents a particular emoji.
-	 * The cached tiles collection is used for efficiency purposes to avoid re-creating a particual
+	 * The cached tiles collection is used for efficiency purposes to avoid re-creating a particular
 	 * tile again when the grid view has changed.
 	 */
 	private readonly cachedTiles: ViewCollection<ButtonView>;
@@ -247,18 +247,16 @@ export default class EmojiGridView extends View<HTMLDivElement> implements Filte
 	private _createTile( emoji: string, name: string ): ButtonView {
 		const tile = new ButtonView( this.locale );
 
-		tile.viewUid = emoji;
-
 		tile.set( {
+			viewUid: emoji,
 			label: emoji,
+			tooltip: name,
 			withText: true,
-			class: 'ck-emoji__tile'
-		} );
-
-		tile.extendTemplate( {
-			attributes: {
-				title: name
-			}
+			class: 'ck-emoji__tile',
+			ariaLabel: name,
+			// To improve accessibility, disconnect a button and its label connection so that screen
+			// readers can read the `[aria-label]` attribute directly from the more descriptive button.
+			ariaLabelledBy: undefined
 		} );
 
 		tile.on( 'execute', () => {

--- a/packages/ckeditor5-emoji/src/ui/emojigridview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojigridview.ts
@@ -153,8 +153,6 @@ export default class EmojiGridView extends View<HTMLDivElement> implements Filte
 
 		this.keystrokes.destroy();
 		this.focusTracker.destroy();
-		this.tiles.destroy();
-		this.cachedTiles.destroy();
 	}
 
 	/**

--- a/packages/ckeditor5-emoji/src/ui/emojipickerview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojipickerview.ts
@@ -191,7 +191,6 @@ export default class EmojiPickerView extends View<HTMLDivElement> {
 
 		this.focusTracker.destroy();
 		this.keystrokes.destroy();
-		this.items.destroy();
 	}
 
 	/**

--- a/packages/ckeditor5-emoji/src/ui/emojisearchview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojisearchview.ts
@@ -73,7 +73,6 @@ export default class EmojiSearchView extends View {
 		super.destroy();
 
 		this.inputView.destroy();
-		this.gridView.destroy();
 	}
 
 	/**

--- a/packages/ckeditor5-emoji/src/ui/emojitoneview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojitoneview.ts
@@ -126,15 +126,6 @@ export default class EmojiToneView extends View {
 	/**
 	 * @inheritDoc
 	 */
-	public override destroy(): void {
-		super.destroy();
-
-		this.dropdownView.destroy();
-	}
-
-	/**
-	 * @inheritDoc
-	 */
 	public focus(): void {
 		this.dropdownView.buttonView.focus();
 	}

--- a/packages/ckeditor5-emoji/src/ui/emojitoneview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojitoneview.ts
@@ -68,7 +68,10 @@ export default class EmojiToneView extends View {
 					tooltip,
 					tooltipPosition: 'e',
 					role: 'menuitemradio',
-					withText: true
+					withText: true,
+					// To improve accessibility, disconnect a button and its label connection so that screen
+					// readers can read the `[aria-label]` attribute directly from the more descriptive button.
+					ariaLabelledBy: undefined
 				} )
 			};
 
@@ -107,7 +110,8 @@ export default class EmojiToneView extends View {
 		} );
 
 		dropdownView.buttonView.bind( 'ariaLabel' ).to( this, 'skinTone', () => {
-			return this._getSkinTone().tooltip;
+			// Render a current state, but also what the dropdown does.
+			return `${ this._getSkinTone().tooltip }, ${ accessibleLabel }`;
 		} );
 
 		this.setTemplate( {

--- a/packages/ckeditor5-emoji/tests/ui/emojicategoriesview.js
+++ b/packages/ckeditor5-emoji/tests/ui/emojicategoriesview.js
@@ -5,6 +5,7 @@
 
 import EmojiCategoriesView from '../../src/ui/emojicategoriesview.js';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
+import ViewCollection from '@ckeditor/ckeditor5-ui/src/viewcollection.js';
 
 describe( 'EmojiCategoriesView', () => {
 	let locale, emojiCategoriesView, emojiGroups;
@@ -38,6 +39,13 @@ describe( 'EmojiCategoriesView', () => {
 	} );
 
 	describe( 'constructor()', () => {
+		it( 'creates `view#buttonViews` collection', () => {
+			expect( emojiCategoriesView.buttonViews ).to.be.instanceOf( ViewCollection );
+
+			// To check if the `#createCollection()` factory was used.
+			expect( emojiCategoriesView._viewCollections.has( emojiCategoriesView.buttonViews ) ).to.equal( true );
+		} );
+
 		it( 'creates #element from template', () => {
 			expect( emojiCategoriesView.element.classList.contains( 'ck' ) ).to.be.true;
 			expect( emojiCategoriesView.element.classList.contains( 'ck-emoji__categories' ) ).to.be.true;
@@ -69,14 +77,6 @@ describe( 'EmojiCategoriesView', () => {
 
 		it( 'should destroy an instance of keystroke handler', () => {
 			const spy = sinon.spy( emojiCategoriesView.keystrokes, 'destroy' );
-
-			emojiCategoriesView.destroy();
-
-			sinon.assert.calledOnce( spy );
-		} );
-
-		it( 'should destroy an instance of category buttons', () => {
-			const spy = sinon.spy( emojiCategoriesView.buttonViews, 'destroy' );
 
 			emojiCategoriesView.destroy();
 

--- a/packages/ckeditor5-emoji/tests/ui/emojicategoriesview.js
+++ b/packages/ckeditor5-emoji/tests/ui/emojicategoriesview.js
@@ -19,13 +19,13 @@ describe( 'EmojiCategoriesView', () => {
 		emojiGroups = [
 			{
 				title: 'faces',
-				exampleEmoji: '😊'
+				icon: '😊'
 			}, {
 				title: 'food',
-				exampleEmoji: '🍕'
+				icon: '🍕'
 			}, {
 				title: 'things',
-				exampleEmoji: '📕'
+				icon: '📕'
 			}
 		];
 
@@ -35,14 +35,6 @@ describe( 'EmojiCategoriesView', () => {
 
 	afterEach( () => {
 		emojiCategoriesView.destroy();
-	} );
-
-	it( 'updates `categoryName` on a category item click', () => {
-		expect( emojiCategoriesView.categoryName ).to.equal( 'faces' );
-
-		emojiCategoriesView._buttonViews._items[ 1 ].fire( 'execute' );
-
-		expect( emojiCategoriesView.categoryName ).to.equal( 'food' );
 	} );
 
 	describe( 'constructor()', () => {
@@ -57,10 +49,36 @@ describe( 'EmojiCategoriesView', () => {
 	} );
 
 	describe( 'focus()', () => {
-		it( 'focuses the search bar', () => {
-			const spy = sinon.spy( emojiCategoriesView._buttonViews.first, 'focus' );
+		it( 'should focus the first category item', () => {
+			const spy = sinon.spy( emojiCategoriesView.buttonViews.first, 'focus' );
 
 			emojiCategoriesView.focus();
+
+			sinon.assert.calledOnce( spy );
+		} );
+	} );
+
+	describe( 'destroy()', () => {
+		it( 'should destroy an instance of focus tracker', () => {
+			const spy = sinon.spy( emojiCategoriesView.focusTracker, 'destroy' );
+
+			emojiCategoriesView.destroy();
+
+			sinon.assert.calledOnce( spy );
+		} );
+
+		it( 'should destroy an instance of keystroke handler', () => {
+			const spy = sinon.spy( emojiCategoriesView.keystrokes, 'destroy' );
+
+			emojiCategoriesView.destroy();
+
+			sinon.assert.calledOnce( spy );
+		} );
+
+		it( 'should destroy an instance of category buttons', () => {
+			const spy = sinon.spy( emojiCategoriesView.buttonViews, 'destroy' );
+
+			emojiCategoriesView.destroy();
 
 			sinon.assert.calledOnce( spy );
 		} );
@@ -70,19 +88,24 @@ describe( 'EmojiCategoriesView', () => {
 		it( 'enables all buttons', () => {
 			emojiCategoriesView.enableCategories();
 
-			emojiCategoriesView._buttonViews.forEach( buttonView => {
+			emojiCategoriesView.buttonViews.forEach( buttonView => {
 				expect( buttonView.isEnabled ).to.equal( true );
 			} );
 		} );
 
 		it( 'should restore the "active" category indicator when categories are enabled', () => {
-			const button = emojiCategoriesView._buttonViews.get( 0 );
+			const button = emojiCategoriesView.buttonViews.get( 0 );
 
 			expect( button.element.classList.contains( 'ck-emoji__category-item_active' ) ).to.equal( true );
+			expect( button.isOn ).to.equal( true );
+
 			emojiCategoriesView.disableCategories();
 			expect( button.element.classList.contains( 'ck-emoji__category-item_active' ) ).to.equal( false );
+			expect( button.isOn ).to.equal( false );
+
 			emojiCategoriesView.enableCategories();
 			expect( button.element.classList.contains( 'ck-emoji__category-item_active' ) ).to.equal( true );
+			expect( button.isOn ).to.equal( true );
 		} );
 	} );
 
@@ -90,9 +113,82 @@ describe( 'EmojiCategoriesView', () => {
 		it( 'disables all buttons', () => {
 			emojiCategoriesView.disableCategories();
 
-			emojiCategoriesView._buttonViews.forEach( buttonView => {
+			emojiCategoriesView.buttonViews.forEach( buttonView => {
+				expect( buttonView.class ).to.equal( '' );
+				expect( buttonView.isOn ).to.equal( false );
 				expect( buttonView.isEnabled ).to.equal( false );
 			} );
+		} );
+	} );
+
+	describe( '_createCategoryButton()', () => {
+		it( 'renders the `[role]` attribute on each item', () => {
+			const categoryButton = emojiCategoriesView._createCategoryButton( {
+				title: 'faces',
+				icon: '😊'
+			} );
+
+			expect( categoryButton.role ).to.equal( 'tab' );
+		} );
+
+		it( 'does not use the `[aria-labelled-by]` attribute as the button is descriptive enough', () => {
+			const categoryButton = emojiCategoriesView._createCategoryButton( {
+				title: 'faces',
+				icon: '😊'
+			} );
+
+			expect( categoryButton.ariaLabelledBy ).to.equal( undefined );
+		} );
+
+		it( 'uses the emoji instead of a descriptive text label for a non-screen reader', () => {
+			const categoryButton = emojiCategoriesView._createCategoryButton( {
+				title: 'faces',
+				icon: '😊'
+			} );
+
+			expect( categoryButton.label ).to.equal( '😊' );
+		} );
+
+		it( 'uses the emoji name instead of an icon for a screen reader', () => {
+			const categoryButton = emojiCategoriesView._createCategoryButton( {
+				title: 'faces',
+				icon: '😊'
+			} );
+
+			expect( categoryButton.ariaLabel ).to.equal( 'faces' );
+		} );
+	} );
+
+	describe( '#buttonViews', () => {
+		it( 'updates `categoryName` upon clicking  a category item click', () => {
+			expect( emojiCategoriesView.categoryName ).to.equal( 'faces' );
+
+			emojiCategoriesView.buttonViews.get( 1 ).fire( 'execute' );
+
+			expect( emojiCategoriesView.categoryName ).to.equal( 'food' );
+		} );
+
+		it( 'deactivates the previous active button upon clicking on a new one', () => {
+			const facesButton = emojiCategoriesView.buttonViews.get( 0 );
+			const thingsBottom = emojiCategoriesView.buttonViews.get( 2 );
+
+			expect( facesButton.isOn ).to.equal( true );
+			expect( thingsBottom.isOn ).to.equal( false );
+
+			thingsBottom.fire( 'execute' );
+
+			expect( facesButton.isOn ).to.equal( false );
+			expect( thingsBottom.isOn ).to.equal( true );
+		} );
+
+		it( 'renders the `[aria-selected]` attribute on each item', () => {
+			const facesButton = emojiCategoriesView.buttonViews.get( 0 );
+			const foodButton = emojiCategoriesView.buttonViews.get( 1 );
+			const thingsBottom = emojiCategoriesView.buttonViews.get( 2 );
+
+			expect( facesButton.element.getAttribute( 'aria-selected' ) ).to.equal( 'true' );
+			expect( foodButton.element.getAttribute( 'aria-selected' ) ).to.equal( 'false' );
+			expect( thingsBottom.element.getAttribute( 'aria-selected' ) ).to.equal( 'false' );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-emoji/tests/ui/emojicategoriesview.js
+++ b/packages/ckeditor5-emoji/tests/ui/emojicategoriesview.js
@@ -48,7 +48,7 @@ describe( 'EmojiCategoriesView', () => {
 
 		it( 'creates #element from template', () => {
 			expect( emojiCategoriesView.element.classList.contains( 'ck' ) ).to.be.true;
-			expect( emojiCategoriesView.element.classList.contains( 'ck-emoji__categories' ) ).to.be.true;
+			expect( emojiCategoriesView.element.classList.contains( 'ck-emoji__categories-list' ) ).to.be.true;
 
 			expect( Object.values( emojiCategoriesView.element.childNodes ).length ).to.equal( emojiGroups.length );
 
@@ -96,15 +96,12 @@ describe( 'EmojiCategoriesView', () => {
 		it( 'should restore the "active" category indicator when categories are enabled', () => {
 			const button = emojiCategoriesView.buttonViews.get( 0 );
 
-			expect( button.element.classList.contains( 'ck-emoji__category-item_active' ) ).to.equal( true );
 			expect( button.isOn ).to.equal( true );
 
 			emojiCategoriesView.disableCategories();
-			expect( button.element.classList.contains( 'ck-emoji__category-item_active' ) ).to.equal( false );
 			expect( button.isOn ).to.equal( false );
 
 			emojiCategoriesView.enableCategories();
-			expect( button.element.classList.contains( 'ck-emoji__category-item_active' ) ).to.equal( true );
 			expect( button.isOn ).to.equal( true );
 		} );
 	} );

--- a/packages/ckeditor5-emoji/tests/ui/emojigridview.js
+++ b/packages/ckeditor5-emoji/tests/ui/emojigridview.js
@@ -72,14 +72,14 @@ describe( 'EmojiGridView', () => {
 
 		it( 'creates #element from template', () => {
 			expect( view.element.getAttribute( 'role' ) ).to.equal( 'tabpanel' );
-			expect( view.element.classList.contains( 'ck' ) ).to.be.true;
-			expect( view.element.classList.contains( 'ck-emoji__tiles' ) ).to.be.true;
+			expect( view.element.classList.contains( 'ck' ) ).to.equal( true );
+			expect( view.element.classList.contains( 'ck-emoji__tiles' ) ).to.equal( true );
 
 			const tilesContainer = view.element.firstChild;
 
 			expect( tilesContainer.getAttribute( 'role' ) ).to.equal( 'grid' );
-			expect( tilesContainer.classList.contains( 'ck' ) ).to.be.true;
-			expect( tilesContainer.classList.contains( 'ck-emoji__grid' ) ).to.be.true;
+			expect( tilesContainer.classList.contains( 'ck' ) ).to.equal( true );
+			expect( tilesContainer.classList.contains( 'ck-emoji__grid' ) ).to.equal( true );
 		} );
 
 		describe( 'Focus management across the grid items using arrow keys', () => {
@@ -207,38 +207,6 @@ describe( 'EmojiGridView', () => {
 					sinon.assert.calledOnce( spy );
 				} );
 			} );
-		} );
-	} );
-
-	describe( 'createTile()', () => {
-		it( 'creates a new tile button', () => {
-			const tile = view._createTile( '😊', 'smile' );
-
-			expect( tile ).to.be.instanceOf( ButtonView );
-			expect( tile.viewUid ).to.equal( '😊' );
-			expect( tile.label ).to.equal( '😊' );
-			expect( tile.withText ).to.be.true;
-			expect( tile.class ).to.equal( 'ck-emoji__tile' );
-		} );
-
-		it( 'delegates #execute from the tile to the grid', () => {
-			const tile = view._createTile( '😊', 'smile' );
-			const spy = sinon.spy();
-
-			view.on( 'execute', spy );
-			tile.fire( 'execute' );
-
-			sinon.assert.calledOnce( spy );
-			sinon.assert.calledWithExactly( spy, sinon.match.any, { name: 'smile', emoji: '😊' } );
-		} );
-
-		it( 'adds created tile to the collection of cached tiles', () => {
-			expect( view.cachedTiles.has( '😊' ) ).to.equal( false );
-
-			const tile = view._createTile( '😊', 'smile' );
-
-			expect( view.cachedTiles.has( '😊' ) ).to.equal( true );
-			expect( view.cachedTiles.get( '😊' ) ).to.equal( tile );
 		} );
 	} );
 
@@ -379,6 +347,46 @@ describe( 'EmojiGridView', () => {
 
 			expect( view.cachedTiles.length ).to.equal( 1 );
 			expect( view.tiles.get( '😀' ) ).to.equal( view.cachedTiles.get( '😀' ) );
+		} );
+	} );
+
+	describe( '_createTile()', () => {
+		it( 'creates a new tile button', () => {
+			const tile = view._createTile( '😊', 'smile' );
+
+			expect( tile ).to.be.instanceOf( ButtonView );
+			expect( tile.viewUid ).to.equal( '😊' );
+			expect( tile.label ).to.equal( '😊' );
+			expect( tile.tooltip ).to.equal( 'smile' );
+			expect( tile.class ).to.equal( 'ck-emoji__tile' );
+			expect( tile.withText ).to.equal( true );
+		} );
+
+		it( 'does not use the `[aria-labelled-by]` attribute as the button is descriptive enough', () => {
+			const tile = view._createTile( '😊', 'smile' );
+
+			expect( tile.ariaLabel ).to.equal( 'smile' );
+			expect( tile.ariaLabelledBy ).to.equal( undefined );
+		} );
+
+		it( 'delegates `execute` from the tile to the grid', () => {
+			const tile = view._createTile( '😊', 'smile' );
+			const spy = sinon.spy();
+
+			view.on( 'execute', spy );
+			tile.fire( 'execute' );
+
+			sinon.assert.calledOnce( spy );
+			sinon.assert.calledWithExactly( spy, sinon.match.any, { name: 'smile', emoji: '😊' } );
+		} );
+
+		it( 'adds created tile to the collection of cached tiles', () => {
+			expect( view.cachedTiles.has( '😊' ) ).to.equal( false );
+
+			const tile = view._createTile( '😊', 'smile' );
+
+			expect( view.cachedTiles.has( '😊' ) ).to.equal( true );
+			expect( view.cachedTiles.get( '😊' ) ).to.equal( tile );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-emoji/tests/ui/emojigridview.js
+++ b/packages/ckeditor5-emoji/tests/ui/emojigridview.js
@@ -427,8 +427,8 @@ describe( 'EmojiGridView', () => {
 			expect( tile.viewUid ).to.equal( '😊' );
 			expect( tile.label ).to.equal( '😊' );
 			expect( tile.tooltip ).to.equal( 'smile' );
-			expect( tile.class ).to.equal( 'ck-emoji__tile' );
 			expect( tile.withText ).to.equal( true );
+			expect( tile.element.classList.contains( 'ck-emoji__tile' ) ).to.equal( true );
 		} );
 
 		it( 'does not use the `[aria-labelled-by]` attribute as the button is descriptive enough', () => {

--- a/packages/ckeditor5-emoji/tests/ui/emojipickerview.js
+++ b/packages/ckeditor5-emoji/tests/ui/emojipickerview.js
@@ -3,12 +3,12 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
+import { SearchInfoView, ViewCollection } from 'ckeditor5/src/ui.js';
 import EmojiCategoriesView from '../../src/ui/emojicategoriesview.js';
 import EmojiGridView from '../../src/ui/emojigridview.js';
 import EmojiPickerView from '../../src/ui/emojipickerview.js';
 import EmojiSearchView from '../../src/ui/emojisearchview.js';
 import EmojiToneView from '../../src/ui/emojitoneview.js';
-import { SearchInfoView } from 'ckeditor5/src/ui.js';
 
 describe( 'EmojiPickerView', () => {
 	let emojiPickerView, locale, emojiGroups, skinTones, emojiBySearchQuery;
@@ -104,6 +104,13 @@ describe( 'EmojiPickerView', () => {
 			expect( emojiPickerView.template.attributes.tabindex ).to.deep.equal( [ '-1' ] );
 		} );
 
+		it( 'creates `view#items` collection', () => {
+			expect( emojiPickerView.items ).to.be.instanceOf( ViewCollection );
+
+			// To check if the `#createCollection()` factory was used.
+			expect( emojiPickerView._viewCollections.has( emojiPickerView.items ) ).to.equal( true );
+		} );
+
 		describe( 'events handling', () => {
 			it( 'should disable categories on search event emitted when query is not empty', () => {
 				const stub = sinon.stub( emojiPickerView.categoriesView, 'disableCategories' );
@@ -121,7 +128,7 @@ describe( 'EmojiPickerView', () => {
 				sinon.assert.calledOnce( stub );
 			} );
 
-			it( 'should set info view properties when search query length is equal to one', () => {
+			it( 'should display a hint for users when the query is too short', () => {
 				emojiPickerView.searchView.fire( 'search', { query: '1' } );
 
 				expect( emojiPickerView.infoView.primaryText ).to.equal( 'Keep on typing to see the emoji.' );
@@ -129,7 +136,7 @@ describe( 'EmojiPickerView', () => {
 				expect( emojiPickerView.infoView.isVisible ).to.equal( true );
 			} );
 
-			it( 'should set info view properties when search query is other than one and there is nothing to show', () => {
+			it( 'should display a note when emoji were not matched with the specified query', () => {
 				emojiPickerView.searchView.fire( 'search', { query: 'foo', resultsCount: 0 } );
 
 				expect( emojiPickerView.infoView.primaryText ).to.equal( 'No emojis were found matching "%0".' );
@@ -137,13 +144,13 @@ describe( 'EmojiPickerView', () => {
 				expect( emojiPickerView.infoView.isVisible ).to.equal( true );
 			} );
 
-			it( 'should set info view properties when search query is other than one and there are results to show', () => {
+			it( 'should hide the hint view when found emoji matches with the specified query', () => {
 				emojiPickerView.searchView.fire( 'search', { query: 'foo', resultsCount: 1 } );
 
 				expect( emojiPickerView.infoView.isVisible ).to.equal( false );
 			} );
 
-			it( 'should set info view properties when search query is other than one and there are results to show', () => {
+			it( 'should trigger the search mechanism when an active category is changed', () => {
 				const stub = sinon.stub( emojiPickerView.searchView, 'search' );
 
 				emojiPickerView.categoriesView.categoryName = 'food';
@@ -153,7 +160,7 @@ describe( 'EmojiPickerView', () => {
 				sinon.assert.calledWith( stub, '' );
 			} );
 
-			it( 'should set info view properties when search query is other than one and there are results to show', () => {
+			it( 'should use the current query value when updating the skin tone property', () => {
 				const searchStub = sinon.stub( emojiPickerView.searchView, 'search' );
 				const getInputValueStub = sinon.stub( emojiPickerView.searchView, 'getInputValue' ).returns( 'thum' );
 

--- a/packages/ckeditor5-emoji/tests/ui/emojisearchview.js
+++ b/packages/ckeditor5-emoji/tests/ui/emojisearchview.js
@@ -102,6 +102,16 @@ describe( 'EmojiSearchView', () => {
 		} );
 	} );
 
+	describe( 'destroy()', () => {
+		it( 'should destroy an instance of the search view', () => {
+			const spy = sinon.spy( emojiSearchView.inputView, 'destroy' );
+
+			emojiSearchView.destroy();
+
+			sinon.assert.calledOnce( spy );
+		} );
+	} );
+
 	describe( 'setInputValue()', () => {
 		it( 'sets the value of text input element to passed string', () => {
 			emojiSearchView.setInputValue( 'smile' );

--- a/packages/ckeditor5-emoji/tests/ui/emojitoneview.js
+++ b/packages/ckeditor5-emoji/tests/ui/emojitoneview.js
@@ -33,16 +33,6 @@ describe( 'EmojiToneView', () => {
 		emojiToneView.destroy();
 	} );
 
-	it( 'updates the skin tone when #execute event triggers', () => {
-		emojiToneView.dropdownView.isOpen = true;
-
-		expect( emojiToneView.skinTone ).to.equal( 'default' );
-
-		emojiToneView.dropdownView.listView.items.get( 5 ).children.first.fire( 'execute' );
-
-		expect( emojiToneView.skinTone ).to.equal( 'dark' );
-	} );
-
 	describe( 'constructor()', () => {
 		it( 'creates #element from template', () => {
 			expect( emojiToneView.element.classList.contains( 'ck' ) ).to.be.true;
@@ -72,6 +62,86 @@ describe( 'EmojiToneView', () => {
 			emojiToneView.focus();
 
 			sinon.assert.calledOnce( spy );
+		} );
+	} );
+
+	describe( '#dropdownView', () => {
+		it( 'updates the `#skinTone` property on click on a menu option', () => {
+			emojiToneView.dropdownView.isOpen = true;
+
+			expect( emojiToneView.skinTone ).to.equal( 'default' );
+
+			emojiToneView.dropdownView.listView.items.get( 5 ).children.first.fire( 'execute' );
+
+			expect( emojiToneView.skinTone ).to.equal( 'dark' );
+		} );
+
+		describe( '#buttonView', () => {
+			it( 'uses the emoji instead of a descriptive text label as initial value', () => {
+				expect( emojiToneView.dropdownView.buttonView.label ).to.equal( '👋' );
+			} );
+
+			it( 'uses the emoji instead of a descriptive text label after clicking on a menu option', () => {
+				emojiToneView.dropdownView.isOpen = true;
+				emojiToneView.dropdownView.listView.items.get( 3 ).children.first.fire( 'execute' );
+
+				expect( emojiToneView.dropdownView.buttonView.label ).to.equal( '👋🏽' );
+			} );
+
+			it( 'does not use the `[aria-labelled-by]` attribute as the button is descriptive enough', () => {
+				expect( emojiToneView.dropdownView.buttonView.ariaLabel ).to.equal( 'Default skin tone, Select skin tone' );
+				expect( emojiToneView.dropdownView.buttonView.ariaLabelledBy ).to.equal( undefined );
+			} );
+
+			it( 'updates the `[aria-label]` attribute to include the current state and the dropdown action', () => {
+				emojiToneView.dropdownView.isOpen = true;
+
+				expect( emojiToneView.skinTone ).to.equal( 'default' );
+
+				emojiToneView.dropdownView.listView.items.get( 3 ).children.first.fire( 'execute' );
+
+				expect( emojiToneView.dropdownView.buttonView.ariaLabel ).to.equal( 'Medium skin tone, Select skin tone' );
+			} );
+		} );
+
+		describe( '#listView', () => {
+			it( 'does not use the `[aria-labelled-by]` attribute as the button is descriptive enough for all items', () => {
+				emojiToneView.dropdownView.isOpen = true;
+
+				const listItems = [ ...emojiToneView.dropdownView.listView.items ];
+
+				expect( listItems.length ).to.equal( 6 );
+
+				expect( listItems[ 0 ].children.first.tooltip ).to.equal( 'Default skin tone' );
+				expect( listItems[ 0 ].children.first.label ).to.equal( '👋' );
+				expect( listItems[ 0 ].children.first.ariaLabel ).to.equal( 'Default skin tone' );
+				expect( listItems[ 0 ].children.first.ariaLabelledBy ).to.equal( undefined );
+
+				expect( listItems[ 1 ].children.first.tooltip ).to.equal( 'Light skin tone' );
+				expect( listItems[ 1 ].children.first.label ).to.equal( '👋🏻' );
+				expect( listItems[ 1 ].children.first.ariaLabel ).to.equal( 'Light skin tone' );
+				expect( listItems[ 1 ].children.first.ariaLabelledBy ).to.equal( undefined );
+
+				expect( listItems[ 2 ].children.first.tooltip ).to.equal( 'Medium Light skin tone' );
+				expect( listItems[ 2 ].children.first.label ).to.equal( '👋🏼' );
+				expect( listItems[ 2 ].children.first.ariaLabel ).to.equal( 'Medium Light skin tone' );
+				expect( listItems[ 2 ].children.first.ariaLabelledBy ).to.equal( undefined );
+
+				expect( listItems[ 3 ].children.first.tooltip ).to.equal( 'Medium skin tone' );
+				expect( listItems[ 3 ].children.first.label ).to.equal( '👋🏽' );
+				expect( listItems[ 3 ].children.first.ariaLabel ).to.equal( 'Medium skin tone' );
+				expect( listItems[ 3 ].children.first.ariaLabelledBy ).to.equal( undefined );
+
+				expect( listItems[ 4 ].children.first.tooltip ).to.equal( 'Medium Dark skin tone' );
+				expect( listItems[ 4 ].children.first.label ).to.equal( '👋🏾' );
+				expect( listItems[ 4 ].children.first.ariaLabel ).to.equal( 'Medium Dark skin tone' );
+				expect( listItems[ 4 ].children.first.ariaLabelledBy ).to.equal( undefined );
+
+				expect( listItems[ 5 ].children.first.tooltip ).to.equal( 'Dark skin tone' );
+				expect( listItems[ 5 ].children.first.label ).to.equal( '👋🏿' );
+				expect( listItems[ 5 ].children.first.ariaLabel ).to.equal( 'Dark skin tone' );
+				expect( listItems[ 5 ].children.first.ariaLabelledBy ).to.equal( undefined );
+			} );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-emoji/theme/emojicategories.css
+++ b/packages/ckeditor5-emoji/theme/emojicategories.css
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-.ck.ck-emoji__categories {
+.ck.ck-emoji__categories-list {
 	display: flex;
 	justify-content: space-between;
 	margin: 0 var(--ck-spacing-large);
@@ -13,14 +13,12 @@
 		border-bottom-width: 2px;
 		border-bottom-style: solid;
 		border-bottom-color: transparent;
-
 		padding: 0;
-
 		font-size: var(--ck-font-size-big);
 		min-width: var(--ck-font-size-big);
 		min-height: var(--ck-font-size-big);
 
-		&.ck-emoji__category-item_active {
+		&.ck-emoji__category-item.ck-on {
 			border-bottom-color: var(--ck-color-base-active);
 		}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Improved accessibility of the emoji picker. Closes #17815.

---

### Additional information

The following items have been improved in this PR. In the attached issue, you can find the previous values.

* Skin tone dropdown (label)
	<img width="381" alt="image" src="https://github.com/user-attachments/assets/35c77f08-854e-4c16-ba80-9b76af0a45e0" />
* Skin tone menu options (descriptions)
	<img width="321" alt="image" src="https://github.com/user-attachments/assets/dfd17089-8290-4ecb-9689-3baad411f419" />
* Category switches miss a few attributes
	* An active button:
		```html
		<button
		  class="ck ck-button ck-on ck-button_with-text ck-emoji__category-item_active"
		  role="tab"
		  type="button"
		  tabindex="-1"
		  aria-label="Smileys &amp; Expressions"
		  data-cke-tooltip-text="Smileys &amp; Expressions"
		  data-cke-tooltip-position="s"
		  aria-selected="true"
		>
		  <span class="ck ck-button__label">😀</span>
		</button>;
		```	
	* A non-active button:
		```html
		<button
		  class="ck ck-button ck-off ck-button_with-text"
		  role="tab"
		  type="button"
		  tabindex="-1"
		  aria-label="Gestures &amp; People"
		  data-cke-tooltip-text="Gestures &amp; People"
		  data-cke-tooltip-position="s"
		  aria-selected="false"
		>
		  <span class="ck ck-button__label">👋</span>
		</button>;
		```	
* Category switches (descriptions)
	<img width="273" alt="image" src="https://github.com/user-attachments/assets/c06cd939-5080-4dee-be3b-ad0431e61f40" />
* Grid items (a keyboard navigation)
	<img width="325" alt="image" src="https://github.com/user-attachments/assets/49e35d8c-5dba-4b00-9e56-75b8d10ee16e" />
