### PR TITLE
Plain table should be properly aligned in the output

### DIFF
--- a/packages/ckeditor5-table/src/plaintableoutput.ts
+++ b/packages/ckeditor5-table/src/plaintableoutput.ts
@@ -8,7 +8,7 @@
  */
 
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
-import type { DowncastWriter, Element, Node, ViewContainerElement } from 'ckeditor5/src/engine.js';
+import type { DowncastWriter, Element, Node, ViewContainerElement, UpcastElementEvent } from 'ckeditor5/src/engine.js';
 
 import Table from './table.js';
 
@@ -67,6 +67,15 @@ export default class PlainTableOutput extends Plugin {
 		if ( editor.plugins.has( 'TableProperties' ) ) {
 			downcastTableBorderAndBackgroundAttributes( editor );
 		}
+
+		editor.conversion.for( 'upcast' ).add( dispatcher => {
+			dispatcher.on<UpcastElementEvent>( 'element:table', ( evt, data, conversionApi ) => {
+				// It's not necessary to upcast the `table` class. This class was only added in data downcast
+				// to center a plain table in the editor output.
+				// See: https://github.com/ckeditor/ckeditor5/issues/17888.
+				conversionApi.consumable.consume( data.viewItem, { classes: 'table' } );
+			} );
+		} );
 	}
 }
 
@@ -121,7 +130,7 @@ function downcastTableElement( table: Element, { writer }: { writer: DowncastWri
 	//        {table-body-rows-slot}
 	//    </tbody>
 	// </table>
-	return writer.createContainerElement( 'table', null, [ childrenSlot, ...tableContentElements ] );
+	return writer.createContainerElement( 'table', { class: 'table' }, [ childrenSlot, ...tableContentElements ] );
 }
 
 /**

--- a/packages/ckeditor5-table/tests/manual/plaintableoutput.html
+++ b/packages/ckeditor5-table/tests/manual/plaintableoutput.html
@@ -1,3 +1,4 @@
+<h2>Editor:</h2>
 <div id="editor">
 	<table>
 		<caption>Monthly savings</caption>
@@ -16,17 +17,25 @@
 	</figure>
 </div>
 
+<h2>Editor output preview:</h2>
+<div id="editor-output-preview" class="ck-content"></div>
+
+<h2>Editor data:</h2>
+<div class="editor-output">
+	<pre id="editor-data" rows="20"></pre>
+</div>
+
 <style>
 	.editor-output {
-		margin-top: 30px;
+		padding: 10px;
+		border: 1px solid #ccc;
 	}
 
 	#editor-data {
 		width: 100%;
 	}
-</style>
 
-<div class="editor-output">
-	<h5>Editor data</h5>
-	<pre id="editor-data" rows="20"></pre>
-</div>
+	#editor-output-preview {
+		border: 1px solid #ccc;
+	}
+</style>

--- a/packages/ckeditor5-table/tests/manual/plaintableoutput.js
+++ b/packages/ckeditor5-table/tests/manual/plaintableoutput.js
@@ -79,11 +79,18 @@ ClassicEditor
 		window.editor = editor;
 
 		const element = document.getElementById( 'editor-data' );
-		element.innerText = formatHtml( editor.getData() );
+		const editorPreview = document.getElementById( 'editor-output-preview' );
+
+		updateOutput();
 
 		editor.model.document.on( 'change:data', () => {
-			element.innerText = formatHtml( editor.getData() );
+			updateOutput();
 		} );
+
+		function updateOutput() {
+			element.innerText = formatHtml( editor.getData() );
+			editorPreview.innerHTML = editor.getData();
+		}
 	} )
 	.catch( err => {
 		console.error( err.stack );

--- a/packages/ckeditor5-table/tests/plaintableoutput.js
+++ b/packages/ckeditor5-table/tests/plaintableoutput.js
@@ -519,4 +519,18 @@ describe( 'PlainTableOutput', () => {
 			}
 		} );
 	} );
+
+	describe( 'upcast', () => {
+		it( 'should consume the `table` class', () => {
+			editor.conversion.for( 'upcast' ).add( dispatcher => {
+				dispatcher.on( 'element:table', ( evt, data, conversionApi ) => {
+					expect( conversionApi.consumable.test( data.viewItem, { classes: [ 'table' ] } ) ).to.be.false;
+				} );
+			}, { priority: 'low' } );
+
+			editor.setData(
+				'<table class="table"><tr><td>foo</td></tr></table>'
+			);
+		} );
+	} );
 } );

--- a/packages/ckeditor5-table/tests/plaintableoutput.js
+++ b/packages/ckeditor5-table/tests/plaintableoutput.js
@@ -59,7 +59,7 @@ describe( 'PlainTableOutput', () => {
 				] ) );
 
 				expect( editor.getData() ).to.equal(
-					'<table>' +
+					'<table class="table">' +
 						'<tbody>' +
 							'<tr><td>foo</td></tr>' +
 						'</tbody>' +
@@ -75,7 +75,7 @@ describe( 'PlainTableOutput', () => {
 				], { headingRows: 2 } ) );
 
 				expect( editor.getData() ).to.equal(
-					'<table>' +
+					'<table class="table">' +
 						'<thead>' +
 							'<tr><th>1</th><th>2</th></tr>' +
 							'<tr><th>3</th><th>4</th></tr>' +
@@ -95,7 +95,7 @@ describe( 'PlainTableOutput', () => {
 				], { headingColumns: 1 } ) );
 
 				expect( editor.getData() ).to.equal(
-					'<table>' +
+					'<table class="table">' +
 						'<tbody>' +
 							'<tr><th>1</th><td>2</td></tr>' +
 							'<tr><th>3</th><td>4</td></tr>' +
@@ -113,7 +113,7 @@ describe( 'PlainTableOutput', () => {
 				], { headingRows: 1, headingColumns: 1 } ) );
 
 				expect( editor.getData() ).to.equal(
-					'<table>' +
+					'<table class="table">' +
 						'<thead>' +
 							'<tr><th>1</th><th>2</th></tr>' +
 						'</thead>' +
@@ -132,7 +132,7 @@ describe( 'PlainTableOutput', () => {
 				], { headingRows: 3 } ) );
 
 				expect( editor.getData() ).to.equal(
-					'<table>' +
+					'<table class="table">' +
 						'<thead>' +
 							'<tr><th>1</th><th>2</th></tr>' +
 							'<tr><th>3</th><th>4</th></tr>' +
@@ -153,7 +153,7 @@ describe( 'PlainTableOutput', () => {
 				);
 
 				expect( editor.getData() ).to.equal(
-					'<table>' +
+					'<table class="table">' +
 						'<caption>Foo</caption>' +
 						'<tbody>' +
 							'<tr><td>1</td><td>2</td></tr>' +
@@ -177,7 +177,7 @@ describe( 'PlainTableOutput', () => {
 				);
 
 				expect( testEditor.getData() ).to.equal(
-					'<table>' +
+					'<table class="table">' +
 						'<tbody>' +
 							'<tr><td>1</td><td>2</td></tr>' +
 						'</tbody>' +
@@ -512,7 +512,7 @@ describe( 'PlainTableOutput', () => {
 				const tableStyleEntry = tableStyle ? ` style="${ tableStyle }"` : '';
 
 				expect( editor.getData() ).to.equalMarkup(
-					`<table${ tableStyleEntry }>` +
+					`<table class="table"${ tableStyleEntry }>` +
 						'<tbody><tr><td>foo</td></tr></tbody>' +
 					'</table>'
 				);

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -2990,7 +2990,7 @@ describe( 'TableColumnResizeEditing', () => {
 				setModelData( ptoEditor.model, table );
 
 				expect( ptoEditor.getData() ).to.equal(
-					'<table class="ck-table-resized" style="width:100%;">' +
+					'<table class="table ck-table-resized" style="width:100%;">' +
 						'<colgroup>' +
 							'<col style="width:80%;">' +
 							'<col style="width:20%;">' +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (table): Plain table should be properly aligned in the output. Closes #17888.

---

### Additional information

The table class that we use for `<figure>` elements has `margin-left` and `margin-right` set to `auto`. Since a `plain table` is not wrapped in a `<figure>` element, it lacked the proper margin. That's why I added the same class used for `<figure>` to the `<table>` element in the data output.
