### PR TITLE
Restore `skipComments` option on reinitialization of the data process…

### DIFF
--- a/packages/ckeditor5-html-support/src/fullpage.ts
+++ b/packages/ckeditor5-html-support/src/fullpage.ts
@@ -36,7 +36,12 @@ export default class FullPage extends Plugin {
 		const editor = this.editor;
 		const properties = [ '$fullPageDocument', '$fullPageDocType', '$fullPageXmlDeclaration' ];
 
+		// Store the original skipComments value to restore it later. It may be set to `true` by
+		// the `HtmlComment` plugin before this plugin is initialized.
+		const oldSkipComments = editor.data.processor.skipComments;
+
 		editor.data.processor = new HtmlPageDataProcessor( editor.data.viewDocument );
+		editor.data.processor.skipComments = oldSkipComments;
 
 		editor.model.schema.extend( '$root', {
 			allowAttributes: properties

--- a/packages/ckeditor5-html-support/src/fullpage.ts
+++ b/packages/ckeditor5-html-support/src/fullpage.ts
@@ -7,7 +7,7 @@
  * @module html-support/fullpage
  */
 
-import { Plugin } from 'ckeditor5/src/core.js';
+import { type Editor, Plugin } from 'ckeditor5/src/core.js';
 import { UpcastWriter, type DataControllerToModelEvent, type DataControllerToViewEvent } from 'ckeditor5/src/engine.js';
 import HtmlPageDataProcessor from './htmlpagedataprocessor.js';
 
@@ -32,16 +32,18 @@ export default class FullPage extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
+	constructor( editor: Editor ) {
+		super( editor );
+
+		editor.data.processor = new HtmlPageDataProcessor( editor.data.viewDocument );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
 	public init(): void {
 		const editor = this.editor;
 		const properties = [ '$fullPageDocument', '$fullPageDocType', '$fullPageXmlDeclaration' ];
-
-		// Store the original skipComments value to restore it later. It may be set to `true` by
-		// the `HtmlComment` plugin before this plugin is initialized.
-		const oldSkipComments = editor.data.processor.skipComments;
-
-		editor.data.processor = new HtmlPageDataProcessor( editor.data.viewDocument );
-		editor.data.processor.skipComments = oldSkipComments;
 
 		editor.model.schema.extend( '$root', {
 			allowAttributes: properties

--- a/packages/ckeditor5-html-support/tests/fullpage.js
+++ b/packages/ckeditor5-html-support/tests/fullpage.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import { FullPage, HtmlPageDataProcessor } from '../src/index.js';
+import { FullPage, HtmlComment, HtmlPageDataProcessor } from '../src/index.js';
 
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor.js';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
@@ -226,10 +226,32 @@ describe( 'FullPage', () => {
 		}
 	} );
 
-	async function createEditor( initialData ) {
+	describe( 'HtmlComments integration', () => {
+		it( 'should preserve comments', async () => {
+			const content =
+				'<?xml version="1.0" encoding="UTF-8"?>\n' +
+				'<!DOCTYPE html>\n' +
+				'<html>' +
+					'<head><title>Testing full page</title></head>' +
+					'<body style="background: red">' +
+						'<!-- comment -->' +
+						'<p>foo</p><p>bar</p>' +
+					'</body>' +
+				'</html>';
+
+			await createEditor( content, {
+				plugins: [ Paragraph, ClipboardPipeline, HtmlComment, FullPage ]
+			} );
+
+			expect( editor.getData() ).to.equal( content );
+		} );
+	} );
+
+	async function createEditor( initialData, options = {} ) {
 		editor = await VirtualTestEditor.create( {
 			plugins: [ Paragraph, ClipboardPipeline, FullPage ],
-			initialData
+			initialData,
+			...options
 		} );
 
 		// Stub `editor.editing.view.scrollToTheSelection` as it will fail on VirtualTestEditor without DOM.

--- a/packages/ckeditor5-html-support/tests/fullpage.js
+++ b/packages/ckeditor5-html-support/tests/fullpage.js
@@ -226,7 +226,7 @@ describe( 'FullPage', () => {
 		}
 	} );
 
-	describe( 'HtmlComments integration', () => {
+	describe( 'HtmlComment integration', () => {
 		it( 'should preserve comments', async () => {
 			const content =
 				'<?xml version="1.0" encoding="UTF-8"?>\n' +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (html-support): Comments are no longer lost when `FullPage` plugin is added after the `HtmlComment` plugin.

---

### Additional information

The `HtmlComment` plugin sets `skipComments` to `false` but `FullPage` reinitializes the processor and resets this flag.

Reported in this [comment](https://github.com/ckeditor/ckeditor5/issues/16834#issuecomment-2642960807)