### PR TITLE
Fix typo in license type warning.

### DIFF
--- a/packages/ckeditor5-core/src/editor/editor.ts
+++ b/packages/ckeditor5-core/src/editor/editor.ts
@@ -528,6 +528,7 @@ export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 			if ( [ 'development', 'evaluation', 'trial' ].includes( licensePayload.licenseType ) ) {
 				const { licenseType } = licensePayload;
 				const capitalizedLicenseType = licenseType[ 0 ].toUpperCase() + licenseType.slice( 1 );
+				const article = licenseType === 'evaluation' ? 'an' : 'a';
 
 				console.info(
 					`%cCKEditor 5 ${ capitalizedLicenseType } License`,
@@ -535,7 +536,7 @@ export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 				);
 
 				console.warn(
-					`⚠️ You are using a ${ licenseType } license of CKEditor 5` +
+					`⚠️ You are using ${ article } ${ licenseType } license of CKEditor 5` +
 					`${ licenseType === 'trial' ? ' which is for evaluation purposes only' : '' }. ` +
 					'For production usage, please obtain a production license at https://portal.ckeditor.com/'
 				);

--- a/packages/ckeditor5-core/tests/editor/licensecheck.js
+++ b/packages/ckeditor5-core/tests/editor/licensecheck.js
@@ -403,9 +403,11 @@ describe( 'Editor - license check', () => {
 					// Verify console.warn call with the warning message
 					sinon.assert.calledOnce( consoleWarnStub );
 
+					const article = licenseType === 'evaluation' ? 'an' : 'a';
+
 					sinon.assert.calledWith(
 						consoleWarnStub,
-						`⚠️ You are using a ${ licenseType } license of CKEditor 5` +
+						`⚠️ You are using ${ article } ${ licenseType } license of CKEditor 5` +
 						`${ licenseType === 'trial' ? ' which is for evaluation purposes only' : '' }. ` +
 						'For production usage, please obtain a production license at https://portal.ckeditor.com/'
 					);


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (core): Fix typo in license type warning.

---

### Additional information

**Before**

`You are using a evaluation license [..]`

**After**

`You are using an evaluation license [..]`
