### PR TITLE
Fixed emoji config marker already used warning in Revision History.

### DIFF
--- a/packages/ckeditor5-emoji/src/emojimention.ts
+++ b/packages/ckeditor5-emoji/src/emojimention.ts
@@ -48,16 +48,6 @@ export default class EmojiMention extends Plugin {
 	private readonly _skinTone: SkinToneId;
 
 	/**
-	 * Mention feeds.
-	 */
-	private readonly _mentionFeeds: Array<EmojiMentionFeed>;
-
-	/**
-	 * Merge fields prefix.
-	 */
-	private readonly _mergeFieldsPrefix: string;
-
-	/**
 	 * @inheritDoc
 	 */
 	public static get requires() {
@@ -90,10 +80,8 @@ export default class EmojiMention extends Plugin {
 
 		this._emojiDropdownLimit = editor.config.get( 'emoji.dropdownLimit' )!;
 		this._skinTone = editor.config.get( 'emoji.skinTone' )!;
-		this._mentionFeeds = editor.config.get( 'mention.feeds' )!;
-		this._mergeFieldsPrefix = editor.config.get( 'mergeFields.prefix' )! as string;
 
-		this._setupMentionConfiguration();
+		this._setupMentionConfiguration( editor );
 	}
 
 	/**
@@ -101,12 +89,14 @@ export default class EmojiMention extends Plugin {
 	 * If the marker used by emoji mention is already registered, it displays a warning.
 	 * If emoji mention configuration is detected, it does not register it for a second time.
 	 */
-	private _setupMentionConfiguration() {
-		const isEmojiMarkerAlreadyAdded = this._mentionFeeds.find( config => config._isEmojiMarker );
-		const markerAlreadyUsed = this._mentionFeeds
+	private _setupMentionConfiguration( editor: Editor ) {
+		const mentionFeedsConfigs = editor.config.get( 'mention.feeds' )! as Array<EmojiMentionFeed>;
+		const mergeFieldsPrefix = editor.config.get( 'mergeFields.prefix' )! as string;
+		const isEmojiMarkerAlreadyAdded = mentionFeedsConfigs.find( config => config._isEmojiMarker );
+		const markerAlreadyUsed = mentionFeedsConfigs
 			.filter( config => !config._isEmojiMarker )
 			.some( config => config.marker === EMOJI_MENTION_MARKER );
-		const isMarkerUsedByMergeFields = this._mergeFieldsPrefix ? this._mergeFieldsPrefix[ 0 ] === EMOJI_MENTION_MARKER : false;
+		const isMarkerUsedByMergeFields = mergeFieldsPrefix ? mergeFieldsPrefix[ 0 ] === EMOJI_MENTION_MARKER : false;
 
 		if ( markerAlreadyUsed || isMarkerUsedByMergeFields ) {
 			/**
@@ -132,7 +122,7 @@ export default class EmojiMention extends Plugin {
 			feed: this._queryEmojiCallbackFactory()
 		};
 
-		this.editor.config.set( 'mention.feeds', [ ...this._mentionFeeds, emojiMentionFeedConfig ] );
+		this.editor.config.set( 'mention.feeds', [ ...mentionFeedsConfigs, emojiMentionFeedConfig ] );
 	}
 
 	/**

--- a/packages/ckeditor5-emoji/src/emojimention.ts
+++ b/packages/ckeditor5-emoji/src/emojimention.ts
@@ -90,15 +90,15 @@ export default class EmojiMention extends Plugin {
 	 * If emoji mention configuration is detected, it does not register it for a second time.
 	 */
 	private _setupMentionConfiguration( editor: Editor ) {
-		const mentionFeedsConfigs = editor.config.get( 'mention.feeds' )! as Array<EmojiMentionFeed>;
 		const mergeFieldsPrefix = editor.config.get( 'mergeFields.prefix' )! as string;
-		const isEmojiMarkerAlreadyAdded = mentionFeedsConfigs.find( config => config._isEmojiMarker );
-		const markerAlreadyUsed = mentionFeedsConfigs
+		const mentionFeedsConfigs = editor.config.get( 'mention.feeds' )! as Array<EmojiMentionFeed>;
+
+		const isEmojiMarkerUsedByMergeFields = mergeFieldsPrefix ? mergeFieldsPrefix[ 0 ] === EMOJI_MENTION_MARKER : false;
+		const isEmojiMarkerUsedByMention = mentionFeedsConfigs
 			.filter( config => !config._isEmojiMarker )
 			.some( config => config.marker === EMOJI_MENTION_MARKER );
-		const isMarkerUsedByMergeFields = mergeFieldsPrefix ? mergeFieldsPrefix[ 0 ] === EMOJI_MENTION_MARKER : false;
 
-		if ( markerAlreadyUsed || isMarkerUsedByMergeFields ) {
+		if ( isEmojiMarkerUsedByMention || isEmojiMarkerUsedByMergeFields ) {
 			/**
 			 * The `marker` in the `emoji` config is already used by other plugin configuration.
 			 *
@@ -110,7 +110,9 @@ export default class EmojiMention extends Plugin {
 			return;
 		}
 
-		if ( isEmojiMarkerAlreadyAdded ) {
+		const isEmojiConfigDefined = mentionFeedsConfigs.some( config => config._isEmojiMarker );
+
+		if ( isEmojiConfigDefined ) {
 			return;
 		}
 

--- a/packages/ckeditor5-emoji/src/emojimention.ts
+++ b/packages/ckeditor5-emoji/src/emojimention.ts
@@ -48,12 +48,12 @@ export default class EmojiMention extends Plugin {
 	private readonly _skinTone: SkinToneId;
 
 	/**
-	 * Defines a skin tone that is set in the emoji config.
+	 * Mention feeds.
 	 */
 	private readonly _mentionFeeds: Array<EmojiMentionFeed>;
 
 	/**
-	 * Defines a skin tone that is set in the emoji config.
+	 * Merge fields prefix.
 	 */
 	private readonly _mergeFieldsPrefix: string;
 

--- a/packages/ckeditor5-emoji/src/emojimention.ts
+++ b/packages/ckeditor5-emoji/src/emojimention.ts
@@ -81,6 +81,13 @@ export default class EmojiMention extends Plugin {
 		this._emojiDropdownLimit = editor.config.get( 'emoji.dropdownLimit' )!;
 		this._skinTone = editor.config.get( 'emoji.skinTone' )!;
 
+		this._setupMentionConfiguration( editor );
+	}
+
+	/**
+	 * Initializes the configuration for emojis in the mention feature.
+	 */
+	private _setupMentionConfiguration( editor: Editor ) {
 		const mentionFeedsConfigs = editor.config.get( 'mention.feeds' )! as Array<EmojiMentionFeed>;
 		const mergeFieldsPrefix = editor.config.get( 'mergeFields.prefix' )! as string;
 		const isEmojiMarkerAlreadyAdded = mentionFeedsConfigs.find( config => config._isEmojiMarker );
@@ -105,7 +112,15 @@ export default class EmojiMention extends Plugin {
 			return;
 		}
 
-		this._setupMentionConfiguration( mentionFeedsConfigs );
+		const emojiMentionFeedConfig = {
+			_isEmojiMarker: true,
+			marker: EMOJI_MENTION_MARKER,
+			dropdownLimit: this._emojiDropdownLimit,
+			itemRenderer: this._customItemRendererFactory( this.editor.t ),
+			feed: this._queryEmojiCallbackFactory()
+		};
+
+		this.editor.config.set( 'mention.feeds', [ ...mentionFeedsConfigs, emojiMentionFeedConfig ] );
 	}
 
 	/**
@@ -130,21 +145,6 @@ export default class EmojiMention extends Plugin {
 		}
 
 		editor.once( 'ready', this._overrideMentionExecuteListener.bind( this ) );
-	}
-
-	/**
-	 * Initializes the configuration for emojis in the mention feature.
-	 */
-	private _setupMentionConfiguration( mentionFeedsConfigs: Array<EmojiMentionFeed> ): void {
-		const emojiMentionFeedConfig = {
-			isEmojiMarker: true,
-			marker: EMOJI_MENTION_MARKER,
-			dropdownLimit: this._emojiDropdownLimit,
-			itemRenderer: this._customItemRendererFactory( this.editor.t ),
-			feed: this._queryEmojiCallbackFactory()
-		};
-
-		this.editor.config.set( 'mention.feeds', [ ...mentionFeedsConfigs, emojiMentionFeedConfig ] );
 	}
 
 	/**

--- a/packages/ckeditor5-emoji/src/emojimention.ts
+++ b/packages/ckeditor5-emoji/src/emojimention.ts
@@ -83,9 +83,9 @@ export default class EmojiMention extends Plugin {
 
 		const mentionFeedsConfigs = editor.config.get( 'mention.feeds' )! as Array<EmojiMentionFeed>;
 		const mergeFieldsPrefix = editor.config.get( 'mergeFields.prefix' )! as string;
-		const isEmojiMarkerAlreadyAdded = mentionFeedsConfigs.find( config => config.isEmojiMarker );
+		const isEmojiMarkerAlreadyAdded = mentionFeedsConfigs.find( config => config._isEmojiMarker );
 		const markerAlreadyUsed = mentionFeedsConfigs
-			.filter( config => !config.isEmojiMarker )
+			.filter( config => !config._isEmojiMarker )
 			.some( config => config.marker === EMOJI_MENTION_MARKER );
 		const isMarkerUsedByMergeFields = mergeFieldsPrefix ? mergeFieldsPrefix[ 0 ] === EMOJI_MENTION_MARKER : false;
 
@@ -266,5 +266,9 @@ export default class EmojiMention extends Plugin {
 }
 
 type EmojiMentionFeed = MentionFeed & {
-	isEmojiMarker?: boolean;
+
+	/**
+	 * It's used to not display an emoji mention feed warning when editor plugins are initialized multiple times.
+	 */
+	_isEmojiMarker?: boolean;
 };

--- a/packages/ckeditor5-emoji/src/emojimention.ts
+++ b/packages/ckeditor5-emoji/src/emojimention.ts
@@ -81,9 +81,12 @@ export default class EmojiMention extends Plugin {
 		this._emojiDropdownLimit = editor.config.get( 'emoji.dropdownLimit' )!;
 		this._skinTone = editor.config.get( 'emoji.skinTone' )!;
 
-		const mentionFeedsConfigs = editor.config.get( 'mention.feeds' )! as Array<MentionFeed>;
+		const mentionFeedsConfigs = editor.config.get( 'mention.feeds' )! as Array<EmojiMentionFeed>;
 		const mergeFieldsPrefix = editor.config.get( 'mergeFields.prefix' )! as string;
-		const markerAlreadyUsed = mentionFeedsConfigs.some( config => config.marker === EMOJI_MENTION_MARKER );
+		const isEmojiMarkerAlreadyAdded = mentionFeedsConfigs.find( config => config.isEmojiMarker );
+		const markerAlreadyUsed = mentionFeedsConfigs
+			.filter( config => !config.isEmojiMarker )
+			.some( config => config.marker === EMOJI_MENTION_MARKER );
 		const isMarkerUsedByMergeFields = mergeFieldsPrefix ? mergeFieldsPrefix[ 0 ] === EMOJI_MENTION_MARKER : false;
 
 		if ( markerAlreadyUsed || isMarkerUsedByMergeFields ) {
@@ -95,6 +98,10 @@ export default class EmojiMention extends Plugin {
 			 */
 			logWarning( 'emoji-config-marker-already-used', { marker: EMOJI_MENTION_MARKER } );
 
+			return;
+		}
+
+		if ( isEmojiMarkerAlreadyAdded ) {
 			return;
 		}
 
@@ -128,8 +135,9 @@ export default class EmojiMention extends Plugin {
 	/**
 	 * Initializes the configuration for emojis in the mention feature.
 	 */
-	private _setupMentionConfiguration( mentionFeedsConfigs: Array<MentionFeed> ): void {
+	private _setupMentionConfiguration( mentionFeedsConfigs: Array<EmojiMentionFeed> ): void {
 		const emojiMentionFeedConfig = {
+			isEmojiMarker: true,
 			marker: EMOJI_MENTION_MARKER,
 			dropdownLimit: this._emojiDropdownLimit,
 			itemRenderer: this._customItemRendererFactory( this.editor.t ),
@@ -256,3 +264,7 @@ export default class EmojiMention extends Plugin {
 		};
 	}
 }
+
+type EmojiMentionFeed = MentionFeed & {
+	isEmojiMarker?: boolean;
+};

--- a/packages/ckeditor5-emoji/tests/emojimention.js
+++ b/packages/ckeditor5-emoji/tests/emojimention.js
@@ -125,9 +125,28 @@ describe( 'EmojiMention', () => {
 			const config = configs.find( config => config.marker !== '@' );
 
 			expect( config.marker ).to.equal( ':' );
+			expect( config._isEmojiMarker ).to.equal( true );
 			expect( config.dropdownLimit ).to.equal( 6 );
 			expect( config.itemRenderer ).to.be.instanceOf( Function );
 			expect( config.feed ).to.be.instanceOf( Function );
+
+			await editor.destroy();
+			editorElement.remove();
+		} );
+
+		it( 'should not modify mention feed when emoji plugin is already in mention feeds', async () => {
+			const editorElement = document.createElement( 'div' );
+			document.body.appendChild( editorElement );
+
+			const editor = await ClassicTestEditor.create( editorElement, {
+				plugins: [ EmojiMention, Mention ]
+			} );
+
+			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
+
+			editor.plugins.get( 'EmojiMention' )._setupMentionConfiguration( editor );
+
+			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
 
 			await editor.destroy();
 			editorElement.remove();

--- a/packages/ckeditor5-emoji/tests/emojimention.js
+++ b/packages/ckeditor5-emoji/tests/emojimention.js
@@ -144,7 +144,7 @@ describe( 'EmojiMention', () => {
 
 			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
 
-			editor.plugins.get( 'EmojiMention' )._setupMentionConfiguration();
+			editor.plugins.get( 'EmojiMention' )._setupMentionConfiguration( editor );
 
 			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
 

--- a/packages/ckeditor5-emoji/tests/emojimention.js
+++ b/packages/ckeditor5-emoji/tests/emojimention.js
@@ -224,133 +224,27 @@ describe( 'EmojiMention', () => {
 		editor1Element.remove();
 	} );
 
-	describe( 'should not update the mention configuration when emoji configuration is already added', () => {
-		let consoleWarnStub;
+	it( 'should not update the mention configuration when emoji configuration is already added', async () => {
+		const consoleWarnStub = sinon.stub( console, 'warn' );
+		const editorElement = document.createElement( 'div' );
+		document.body.appendChild( editorElement );
 
-		beforeEach( () => {
-			consoleWarnStub = sinon.stub( console, 'warn' );
+		const editor = await ClassicTestEditor.create( editorElement, {
+			plugins: [ EmojiMention, Mention ],
+			substitutePlugins: [ EmojiDatabaseMock ]
 		} );
 
-		afterEach( () => {
-			consoleWarnStub.restore();
-		} );
+		expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
 
-		it( 'should not call console warn when no additional mention or merge fields config is defined', async () => {
-			const editorElement = document.createElement( 'div' );
-			document.body.appendChild( editorElement );
+		editor.plugins.get( 'EmojiMention' )._setupMentionConfiguration( editor );
 
-			const editor = await ClassicTestEditor.create( editorElement, {
-				plugins: [ EmojiMention, Mention ],
-				substitutePlugins: [ EmojiDatabaseMock ]
-			} );
+		// Should not call console warn when there are no mention or merge fields configs defined.
+		expect( consoleWarnStub.callCount ).to.equal( 0 );
+		expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
 
-			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
-
-			editor.plugins.get( 'EmojiMention' )._setupMentionConfiguration( editor );
-
-			// Should not call console warn when there are no mention or merge fields configs defined.
-			expect( consoleWarnStub.callCount ).to.equal( 0 );
-			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
-
-			await editor.destroy();
-			editorElement.remove();
-		} );
-
-		it( 'should call console warn when merge fields config uses `:` prefix', async () => {
-			const editorElement = document.createElement( 'div' );
-			document.body.appendChild( editorElement );
-
-			const editor = await ClassicTestEditor.create( editorElement, {
-				plugins: [ EmojiMention, Mention ],
-				substitutePlugins: [ EmojiDatabaseMock ],
-				mergeFields: {
-					prefix: ':'
-				}
-			} );
-
-			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 0 );
-			expect( consoleWarnStub.callCount ).to.equal( 1 );
-
-			editor.plugins.get( 'EmojiMention' )._setupMentionConfiguration( editor );
-
-			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 0 );
-
-			// Should call console warn when there is merge fields config defined.
-			expect( consoleWarnStub.callCount ).to.equal( 2 );
-			expect( consoleWarnStub.firstCall.firstArg ).to.equal( 'emoji-config-marker-already-used' );
-
-			await editor.destroy();
-			editorElement.remove();
-		} );
-
-		it( 'should call console warn when mention feed uses `:` marker', async () => {
-			const editorElement = document.createElement( 'div' );
-			document.body.appendChild( editorElement );
-
-			const editor = await ClassicTestEditor.create( editorElement, {
-				plugins: [ EmojiMention, Mention ],
-				substitutePlugins: [ EmojiDatabaseMock ],
-				mention: {
-					feeds: [
-						{
-							marker: ':',
-							feed: [ ':Barney', ':Lily', ':Marry Ann', ':Marshall', ':Robin', ':Ted' ],
-							minimumCharacters: 1
-						}
-					]
-				}
-			} );
-
-			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
-			expect( consoleWarnStub.callCount ).to.equal( 1 );
-
-			editor.plugins.get( 'EmojiMention' )._setupMentionConfiguration( editor );
-
-			// Should call console warn when there is mention config defined.
-			expect( consoleWarnStub.callCount ).to.equal( 2 );
-			expect( consoleWarnStub.firstCall.firstArg ).to.equal( 'emoji-config-marker-already-used' );
-
-			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
-
-			await editor.destroy();
-			editorElement.remove();
-		} );
-
-		it( 'should call console warn when mention feed uses `:` marker and merge fields config uses `:` prefix', async () => {
-			const editorElement = document.createElement( 'div' );
-			document.body.appendChild( editorElement );
-
-			const editor = await ClassicTestEditor.create( editorElement, {
-				plugins: [ EmojiMention, Mention ],
-				substitutePlugins: [ EmojiDatabaseMock ],
-				mention: {
-					feeds: [
-						{
-							marker: ':',
-							feed: [ ':Barney', ':Lily', ':Marry Ann', ':Marshall', ':Robin', ':Ted' ],
-							minimumCharacters: 1
-						}
-					]
-				},
-				mergeFields: {
-					prefix: ':'
-				}
-			} );
-
-			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
-			expect( consoleWarnStub.callCount ).to.equal( 1 );
-
-			editor.plugins.get( 'EmojiMention' )._setupMentionConfiguration( editor );
-
-			// Should call console warn when there is mention and merge fields configs defined.
-			expect( consoleWarnStub.callCount ).to.equal( 2 );
-			expect( consoleWarnStub.firstCall.firstArg ).to.equal( 'emoji-config-marker-already-used' );
-
-			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
-
-			await editor.destroy();
-			editorElement.remove();
-		} );
+		await editor.destroy();
+		editorElement.remove();
+		consoleWarnStub.restore();
 	} );
 
 	describe( '_customItemRendererFactory()', () => {

--- a/packages/ckeditor5-emoji/tests/emojimention.js
+++ b/packages/ckeditor5-emoji/tests/emojimention.js
@@ -134,24 +134,6 @@ describe( 'EmojiMention', () => {
 			editorElement.remove();
 		} );
 
-		it( 'should not modify mention feed when emoji plugin is already in mention feeds', async () => {
-			const editorElement = document.createElement( 'div' );
-			document.body.appendChild( editorElement );
-
-			const editor = await ClassicTestEditor.create( editorElement, {
-				plugins: [ EmojiMention, Mention ]
-			} );
-
-			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
-
-			editor.plugins.get( 'EmojiMention' )._setupMentionConfiguration( editor );
-
-			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
-
-			await editor.destroy();
-			editorElement.remove();
-		} );
-
 		it( 'should not update the mention configuration when the `:` character is already used', async () => {
 			const editorElement = document.createElement( 'div' );
 			document.body.appendChild( editorElement );
@@ -208,6 +190,135 @@ describe( 'EmojiMention', () => {
 
 			expect( consoleWarnStub.callCount ).to.equal( 1 );
 			expect( consoleWarnStub.firstCall.firstArg ).to.equal( 'emoji-config-marker-already-used' );
+
+			await editor.destroy();
+			editorElement.remove();
+		} );
+	} );
+
+	describe( 'should not update the mention configuration when emoji configuration is already added', () => {
+		let consoleWarnStub;
+
+		beforeEach( () => {
+			consoleWarnStub = sinon.stub( console, 'warn' );
+		} );
+
+		afterEach( () => {
+			consoleWarnStub.restore();
+		} );
+
+		it( 'should not call console warn when no additional mention or merge fields config is defined', async () => {
+			const editorElement = document.createElement( 'div' );
+			document.body.appendChild( editorElement );
+
+			const editor = await ClassicTestEditor.create( editorElement, {
+				plugins: [ EmojiMention, Mention ],
+				substitutePlugins: [ EmojiDatabaseMock ]
+			} );
+
+			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
+
+			editor.plugins.get( 'EmojiMention' )._setupMentionConfiguration( editor );
+
+			// Should not call console warn when there are no mention or merge fields configs defined.
+			expect( consoleWarnStub.callCount ).to.equal( 0 );
+			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
+
+			await editor.destroy();
+			editorElement.remove();
+		} );
+
+		it( 'should call console warn when merge fields config uses `:` prefix', async () => {
+			const editorElement = document.createElement( 'div' );
+			document.body.appendChild( editorElement );
+
+			const editor = await ClassicTestEditor.create( editorElement, {
+				plugins: [ EmojiMention, Mention ],
+				substitutePlugins: [ EmojiDatabaseMock ],
+				mergeFields: {
+					prefix: ':'
+				}
+			} );
+
+			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 0 );
+			expect( consoleWarnStub.callCount ).to.equal( 1 );
+
+			editor.plugins.get( 'EmojiMention' )._setupMentionConfiguration( editor );
+
+			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 0 );
+
+			// Should call console warn when there is merge fields config defined.
+			expect( consoleWarnStub.callCount ).to.equal( 2 );
+			expect( consoleWarnStub.firstCall.firstArg ).to.equal( 'emoji-config-marker-already-used' );
+
+			await editor.destroy();
+			editorElement.remove();
+		} );
+
+		it( 'should call console warn when mention feed uses `:` marker', async () => {
+			const editorElement = document.createElement( 'div' );
+			document.body.appendChild( editorElement );
+
+			const editor = await ClassicTestEditor.create( editorElement, {
+				plugins: [ EmojiMention, Mention ],
+				substitutePlugins: [ EmojiDatabaseMock ],
+				mention: {
+					feeds: [
+						{
+							marker: ':',
+							feed: [ ':Barney', ':Lily', ':Marry Ann', ':Marshall', ':Robin', ':Ted' ],
+							minimumCharacters: 1
+						}
+					]
+				}
+			} );
+
+			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
+			expect( consoleWarnStub.callCount ).to.equal( 1 );
+
+			editor.plugins.get( 'EmojiMention' )._setupMentionConfiguration( editor );
+
+			// Should call console warn when there is mention config defined.
+			expect( consoleWarnStub.callCount ).to.equal( 2 );
+			expect( consoleWarnStub.firstCall.firstArg ).to.equal( 'emoji-config-marker-already-used' );
+
+			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
+
+			await editor.destroy();
+			editorElement.remove();
+		} );
+
+		it( 'should call console warn when mention feed uses `:` marker and merge fields config uses `:` prefix', async () => {
+			const editorElement = document.createElement( 'div' );
+			document.body.appendChild( editorElement );
+
+			const editor = await ClassicTestEditor.create( editorElement, {
+				plugins: [ EmojiMention, Mention ],
+				substitutePlugins: [ EmojiDatabaseMock ],
+				mention: {
+					feeds: [
+						{
+							marker: ':',
+							feed: [ ':Barney', ':Lily', ':Marry Ann', ':Marshall', ':Robin', ':Ted' ],
+							minimumCharacters: 1
+						}
+					]
+				},
+				mergeFields: {
+					prefix: ':'
+				}
+			} );
+
+			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
+			expect( consoleWarnStub.callCount ).to.equal( 1 );
+
+			editor.plugins.get( 'EmojiMention' )._setupMentionConfiguration( editor );
+
+			// Should call console warn when there is mention and merge fields configs defined.
+			expect( consoleWarnStub.callCount ).to.equal( 2 );
+			expect( consoleWarnStub.firstCall.firstArg ).to.equal( 'emoji-config-marker-already-used' );
+
+			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
 
 			await editor.destroy();
 			editorElement.remove();

--- a/packages/ckeditor5-emoji/tests/emojimention.js
+++ b/packages/ckeditor5-emoji/tests/emojimention.js
@@ -144,7 +144,7 @@ describe( 'EmojiMention', () => {
 
 			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
 
-			editor.plugins.get( 'EmojiMention' )._setupMentionConfiguration( editor );
+			editor.plugins.get( 'EmojiMention' )._setupMentionConfiguration();
 
 			expect( editor.config.get( 'mention.feeds' ).length ).to.equal( 1 );
 

--- a/packages/ckeditor5-emoji/tests/emojimention.js
+++ b/packages/ckeditor5-emoji/tests/emojimention.js
@@ -196,6 +196,33 @@ describe( 'EmojiMention', () => {
 		} );
 	} );
 
+	it( 'should set emoji mention feed configuration only once', async () => {
+		const editorElement = document.createElement( 'div' );
+		const editor1Element = document.createElement( 'div' );
+		document.body.appendChild( editorElement );
+
+		const editor = await ClassicTestEditor.create( editorElement, {
+			plugins: [ EmojiMention, Mention ],
+			substitutePlugins: [ EmojiDatabaseMock ]
+		} );
+
+		const editor1 = await ClassicTestEditor.create( editorElement, {
+			plugins: [ EmojiMention, Mention ],
+			substitutePlugins: [ EmojiDatabaseMock ],
+			mention: {
+				feeds: editor.config.get( 'mention.feeds' )
+			}
+		} );
+
+		// Should register emoji mention config only once.
+		expect( editor1.config.get( 'mention.feeds' ).length ).to.equal( 1 );
+
+		await editor.destroy();
+		await editor1.destroy();
+		editorElement.remove();
+		editor1Element.remove();
+	} );
+
 	describe( 'should not update the mention configuration when emoji configuration is already added', () => {
 		let consoleWarnStub;
 

--- a/packages/ckeditor5-emoji/tests/emojimention.js
+++ b/packages/ckeditor5-emoji/tests/emojimention.js
@@ -206,7 +206,7 @@ describe( 'EmojiMention', () => {
 			substitutePlugins: [ EmojiDatabaseMock ]
 		} );
 
-		const editor1 = await ClassicTestEditor.create( editorElement, {
+		const editor1 = await ClassicTestEditor.create( editor1Element, {
 			plugins: [ EmojiMention, Mention ],
 			substitutePlugins: [ EmojiDatabaseMock ],
 			mention: {

--- a/packages/ckeditor5-emoji/tests/emojimention.js
+++ b/packages/ckeditor5-emoji/tests/emojimention.js
@@ -200,6 +200,7 @@ describe( 'EmojiMention', () => {
 		const editorElement = document.createElement( 'div' );
 		const editor1Element = document.createElement( 'div' );
 		document.body.appendChild( editorElement );
+		document.body.appendChild( editor1Element );
 
 		const editor = await ClassicTestEditor.create( editorElement, {
 			plugins: [ EmojiMention, Mention ],


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Fixed emoji config marker already used warning in Revision History. Closes cksource/ckeditor5-commercial#6980.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
