### PR TITLE
Add basic clipboard support for table layout editing.

### DIFF
--- a/packages/ckeditor5-table/src/tablelayout/tablelayoutediting.ts
+++ b/packages/ckeditor5-table/src/tablelayout/tablelayoutediting.ts
@@ -9,7 +9,6 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import type { EventInfo } from 'ckeditor5/src/utils.js';
-import type { ClipboardContentInsertionEvent, ClipboardPipeline } from 'ckeditor5/src/clipboard.js';
 import type {
 	UpcastConversionApi,
 	UpcastConversionData,
@@ -44,7 +43,6 @@ export default class TableLayoutEditing extends Plugin {
 	public init(): void {
 		this._defineSchema();
 		this._defineConverters();
-		this._handleClipboardPasting();
 
 		this.editor.commands.add( 'insertTableLayout', new InsertTableLayoutCommand( this.editor ) );
 	}
@@ -106,42 +104,6 @@ export default class TableLayoutEditing extends Plugin {
 				const viewElement = mapper.toViewElement( modelElement );
 
 				writer.addClass( `${ attributeNewValue }-table`, viewElement );
-			} );
-		} );
-	}
-
-	/**
-	 * Handle clipboard paste events:
-	 *
-	 * * It does not affect *copying* content from the editor, only *pasting*.
-	 * * When content is pasted from another editor instance, tables are always converted to content tables,
-	 *   regardless of their original type.
-	 * * When content is pasted from the same editor instance, table types are preserved:
-	 *   - layout tables remain layout tables.
-	 *   - content tables remain content tables.
-	 */
-	private _handleClipboardPasting(): void {
-		const { plugins } = this.editor;
-
-		if ( !plugins.has( 'ClipboardPipeline' ) ) {
-			return;
-		}
-
-		const clipboardPipeline: ClipboardPipeline = plugins.get( 'ClipboardPipeline' );
-
-		this.listenTo<ClipboardContentInsertionEvent>( clipboardPipeline, 'contentInsertion', ( evt, data ) => {
-			// If content is pasted from the same editor, keep original table types.
-			if ( data.sourceEditorId === this.editor.id ) {
-				return;
-			}
-
-			// For content from other sources, always set table type to 'content'.
-			this.editor.model.change( writer => {
-				for ( const { item } of writer.createRangeIn( data.content ) ) {
-					if ( item.is( 'element', 'table' ) ) {
-						writer.setAttribute( 'tableType', 'content', item );
-					}
-				}
 			} );
 		} );
 	}

--- a/packages/ckeditor5-table/src/utils/structure.ts
+++ b/packages/ckeditor5-table/src/utils/structure.ts
@@ -59,8 +59,17 @@ export function cropTableToDimensions(
 ): Element {
 	const { startRow, startColumn, endRow, endColumn } = cropDimensions;
 
-	// Create empty table with empty rows equal to crop height.
+	// Initialize the cropped table element.
 	const croppedTable = writer.createElement( 'table' );
+
+	// Copy table type attribute if present.
+	const sourceTableType = sourceTable.getAttribute( 'tableType' );
+
+	if ( sourceTableType ) {
+		writer.setAttribute( 'tableType', sourceTableType, croppedTable );
+	}
+
+	// Create empty table with empty rows equal to crop height.
 	const cropHeight = endRow - startRow + 1;
 
 	for ( let i = 0; i < cropHeight; i++ ) {

--- a/packages/ckeditor5-table/tests/manual/tablelayout.html
+++ b/packages/ckeditor5-table/tests/manual/tablelayout.html
@@ -1,216 +1,257 @@
-<div id="editor">
-	<p>Table default: content table</p>
-	<table>
-		<tr>
-			<td>a</td>
-			<td>b</td>
-			<td>c</td>
-		</tr>
-		<tr>
-			<td>1</td>
-			<td>2</td>
-			<td>3</td>
-		</tr>
-	</table>
+<head>
+	<meta
+		http-equiv="Content-Security-Policy"
+		content="script-src 'self' https://ckeditor.com 'unsafe-inline' 'unsafe-eval'"
+	>
 
-	<p>Table with layout-table class: layout table</p>
-	<table class="layout-table">
-		<tr>
-			<td>a</td>
-			<td>b</td>
-			<td>c</td>
-		</tr>
-		<tr>
-			<td>1</td>
-			<td>2</td>
-			<td>3</td>
-		</tr>
-	</table>
+	<style>
+		.editors-container {
+			display: flex;
+			gap: 20px;
+		}
 
-	<p>Figure that contains "table" class with table inside: content table</p>
-	<figure class="table">
-		<table>
-			<tr>
-				<td>a</td>
-				<td>b</td>
-				<td>c</td>
-			</tr>
-			<tr>
-				<td>1</td>
-				<td>2</td>
-				<td>3</td>
-			</tr>
-		</table>
-	</figure>
+		.editor-wrapper {
+			flex: 1;
+		}
 
-	<p>Figure that contains "layout-table" class with table inside: layout table</p>
-	<figure class="layout-table">
-		<table>
-			<tr>
-				<td>a</td>
-				<td>b</td>
-				<td>c</td>
-			</tr>
-			<tr>
-				<td>1</td>
-				<td>2</td>
-				<td>3</td>
-			</tr>
-		</table>
-	</figure>
+		.clipboard-preview-wrapper {
+			margin-top: 20px;
+		}
 
+		.clipboard-preview {
+			padding: 10px;
+			background: #f0f0f0;
+			border: 1px solid #ccc;
+			white-space: pre-wrap;
+		}
+	</style>
+</head>
 
-	<p>Figure with table default: content table</p>
-	<figure>
-		<table>
-			<thead>
-				<tr>
-					<th>0</th>
-					<th>1</th>
-					<th>2</th>
-					<th>3</th>
-					<th>4</th>
-				</tr>
-			</thead>
-			<tbody>
+<div class="editors-container">
+	<div class="editor-wrapper">
+		<h2>Editor 1 (with TableLayout)</h2>
+		<div id="editor">
+			<p>Table default: content table</p>
+			<table>
 				<tr>
 					<td>a</td>
 					<td>b</td>
 					<td>c</td>
-					<td>d</td>
-					<td>e</td>
 				</tr>
 				<tr>
-					<td>f</td>
-					<td>g</td>
-					<td>h</td>
-					<td>i</td>
-					<td>j</td>
+					<td>1</td>
+					<td>2</td>
+					<td>3</td>
+				</tr>
+			</table>
+
+			<p>Table with layout-table class: layout table</p>
+			<table class="layout-table">
+				<tr>
+					<td>a</td>
+					<td>b</td>
+					<td>c</td>
 				</tr>
 				<tr>
-					<td>k</td>
-					<td>l</td>
-					<td>m</td>
-					<td>n</td>
-					<td>o</td>
+					<td>1</td>
+					<td>2</td>
+					<td>3</td>
+				</tr>
+			</table>
+
+			<p>Figure that contains "table" class with table inside: content table</p>
+			<figure class="table">
+				<table>
+					<tr>
+						<td>a</td>
+						<td>b</td>
+						<td>c</td>
+					</tr>
+					<tr>
+						<td>1</td>
+						<td>2</td>
+						<td>3</td>
+					</tr>
+				</table>
+			</figure>
+
+			<p>Figure that contains "layout-table" class with table inside: layout table</p>
+			<figure class="layout-table">
+				<table>
+					<tr>
+						<td>a</td>
+						<td>b</td>
+						<td>c</td>
+					</tr>
+					<tr>
+						<td>1</td>
+						<td>2</td>
+						<td>3</td>
+					</tr>
+				</table>
+			</figure>
+
+
+			<p>Figure with table default: content table</p>
+			<figure>
+				<table>
+					<thead>
+						<tr>
+							<th>0</th>
+							<th>1</th>
+							<th>2</th>
+							<th>3</th>
+							<th>4</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>a</td>
+							<td>b</td>
+							<td>c</td>
+							<td>d</td>
+							<td>e</td>
+						</tr>
+						<tr>
+							<td>f</td>
+							<td>g</td>
+							<td>h</td>
+							<td>i</td>
+							<td>j</td>
+						</tr>
+						<tr>
+							<td>k</td>
+							<td>l</td>
+							<td>m</td>
+							<td>n</td>
+							<td>o</td>
+						</tr>
+						<tr>
+							<td>p</td>
+							<td>q</td>
+							<td>r</td>
+							<td>s</td>
+							<td>t</td>
+						</tr>
+					</tbody>
+				</table>
+			</figure>
+		</div>
+	</div>
+
+	<div class="editor-wrapper">
+		<h2>Editor 2 (with PlainTableOutput)</h2>
+		<div id="editor-with-plain-table-output">
+			<p>Table default: content table</p>
+			<table>
+				<tr>
+					<td>a</td>
+					<td>b</td>
+					<td>c</td>
 				</tr>
 				<tr>
-					<td>p</td>
-					<td>q</td>
-					<td>r</td>
-					<td>s</td>
-					<td>t</td>
+					<td>1</td>
+					<td>2</td>
+					<td>3</td>
 				</tr>
-			</tbody>
-		</table>
-	</figure>
+			</table>
+
+			<p>Table with layout-table class: layout table</p>
+			<table class="layout-table">
+				<tr>
+					<td>a</td>
+					<td>b</td>
+					<td>c</td>
+				</tr>
+				<tr>
+					<td>1</td>
+					<td>2</td>
+					<td>3</td>
+				</tr>
+			</table>
+
+			<p>Figure that contains "table" class with table inside: content table</p>
+			<figure class="table">
+				<table>
+					<tr>
+						<td>a</td>
+						<td>b</td>
+						<td>c</td>
+					</tr>
+					<tr>
+						<td>1</td>
+						<td>2</td>
+						<td>3</td>
+					</tr>
+				</table>
+			</figure>
+
+			<p>Figure that contains "layout-table" class with table inside: layout table</p>
+			<figure class="layout-table">
+				<table>
+					<tr>
+						<td>a</td>
+						<td>b</td>
+						<td>c</td>
+					</tr>
+					<tr>
+						<td>1</td>
+						<td>2</td>
+						<td>3</td>
+					</tr>
+				</table>
+			</figure>
+
+
+			<p>Figure with table default: content table</p>
+			<figure>
+				<table>
+					<thead>
+						<tr>
+							<th>0</th>
+							<th>1</th>
+							<th>2</th>
+							<th>3</th>
+							<th>4</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>a</td>
+							<td>b</td>
+							<td>c</td>
+							<td>d</td>
+							<td>e</td>
+						</tr>
+						<tr>
+							<td>f</td>
+							<td>g</td>
+							<td>h</td>
+							<td>i</td>
+							<td>j</td>
+						</tr>
+						<tr>
+							<td>k</td>
+							<td>l</td>
+							<td>m</td>
+							<td>n</td>
+							<td>o</td>
+						</tr>
+						<tr>
+							<td>p</td>
+							<td>q</td>
+							<td>r</td>
+							<td>s</td>
+							<td>t</td>
+						</tr>
+					</tbody>
+				</table>
+			</figure>
+		</div>
+	</div>
 </div>
 
-<h2>Editor with PlainTableOutput plugin</h2>
-<div id="editor-with-plain-table-output">
-<p>Table default: content table</p>
-	<table>
-		<tr>
-			<td>a</td>
-			<td>b</td>
-			<td>c</td>
-		</tr>
-		<tr>
-			<td>1</td>
-			<td>2</td>
-			<td>3</td>
-		</tr>
-	</table>
-
-	<p>Table with layout-table class: layout table</p>
-	<table class="layout-table">
-		<tr>
-			<td>a</td>
-			<td>b</td>
-			<td>c</td>
-		</tr>
-		<tr>
-			<td>1</td>
-			<td>2</td>
-			<td>3</td>
-		</tr>
-	</table>
-
-	<p>Figure that contains "table" class with table inside: content table</p>
-	<figure class="table">
-		<table>
-			<tr>
-				<td>a</td>
-				<td>b</td>
-				<td>c</td>
-			</tr>
-			<tr>
-				<td>1</td>
-				<td>2</td>
-				<td>3</td>
-			</tr>
-		</table>
-	</figure>
-
-	<p>Figure that contains "layout-table" class with table inside: layout table</p>
-	<figure class="layout-table">
-		<table>
-			<tr>
-				<td>a</td>
-				<td>b</td>
-				<td>c</td>
-			</tr>
-			<tr>
-				<td>1</td>
-				<td>2</td>
-				<td>3</td>
-			</tr>
-		</table>
-	</figure>
-
-
-	<p>Figure with table default: content table</p>
-	<figure>
-		<table>
-			<thead>
-				<tr>
-					<th>0</th>
-					<th>1</th>
-					<th>2</th>
-					<th>3</th>
-					<th>4</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td>a</td>
-					<td>b</td>
-					<td>c</td>
-					<td>d</td>
-					<td>e</td>
-				</tr>
-				<tr>
-					<td>f</td>
-					<td>g</td>
-					<td>h</td>
-					<td>i</td>
-					<td>j</td>
-				</tr>
-				<tr>
-					<td>k</td>
-					<td>l</td>
-					<td>m</td>
-					<td>n</td>
-					<td>o</td>
-				</tr>
-				<tr>
-					<td>p</td>
-					<td>q</td>
-					<td>r</td>
-					<td>s</td>
-					<td>t</td>
-				</tr>
-			</tbody>
-		</table>
-	</figure>
+<div class="clipboard-preview-wrapper">
+	<h3>Clipboard Preview (text/html)</h3>
+	<pre id="clipboard-preview" class="clipboard-preview"></pre>
 </div>

--- a/packages/ckeditor5-table/tests/manual/tablelayout.js
+++ b/packages/ckeditor5-table/tests/manual/tablelayout.js
@@ -73,3 +73,12 @@ ClassicEditor
 	.catch( err => {
 		console.error( err.stack );
 	} );
+
+function handleClipboardEvent( evt ) {
+	const clipboardPreview = document.getElementById( 'clipboard-preview' );
+
+	clipboardPreview.textContent = evt.clipboardData.getData( 'text/html' );
+}
+
+document.addEventListener( 'copy', handleClipboardEvent );
+document.addEventListener( 'cut', handleClipboardEvent );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (table): Fix missing `tableType` attribute in `cropTableToDimensions` output. 

---

### Additional information

Parent PR: https://github.com/ckeditor/ckeditor5/pull/17931
Grandparent PR: https://github.com/ckeditor/ckeditor5/pull/17849