### PR TITLE
Remove Instagram from Uploadcare related docs

### DIFF
--- a/docs/features/image-upload.md
+++ b/docs/features/image-upload.md
@@ -59,7 +59,7 @@ It is a modern file uploader with a clean interface, automatic support for respo
 
 Thanks to the native CKEditor&nbsp;5 integration, Uploadcare supports drag-and-drop file upload as well as pasting images from the clipboard, Microsoft Word, or Google Docs.
 
-With Uploadcare, users can upload files from external services like Dropbox, Facebook, Google Drive, Google Photos, Instagram, OneDrive or from local computer. Images can be easily adjusted with built-in image editor.
+With Uploadcare, users can upload files from external services like Dropbox, Facebook, Google Drive, Google Photos, OneDrive or from local computer. Images can be easily adjusted with built-in image editor.
 
 {@link features/uploadcare **Learn how to use Uploadcare in your project**}.
 

--- a/docs/features/using-file-managers.md
+++ b/docs/features/using-file-managers.md
@@ -31,7 +31,7 @@ With CKBox you can:
 
 ## Uploadcare file manager
 
-Uploadcare is a modern file management platform with multiple integrations with services like Dropbox, Facebook, Google Drive, Google Photos, Instagram and OneDrive.
+Uploadcare is a modern file management platform with multiple integrations with services like Dropbox, Facebook, Google Drive, Google Photos and OneDrive.
 
 With Uploadcare you can:
 * Upload images directly from:
@@ -39,7 +39,6 @@ With Uploadcare you can:
 	* Facebook,
 	* Google Drive,
 	* Google Photos,
-	* Instagram,
 	* OneDrive,
 	* Local computer,
 	* External URL.

--- a/packages/ckeditor5-image/docs/_snippets/features/image-image-optimizer-uploadcare.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-image-optimizer-uploadcare.js
@@ -45,7 +45,6 @@ ClassicEditor
 					'gdrive',
 					'facebook',
 					'gphotos',
-					'instagram',
 					'onedrive'
 				]
 			}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs (uploadcare): Remove Instagram from Uploadcare related docs.

---

### Additional information

Related to recent changes from https://github.com/ckeditor/ckeditor5/pull/17858 and removing Instagram support from UC plugin.
