### PR TITLE
Make `HtmlPageDataProcessor` stateless.

### DIFF
--- a/packages/ckeditor5-html-support/src/htmlpagedataprocessor.ts
+++ b/packages/ckeditor5-html-support/src/htmlpagedataprocessor.ts
@@ -15,11 +15,6 @@ import { HtmlDataProcessor, UpcastWriter, type ViewDocumentFragment } from 'cked
  */
 export default class HtmlPageDataProcessor extends HtmlDataProcessor {
 	/**
-	 * Contains the `documentElement` property of the `Document` interface.
-	 */
-	public parsedDocument: HTMLElement | null = null;
-
-	/**
 	 * @inheritDoc
 	 */
 	public override toView( data: string ): ViewDocumentFragment {
@@ -58,7 +53,10 @@ export default class HtmlPageDataProcessor extends HtmlDataProcessor {
 		// Using the DOM document with body content extracted as a skeleton of the page.
 		writer.setCustomProperty( '$fullPageDocument', domFragment.ownerDocument.documentElement.outerHTML, viewFragment );
 
-		this.parsedDocument = domFragment.ownerDocument.documentElement;
+		// List of `<style>` elements extracted from document's `<head>` element.
+		const headStylesElements = Array.from( domFragment.ownerDocument.querySelectorAll( 'head style' ) );
+
+		writer.setCustomProperty( '$fullPageHeadStyles', headStylesElements, viewFragment );
 
 		if ( docType ) {
 			writer.setCustomProperty( '$fullPageDocType', docType, viewFragment );

--- a/packages/ckeditor5-html-support/tests/fullpage.js
+++ b/packages/ckeditor5-html-support/tests/fullpage.js
@@ -327,7 +327,7 @@ describe( 'FullPage', () => {
 			} );
 		} );
 
-		describe( 'default `fullPage.sanitizeCss`', () => {
+		describe( 'default `htmlSupport.fullPage.sanitizeCss`', () => {
 			let config = '';
 			let fullPageConfig;
 
@@ -366,7 +366,7 @@ describe( 'FullPage', () => {
 			} );
 		} );
 
-		describe( 'custom `fullPage.sanitizeCss`', () => {
+		describe( 'custom `htmlSupport.fullPage.sanitizeCss`', () => {
 			let config = '';
 			let fullPageConfig;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal(full-page): Removed property from the `HtmlPageDataProcessor` to make it stateless.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
