### PR TITLE
Fix source editing `uiComponents` icon metadata

### DIFF
--- a/packages/ckeditor5-source-editing/ckeditor5-metadata.json
+++ b/packages/ckeditor5-source-editing/ckeditor5-metadata.json
@@ -9,7 +9,8 @@
 			"uiComponents": [
 				{
 					"type": "Button",
-					"name": "sourceEditing"
+					"name": "sourceEditing",
+					"iconPath": "@ckeditor/ckeditor5-core/theme/icons/source.svg"
 				}
 			]
 		}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (source-editing): Fix `uiComponents` icon metadata.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._

None.
