### PR TITLE
Improved the emoji grid view on small screens

### DIFF
--- a/packages/ckeditor5-emoji/theme/emojigrid.css
+++ b/packages/ckeditor5-emoji/theme/emojigrid.css
@@ -10,7 +10,7 @@
 .ck.ck-emoji {
 	& .ck.ck-emoji__tiles {
 		max-width: 100%;
-		max-height: 265px;
+		max-height: min(265px, 40vh);
 
 		overflow-y: auto;
 		overflow-x: hidden;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Improved the emoji grid view on small screens by setting its height to max 40% of the viewport height. Closes #17862.

---

### Additional information

#### Before

https://github.com/user-attachments/assets/a45847e9-7973-4f7d-8ca5-053ec4014326

#### After

https://github.com/user-attachments/assets/e3b54327-f42d-4aaa-8f87-15f04d054120


