### PR TITLE
Fix: button element being wrapped in html-object needlessly

### DIFF
--- a/packages/ckeditor5-html-support/src/schemadefinitions.ts
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.ts
@@ -838,6 +838,14 @@ export default {
 				isFormatting: true
 			}
 		},
+		{
+			model: 'htmlButton',
+			view: 'button',
+			attributeProperties: {
+				copyOnEnter: true,
+				isFormatting: true
+			}
+		},
 
 		// Objects.
 		{
@@ -859,14 +867,6 @@ export default {
 		{
 			model: 'htmlInput',
 			view: 'input',
-			isObject: true,
-			modelSchema: {
-				inheritAllFrom: '$inlineObject'
-			}
-		},
-		{
-			model: 'htmlButton',
-			view: 'button',
 			isObject: true,
 			modelSchema: {
 				inheritAllFrom: '$inlineObject'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (html-support): Configuration change for htmlButton, making it not wrapped in html object. Closes #16379 and #16171.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
