### PR TITLE
Improved EmojiMention feed when repository failed to load

### DIFF
--- a/packages/ckeditor5-emoji/tests/emojimention.js
+++ b/packages/ckeditor5-emoji/tests/emojimention.js
@@ -538,6 +538,26 @@ describe( 'EmojiMention', () => {
 			expect( queryEmoji( ' see' ) ).to.deep.equal( [] );
 		} );
 
+		it( 'should return an empty array the repository plugin is not loaded correctly', async () => {
+			EmojiRepositoryMock.isReady = false;
+
+			const editorElement = document.createElement( 'div' );
+			document.body.appendChild( editorElement );
+
+			const editor = await ClassicTestEditor.create( editorElement, {
+				plugins: [ EmojiMention, Paragraph, Essentials, Mention ],
+				substitutePlugins: [ EmojiRepositoryMock ]
+			} );
+
+			const queryEmoji = editor.plugins.get( 'EmojiMention' )._queryEmojiCallbackFactory();
+
+			expect( queryEmoji( '' ) ).to.deep.equal( [] );
+			expect( queryEmoji( 'see' ) ).to.deep.equal( [] );
+
+			await editor.destroy();
+			editorElement.remove();
+		} );
+
 		it( 'should return a hint item when a query is too short', () => {
 			const { getEmojiByQuery } = editor.plugins.get( 'EmojiRepository' );
 			getEmojiByQuery.returns( [] );

--- a/packages/ckeditor5-emoji/tests/emojimention.js
+++ b/packages/ckeditor5-emoji/tests/emojimention.js
@@ -538,7 +538,7 @@ describe( 'EmojiMention', () => {
 			expect( queryEmoji( ' see' ) ).to.deep.equal( [] );
 		} );
 
-		it( 'should return an empty array the repository plugin is not loaded correctly', async () => {
+		it( 'should return an empty array when the repository plugin is not loaded correctly', async () => {
 			EmojiRepositoryMock.isReady = false;
 
 			const editorElement = document.createElement( 'div' );

--- a/packages/ckeditor5-emoji/tests/manual/emoji.html
+++ b/packages/ckeditor5-emoji/tests/manual/emoji.html
@@ -9,6 +9,7 @@
     <input type="radio" id="unicode-15" name="unicode" value="15"><label for="unicode-15">15</label>
     <input type="radio" id="unicode-16" name="unicode" value="16"><label for="unicode-16">16</label>
     <input type="radio" id="unicode-null" name="unicode" value="null" checked><label for="unicode-null">use the plugin default</label>
+    <input type="radio" id="unicode-6" name="unicode" value="6"><label for="unicode-6">invalid value</label>
 </p>
 
 <p>

--- a/packages/ckeditor5-emoji/tests/manual/emoji.md
+++ b/packages/ckeditor5-emoji/tests/manual/emoji.md
@@ -2,13 +2,13 @@
 
 This test allows for testing of both `EmojiMention` and `EmojiPicker` plugins - both loaded in the editor or separately.
 
-### EmojiPicker
+### 👉️ `EmojiPicker`
 
 The `EmojiPicker` plugin creates a dropdown that allows inserting an emoji or filtering them by a category or a name.
 
 It can be accessed via the main toolbar button and the menu bar under `Insert > Emoji`.
 
-### EmojiMention
+### 👉️ `EmojiMention`
 
 The `EmojiMention` plugin allows by inserting emoji directly via typing.
 
@@ -22,6 +22,12 @@ Then, you can either choose which emoji to insert, or choose the last option: `S
 
 **Note**: The `Show all emoji...` option does not show up when the `EmojiPicker` plugin is not available.
 
+### 👉️ `EmojiRepository`
+
+Both emoji plugin based on the `EmojiRepository` plugin that keeps the available emoji.
+
+If it couldn't be loaded, `EmojiMention` should not show auto-complete options, and `EmojiPicker` should not display a toolbar icon.
+
 ---
 
 #### Configurable options:
@@ -29,4 +35,4 @@ Then, you can either choose which emoji to insert, or choose the last option: `S
 * **`Unicode version`** - its value is passed as `emoji.version` in the configuration.
 * **`Default skin tone`** - its value is passed as `emoji.skinTone` in the configuration.
 
-Selecting the `use the plugin default` option does not pass anything. This way plugins use the default vaules.
+Selecting the `use the plugin default` option does not pass anything. This way plugins use the default values.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: `EmojiMention` feed does not return any items when the repository is not loaded correctly. Closes #17842.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
