### PR TITLE
Notify about CI failures on `master-it84` branch

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -336,6 +336,7 @@ workflows:
             branches:
               only:
                 - master
+                - master-it84
                 - stable
                 - release
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Notify about CI failures on `master-it84` branch.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
