### PR TITLE
Add export inline styles to devDependencies of ckeditor5

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "@ckeditor/ckeditor5-source-editing-enhanced": "0.0.1",
     "@ckeditor/ckeditor5-template": "44.1.0",
     "@ckeditor/ckeditor5-track-changes": "44.1.0",
+    "@ckeditor/ckeditor5-export-inline-styles": "0.0.1",
     "@ckeditor/ckeditor5-uploadcare": "0.0.1",
     "@inquirer/prompts": "^6.0.0",
     "@listr2/prompt-adapter-inquirer": "^2.0.16",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Add export inline styles to `devDependencies` of `ckeditor5`.

---

### Additional information

Commercial PR: https://github.com/cksource/ckeditor5-commercial/pull/6946
