### PR TITLE
Add the `ckeditor5-rules/allow-svg-imports-only-in-icons-package` eslint rule.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
 		'**/*.d.ts'
 	],
 	rules: {
+		'ckeditor5-rules/allow-svg-imports-only-in-icons-package': 'error',
 		'ckeditor5-rules/ckeditor-imports': 'error',
 		'ckeditor5-rules/prevent-license-key-leak': 'error',
 		'ckeditor5-rules/license-header': [ 'error', {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,6 @@ module.exports = {
 		'**/*.d.ts'
 	],
 	rules: {
-		'ckeditor5-rules/allow-svg-imports-only-in-icons-package': 'error',
 		'ckeditor5-rules/ckeditor-imports': 'error',
 		'ckeditor5-rules/prevent-license-key-leak': 'error',
 		'ckeditor5-rules/license-header': [ 'error', {
@@ -42,6 +41,7 @@ module.exports = {
 		{
 			files: [ './packages/*/src/**/*.ts' ],
 			rules: {
+				'ckeditor5-rules/allow-svg-imports-only-in-icons-package': 'error',
 				'ckeditor5-rules/ckeditor-plugin-flags': [
 					'error',
 					{

--- a/docs/framework/contributing/code-style.md
+++ b/docs/framework/contributing/code-style.md
@@ -1251,3 +1251,9 @@ import { AIAssistant } from '@ckeditor/ckeditor5-ai';
 import { Plugin } from 'ckeditor5';
 import { AIAssistant } from 'ckeditor5-premium-features';
 ```
+
+### SVG imports only in the `@ckeditor/ckeditor5-icons` package
+
+This rule ensures that SVG files are imported and exported only in the `@ckeditor/ckeditor5-icons` package. This package should include all icons used in CKEditor&nbsp;5.
+
+SVG imports are also allowed in the documentation folders because they are used as images or diagrams.

--- a/docs/framework/contributing/code-style.md
+++ b/docs/framework/contributing/code-style.md
@@ -1255,5 +1255,3 @@ import { AIAssistant } from 'ckeditor5-premium-features';
 ### SVG imports only in the `@ckeditor/ckeditor5-icons` package
 
 This rule ensures that SVG files are imported and exported only in the `@ckeditor/ckeditor5-icons` package. This package should include all icons used in CKEditor&nbsp;5.
-
-SVG imports are also allowed in the documentation folders because they are used as images or diagrams.

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "coveralls": "^3.1.0",
     "date-fns": "2.30.0",
     "eslint": "^8.21.0",
-    "eslint-config-ckeditor5": "^9.0.0",
+    "eslint-config-ckeditor5": "^9.1.0",
     "eslint-formatter-stylish": "^8.40.0",
     "estree-walker": "^3.0.3",
     "fs-extra": "^11.0.0",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Add the `ckeditor5-rules/allow-svg-imports-only-in-icons-package` eslint rule.

---

### Additional information

Related to #16546.
