### PR TITLE
Return empty emoji feed list if the query starts with a marker character

### DIFF
--- a/packages/ckeditor5-emoji/src/emojimention.ts
+++ b/packages/ckeditor5-emoji/src/emojimention.ts
@@ -246,6 +246,11 @@ export default class EmojiMention extends Plugin {
 				return [];
 			}
 
+			// Do not show anything when a query starts with a marker character.
+			if ( searchQuery.startsWith( EMOJI_MENTION_MARKER ) ) {
+				return [];
+			}
+
 			// If the repository plugin is not available, return an empty feed to avoid confusion. See: #17842.
 			if ( !this._isEmojiRepositoryAvailable ) {
 				return [];

--- a/packages/ckeditor5-emoji/tests/emojimention.js
+++ b/packages/ckeditor5-emoji/tests/emojimention.js
@@ -615,6 +615,14 @@ describe( 'EmojiMention', () => {
 			expect( queryEmoji( ' see' ) ).to.deep.equal( [] );
 		} );
 
+		it( 'should return an empty array when a query starts with a marker character', () => {
+			const { getEmojiByQuery } = editor.plugins.get( 'EmojiRepository' );
+			getEmojiByQuery.returns( [] );
+
+			expect( queryEmoji( ':' ) ).to.deep.equal( [] );
+			expect( queryEmoji( '::' ) ).to.deep.equal( [] );
+		} );
+
 		it( 'should return an empty array when the repository plugin is not available', async () => {
 			testUtils.sinon.stub( console, 'warn' );
 			fetchStub.rejects( 'Failed to load CDN.' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Return empty emoji feed list if the query starts with a marker character. Closes #17851.

---

### Additional information

https://github.com/user-attachments/assets/d9998881-7ba7-451c-9324-5d303440c906