### PR TITLE
Fix source editing `uiComponents` icon metadata (`master` backport)

### DIFF
--- a/packages/ckeditor5-source-editing/ckeditor5-metadata.json
+++ b/packages/ckeditor5-source-editing/ckeditor5-metadata.json
@@ -9,7 +9,8 @@
 			"uiComponents": [
 				{
 					"type": "Button",
-					"name": "sourceEditing"
+					"name": "sourceEditing",
+					"iconPath": "@ckeditor/ckeditor5-core/theme/icons/source.svg"
 				}
 			]
 		}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (source-editing): Fix uiComponents icon metadata.

---

### Additional information

This is a cherry-picked commit which was added to `release` branch in this PR https://github.com/ckeditor/ckeditor5/pull/17847.
