### PR TITLE
Internal: Add range exceptions to `check-dependencies-versions-match` script.

### DIFF
--- a/scripts/ci/check-dependencies-versions-match.mjs
+++ b/scripts/ci/check-dependencies-versions-match.mjs
@@ -184,12 +184,9 @@ function getNewestVersion( packageName, newVersion = '0.0.0', currentMaxVersion 
 		return newVersion;
 	}
 
-	if ( semver.valid( newVersion ) ) {
-		return semver.gt( newVersion, currentMaxVersion ) ? newVersion : currentMaxVersion;
-	}
-
-	const versions = getVersionsList( packageName );
-	const newMaxVersion = semver.maxSatisfying( versions, newVersion );
+	const newMaxVersion = semver.valid( newVersion ) ?
+		newVersion :
+		semver.maxSatisfying( getVersionsList( packageName ), newVersion );
 
 	return semver.gt( newMaxVersion, currentMaxVersion ) ? newMaxVersion : currentMaxVersion;
 }

--- a/scripts/ci/check-dependencies-versions-match.mjs
+++ b/scripts/ci/check-dependencies-versions-match.mjs
@@ -190,9 +190,8 @@ function getNewestVersion( packageName, newVersion = '0.0.0', currentMaxVersion 
 
 	const versions = getVersionsList( packageName );
 	const newMaxVersion = semver.maxSatisfying( versions, newVersion );
-	const range = versionExceptions[ packageName ] || '';
 
-	return semver.gt( newMaxVersion, currentMaxVersion ) ? range + newMaxVersion : currentMaxVersion;
+	return semver.gt( newMaxVersion, currentMaxVersion ) ? newMaxVersion : currentMaxVersion;
 }
 
 /**

--- a/scripts/ci/check-dependencies-versions-match.mjs
+++ b/scripts/ci/check-dependencies-versions-match.mjs
@@ -24,6 +24,14 @@ const shouldFix = process.argv[ 2 ] === '--fix';
 
 console.log( chalk.blue( '🔍 Starting checking dependencies versions...' ) );
 
+/**
+ * All dependencies should be pinned to the exact version. However, there are some exceptions,
+ * where we want to use the caret or tilde operator. This object contains such exceptions.
+ */
+const rangeExceptions = {
+	'@codemirror/state': '^'
+};
+
 const [ packageJsons, pathMappings ] = getPackageJsons( [
 	'package.json',
 	'packages/*/package.json',
@@ -165,8 +173,9 @@ function getNewestVersion( packageName, newVersion = '0.0.0', currentMaxVersion 
 	if ( !semver.valid( newVersion ) ) {
 		const versions = getVersionsList( packageName );
 		const newMaxVersion = semver.maxSatisfying( versions, newVersion );
+		const range = rangeExceptions[ packageName ] || '';
 
-		return semver.gt( newMaxVersion, currentMaxVersion ) ? newMaxVersion : currentMaxVersion;
+		return semver.gt( newMaxVersion, currentMaxVersion ) ? range + newMaxVersion : currentMaxVersion;
 	}
 
 	return semver.gt( newVersion, currentMaxVersion ) ? newVersion : currentMaxVersion;

--- a/scripts/ci/check-dependencies-versions-match.mjs
+++ b/scripts/ci/check-dependencies-versions-match.mjs
@@ -170,15 +170,19 @@ function getExpectedDepsVersions( packageJsons, isCkeditor5Package ) {
  * @return {String}
  */
 function getNewestVersion( packageName, newVersion = '0.0.0', currentMaxVersion = '0.0.0' ) {
-	if ( !semver.valid( newVersion ) ) {
-		const versions = getVersionsList( packageName );
-		const newMaxVersion = semver.maxSatisfying( versions, newVersion );
-		const range = rangeExceptions[ packageName ] || '';
-
-		return semver.gt( newMaxVersion, currentMaxVersion ) ? range + newMaxVersion : currentMaxVersion;
+	if ( rangeExceptions[ packageName ] ) {
+		return newVersion;
 	}
 
-	return semver.gt( newVersion, currentMaxVersion ) ? newVersion : currentMaxVersion;
+	if ( semver.valid( newVersion ) ) {
+		return semver.gt( newVersion, currentMaxVersion ) ? newVersion : currentMaxVersion;
+	}
+
+	const versions = getVersionsList( packageName );
+	const newMaxVersion = semver.maxSatisfying( versions, newVersion );
+	const range = rangeExceptions[ packageName ] || '';
+
+	return semver.gt( newMaxVersion, currentMaxVersion ) ? range + newMaxVersion : currentMaxVersion;
 }
 
 /**

--- a/scripts/ci/check-dependencies-versions-match.mjs
+++ b/scripts/ci/check-dependencies-versions-match.mjs
@@ -29,7 +29,11 @@ console.log( chalk.blue( '🔍 Starting checking dependencies versions...' ) );
  * where we want to use the caret or tilde operator. This object contains such exceptions.
  */
 const rangeExceptions = {
-	'@codemirror/state': '^'
+	'@codemirror/autocomplete': '^',
+	'@codemirror/lang-html': '^',
+	'@codemirror/language': '^',
+	'@codemirror/state': '^',
+	'@codemirror/view': '^'
 };
 
 const [ packageJsons, pathMappings ] = getPackageJsons( [

--- a/scripts/ci/check-dependencies-versions-match.mjs
+++ b/scripts/ci/check-dependencies-versions-match.mjs
@@ -28,7 +28,13 @@ console.log( chalk.blue( '🔍 Starting checking dependencies versions...' ) );
  * All dependencies should be pinned to the exact version. However, there are some exceptions,
  * where we want to use the caret or tilde operator. This object contains such exceptions.
  */
-const rangeExceptions = {
+const versionExceptions = {
+	/**
+	 * CodeMirror packages are modular and depend on each other. We must use the same versions
+	 * as they have in their dependencies to avoid issues with versions mismatch.
+	 *
+	 * See: https://github.com/cksource/ckeditor5-commercial/issues/6939.
+	 */
 	'@codemirror/autocomplete': '^',
 	'@codemirror/lang-html': '^',
 	'@codemirror/language': '^',
@@ -174,7 +180,7 @@ function getExpectedDepsVersions( packageJsons, isCkeditor5Package ) {
  * @return {String}
  */
 function getNewestVersion( packageName, newVersion = '0.0.0', currentMaxVersion = '0.0.0' ) {
-	if ( rangeExceptions[ packageName ] ) {
+	if ( versionExceptions[ packageName ] ) {
 		return newVersion;
 	}
 
@@ -184,7 +190,7 @@ function getNewestVersion( packageName, newVersion = '0.0.0', currentMaxVersion 
 
 	const versions = getVersionsList( packageName );
 	const newMaxVersion = semver.maxSatisfying( versions, newVersion );
-	const range = rangeExceptions[ packageName ] || '';
+	const range = versionExceptions[ packageName ] || '';
 
 	return semver.gt( newMaxVersion, currentMaxVersion ) ? range + newMaxVersion : currentMaxVersion;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Add range exceptions to `check-dependencies-versions-match` script.

---

Related to cksource/ckeditor5-commercial#6939
