### PR TITLE
Extended packagers in the "check-dependencies-versions" script

### DIFF
--- a/scripts/ci/check-dependencies-versions-match.mjs
+++ b/scripts/ci/check-dependencies-versions-match.mjs
@@ -39,7 +39,8 @@ const versionExceptions = {
 	'@codemirror/lang-html': '^',
 	'@codemirror/language': '^',
 	'@codemirror/state': '^',
-	'@codemirror/view': '^'
+	'@codemirror/view': '^',
+	'@codemirror/theme-one-dark': '^'
 };
 
 const [ packageJsons, pathMappings ] = getPackageJsons( [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Allows the installation of the "@codemirror/theme-one-dark" package using the caret range.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
