### PR TITLE
Improved handling the read only mode in the Emoji feature

### DIFF
--- a/packages/ckeditor5-emoji/src/emojimention.ts
+++ b/packages/ckeditor5-emoji/src/emojimention.ts
@@ -9,6 +9,7 @@
 
 import { logWarning, type LocaleTranslate } from 'ckeditor5/src/utils.js';
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
+import { Typing } from 'ckeditor5/src/typing.js';
 import type { MentionFeed, MentionFeedObjectItem, ItemRenderer } from '@ckeditor/ckeditor5-mention';
 
 import EmojiDatabase from './emojidatabase.js';
@@ -51,7 +52,7 @@ export default class EmojiMention extends Plugin {
 	 * @inheritDoc
 	 */
 	public static get requires() {
-		return [ EmojiDatabase, 'Mention' ] as const;
+		return [ EmojiDatabase, Typing, 'Mention' ] as const;
 	}
 
 	/**
@@ -179,7 +180,9 @@ export default class EmojiMention extends Plugin {
 	 * Overrides the default mention execute listener to insert an emoji as plain text instead.
 	 */
 	private _overrideMentionExecuteListener(): void {
-		this.editor.commands.get( 'mention' )!.on( 'execute', ( event, data ) => {
+		const editor = this.editor;
+
+		editor.commands.get( 'mention' )!.on( 'execute', ( event, data ) => {
 			const eventData = data[ 0 ];
 
 			// Ignore non-emoji auto-complete actions.
@@ -202,16 +205,17 @@ export default class EmojiMention extends Plugin {
 					.map( item => item.data )
 					.reduce( ( result, text ) => result + text, '' );
 
-				this.editor.model.change( writer => {
-					this.editor.model.deleteContent( writer.createSelection( eventData.range ) );
+				editor.model.change( writer => {
+					editor.model.deleteContent( writer.createSelection( eventData.range ) );
 				} );
 
 				this._emojiPickerPlugin!.showUI( text.slice( 1 ) );
 			}
 			// Or insert the emoji to editor.
 			else {
-				this.editor.model.change( writer => {
-					this.editor.model.insertContent( writer.createText( eventData.mention.text ), eventData.range );
+				editor.execute( 'insertText', {
+					text: eventData.mention.text,
+					range: eventData.range
 				} );
 			}
 		}, { priority: 'high' } );

--- a/packages/ckeditor5-emoji/src/emojipicker.ts
+++ b/packages/ckeditor5-emoji/src/emojipicker.ts
@@ -10,6 +10,7 @@
 import { ButtonView, clickOutsideHandler, ContextualBalloon, Dialog, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 import type { PositionOptions } from 'ckeditor5/src/utils.js';
 import { icons, Plugin } from 'ckeditor5/src/core.js';
+import { Typing } from 'ckeditor5/src/typing.js';
 
 import EmojiCommand from './emojicommand.js';
 import EmojiDatabase from './emojidatabase.js';
@@ -46,7 +47,7 @@ export default class EmojiPicker extends Plugin {
 	 * @inheritDoc
 	 */
 	public static get requires() {
-		return [ EmojiDatabase, ContextualBalloon, Dialog ] as const;
+		return [ EmojiDatabase, ContextualBalloon, Dialog, Typing ] as const;
 	}
 
 	/**
@@ -84,10 +85,12 @@ export default class EmojiPicker extends Plugin {
 			return;
 		}
 
-		editor.commands.add( 'emoji', new EmojiCommand( editor ) );
+		const command = new EmojiCommand( editor );
+
+		editor.commands.add( 'emoji', command );
 
 		editor.ui.componentFactory.add( 'emoji', () => {
-			const button = this._createButton( ButtonView );
+			const button = this._createButton( ButtonView, command );
 
 			button.set( {
 				tooltip: true
@@ -97,7 +100,7 @@ export default class EmojiPicker extends Plugin {
 		} );
 
 		editor.ui.componentFactory.add( 'menuBar:emoji', () => {
-			return this._createButton( MenuBarMenuListItemButtonView );
+			return this._createButton( MenuBarMenuListItemButtonView, command );
 		} );
 
 		this._setupConversion();
@@ -161,9 +164,11 @@ export default class EmojiPicker extends Plugin {
 	/**
 	 * Creates a button for toolbar and menu bar that will show the emoji dialog.
 	 */
-	private _createButton<T extends typeof ButtonView>( ViewClass: T ): InstanceType<T> {
+	private _createButton<T extends typeof ButtonView>( ViewClass: T, command: EmojiCommand ): InstanceType<T> {
 		const buttonView = new ViewClass( this.editor.locale ) as InstanceType<T>;
 		const t = this.editor.locale.t;
+
+		buttonView.bind( 'isEnabled' ).to( command, 'isEnabled' );
 
 		buttonView.set( {
 			label: t( 'Emoji' ),
@@ -194,12 +199,9 @@ export default class EmojiPicker extends Plugin {
 		// Insert an emoji on a tile click.
 		this.listenTo<EmojiGridViewExecuteEvent>( emojiPickerView.gridView, 'execute', ( evt, data ) => {
 			const editor = this.editor;
-			const model = editor.model;
 			const textToInsert = data.emoji;
 
-			model.change( writer => {
-				model.insertContent( writer.createText( textToInsert ) );
-			} );
+			editor.execute( 'insertText', { text: textToInsert } );
 
 			this._hideUI();
 		} );

--- a/packages/ckeditor5-emoji/tests/emojimention.js
+++ b/packages/ckeditor5-emoji/tests/emojimention.js
@@ -5,14 +5,16 @@
 
 /* global document, console */
 
-import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
-import { EmojiMention, EmojiPicker } from '../src/index.js';
-import { Essentials } from '@ckeditor/ckeditor5-essentials';
+import { Typing } from '@ckeditor/ckeditor5-typing';
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
-import { Mention } from '@ckeditor/ckeditor5-mention';
+import { Essentials } from '@ckeditor/ckeditor5-essentials';
 import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
-import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
+import { Mention } from '@ckeditor/ckeditor5-mention';
 import { expectToThrowCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils.js';
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
+
+import { EmojiMention, EmojiPicker } from '../src/index.js';
 import EmojiDatabase from '../src/emojidatabase.js';
 
 class EmojiDatabaseMock extends EmojiDatabase {
@@ -65,7 +67,7 @@ describe( 'EmojiMention', () => {
 	} );
 
 	it( 'should have proper "requires" value', () => {
-		expect( EmojiMention.requires ).to.deep.equal( [ EmojiDatabase, 'Mention' ] );
+		expect( EmojiMention.requires ).to.deep.equal( [ EmojiDatabase, Typing, 'Mention' ] );
 	} );
 
 	it( 'should have `isOfficialPlugin` static flag set to `true`', () => {
@@ -441,6 +443,30 @@ describe( 'EmojiMention', () => {
 			} );
 
 			expect( getModelData( editor.model ) ).to.equal( '<paragraph>Hello world! 🙌[]</paragraph>' );
+		} );
+
+		it( 'should use the "insertText" command when inserting the emoji', () => {
+			const spy = sinon.spy();
+
+			setModelData( editor.model, '<paragraph>[]</paragraph>' );
+
+			const { startPosition, endPosition } = simulateTyping( ':raising' );
+
+			const range = editor.model.change( writer => {
+				return writer.createRange( startPosition, endPosition );
+			} );
+
+			// Attach the listener right before picking up an item from the mention dropdown.
+			// Otherwise, it counts the typed query, too.
+			editor.commands.get( 'insertText' ).on( 'execute', spy );
+
+			editor.commands.execute( 'mention', {
+				range,
+				marker: ':',
+				mention: { id: ':raising hands:', text: '🙌' }
+			} );
+
+			sinon.assert.calledOnce( spy );
 		} );
 
 		it( 'should remove the auto-complete query when selecting the "Show all emoji" option from the list', () => {

--- a/packages/ckeditor5-emoji/tests/emojipicker.js
+++ b/packages/ckeditor5-emoji/tests/emojipicker.js
@@ -5,15 +5,17 @@
 
 /* global document setTimeout Event KeyboardEvent */
 
-import { ContextualBalloon, Dialog, ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
-import { EmojiPicker } from '../src/index.js';
+import { ContextualBalloon, Dialog, ButtonView, MenuBarMenuListItemButtonView } from '@ckeditor/ckeditor5-ui';
+import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
+import { Typing } from '@ckeditor/ckeditor5-typing';
+import { keyCodes } from '@ckeditor/ckeditor5-utils';
 import { Essentials } from '@ckeditor/ckeditor5-essentials';
 import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
-import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view.js';
-import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
+
+import { EmojiPicker } from '../src/index.js';
 import EmojiDatabase from '../src/emojidatabase.js';
-import { keyCodes } from '@ckeditor/ckeditor5-utils';
 import EmojiPickerView from '../src/ui/emojipickerview.js';
 import EmojiCommand from '../src/emojicommand.js';
 
@@ -84,7 +86,7 @@ describe( 'EmojiPicker', () => {
 
 	it( 'should have proper "requires" value', () => {
 		expect( EmojiPicker.requires ).to.deep.equal( [
-			EmojiDatabase, ContextualBalloon, Dialog
+			EmojiDatabase, ContextualBalloon, Dialog, Typing
 		] );
 	} );
 
@@ -151,52 +153,82 @@ describe( 'EmojiPicker', () => {
 		} );
 	} );
 
-	it( 'should provide the "emoji" toolbar component', async () => {
-		expect( editor.ui.componentFactory.has( 'emoji' ) ).to.equal( true );
+	describe( '_createButton()', () => {
+		describe( 'a toolbar icon', () => {
+			it( 'should provide the "emoji" toolbar component', async () => {
+				expect( editor.ui.componentFactory.has( 'emoji' ) ).to.equal( true );
 
-		const toolbarButton = editor.ui.componentFactory.create( 'emoji' );
-		expect( toolbarButton ).to.instanceOf( ButtonView );
+				const toolbarButton = editor.ui.componentFactory.create( 'emoji' );
+				expect( toolbarButton ).to.instanceOf( ButtonView );
 
-		const stub = sinon.stub( emojiPicker, 'showUI' );
+				const stub = sinon.stub( emojiPicker, 'showUI' );
 
-		toolbarButton.fire( 'execute' );
+				toolbarButton.fire( 'execute' );
 
-		sinon.assert.calledOnce( stub );
-	} );
+				sinon.assert.calledOnce( stub );
+			} );
 
-	it( 'should provide the "menuBar:emoji" toolbar component', async () => {
-		expect( editor.ui.componentFactory.has( 'menuBar:emoji' ) ).to.equal( true );
+			it( 'must not register the "emoji" toolbar component if emoji database is not loaded', async () => {
+				EmojiDatabaseMock.isDatabaseLoaded = false;
 
-		expect( editor.ui.componentFactory.create( 'menuBar:emoji' ) ).to.instanceOf( MenuBarMenuListItemButtonView );
-	} );
+				await editor.destroy();
 
-	it( 'must not register the "emoji" toolbar component if emoji database is not loaded', async () => {
-		EmojiDatabaseMock.isDatabaseLoaded = false;
+				editor = await ClassicTestEditor.create( editorElement, {
+					plugins: [ EmojiPicker, Paragraph, Essentials ],
+					substitutePlugins: [ EmojiDatabaseMock ]
+				} );
 
-		await editor.destroy();
+				expect( editor.ui.componentFactory.has( 'emoji' ) ).to.equal( false );
+			} );
 
-		editor = await ClassicTestEditor.create( editorElement, {
-			plugins: [ EmojiPicker, Paragraph, Essentials ],
-			substitutePlugins: [ EmojiDatabaseMock ]
+			it( 'should disable the button when editor switches to the read-only mode', () => {
+				expect( editor.ui.componentFactory.has( 'emoji' ) ).to.equal( true );
+
+				const toolbarButton = editor.ui.componentFactory.create( 'emoji' );
+
+				expect( toolbarButton.isEnabled ).to.equal( true );
+				editor.enableReadOnlyMode( 'testing-purposes' );
+				expect( toolbarButton.isEnabled ).to.equal( false );
+				editor.disableReadOnlyMode( 'testing-purposes' );
+				expect( toolbarButton.isEnabled ).to.equal( true );
+			} );
 		} );
 
-		expect( editor.ui.componentFactory.has( 'emoji' ) ).to.equal( false );
-	} );
+		describe( 'a menu bar item', () => {
+			it( 'should provide the "menuBar:emoji" toolbar component', async () => {
+				expect( editor.ui.componentFactory.has( 'menuBar:emoji' ) ).to.equal( true );
 
-	it( 'must not register the "menuBar:emoji" toolbar component if emoji database is not loaded', async () => {
-		EmojiDatabaseMock.isDatabaseLoaded = false;
+				expect( editor.ui.componentFactory.create( 'menuBar:emoji' ) ).to.instanceOf( MenuBarMenuListItemButtonView );
+			} );
 
-		await editor.destroy();
+			it( 'must not register the "menuBar:emoji" toolbar component if emoji database is not loaded', async () => {
+				EmojiDatabaseMock.isDatabaseLoaded = false;
 
-		editor = await ClassicTestEditor.create( editorElement, {
-			plugins: [ EmojiPicker, Paragraph, Essentials ],
-			substitutePlugins: [ EmojiDatabaseMock ],
-			menuBar: {
-				isVisible: true
-			}
+				await editor.destroy();
+
+				editor = await ClassicTestEditor.create( editorElement, {
+					plugins: [ EmojiPicker, Paragraph, Essentials ],
+					substitutePlugins: [ EmojiDatabaseMock ],
+					menuBar: {
+						isVisible: true
+					}
+				} );
+
+				expect( editor.ui.componentFactory.has( 'menuBar:emoji' ) ).to.equal( false );
+			} );
+
+			it( 'should disable the menu bar item when editor switches to the read-only mode', () => {
+				expect( editor.ui.componentFactory.has( 'menuBar:emoji' ) ).to.equal( true );
+
+				const toolbarButton = editor.ui.componentFactory.create( 'menuBar:emoji' );
+
+				expect( toolbarButton.isEnabled ).to.equal( true );
+				editor.enableReadOnlyMode( 'testing-purposes' );
+				expect( toolbarButton.isEnabled ).to.equal( false );
+				editor.disableReadOnlyMode( 'testing-purposes' );
+				expect( toolbarButton.isEnabled ).to.equal( true );
+			} );
 		} );
-
-		expect( editor.ui.componentFactory.has( 'menuBar:emoji' ) ).to.equal( false );
 	} );
 
 	describe( 'showUI()', () => {
@@ -252,6 +284,17 @@ describe( 'EmojiPicker', () => {
 			emojiPicker.emojiPickerView.gridView.fire( 'execute', { emoji: '😀' } );
 
 			expect( getModelData( editor.model ) ).to.equal( '<paragraph>😀[]</paragraph>' );
+		} );
+
+		it( 'should use the "insertText" command when inserting the emoji', () => {
+			const spy = sinon.spy();
+
+			editor.commands.get( 'insertText' ).on( 'execute', spy );
+
+			emojiPicker.showUI();
+			emojiPicker.emojiPickerView.gridView.fire( 'execute', { emoji: '😀' } );
+
+			sinon.assert.calledOnce( spy );
 		} );
 
 		it( 'should update the balloon position on update event', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Connected the menu bar item and the toolbar icon with the `emoji` command, so its state impacts the UI state.

Internal: Use the `insertText` command for text insertion to disable inserting emoji when an editor switches to read-only mode.

Closes https://github.com/cksource/ckeditor5-commercial/issues/6981.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
