### PR TITLE
Add integration for fullscreen feature with revision history

### DIFF
--- a/packages/ckeditor5-editor-classic/src/classiceditoruiview.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditoruiview.ts
@@ -27,7 +27,7 @@ export default class ClassicEditorUIView extends BoxedEditorUIView {
 	/**
 	 * Toolbar view instance.
 	 */
-	public readonly toolbar: ToolbarView;
+	public override readonly toolbar: ToolbarView;
 
 	/**
 	 * Editable UI view.

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitoruiview.ts
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitoruiview.ts
@@ -25,7 +25,7 @@ export default class DecoupledEditorUIView extends EditorUIView {
 	/**
 	 * The main toolbar of the decoupled editor UI.
 	 */
-	public readonly toolbar: ToolbarView;
+	public override readonly toolbar: ToolbarView;
 
 	/**
 	 * The editable of the decoupled editor UI.

--- a/packages/ckeditor5-editor-inline/src/inlineeditoruiview.ts
+++ b/packages/ckeditor5-editor-inline/src/inlineeditoruiview.ts
@@ -34,7 +34,7 @@ export default class InlineEditorUIView extends EditorUIView {
 	/**
 	 * A floating toolbar view instance.
 	 */
-	public readonly toolbar: ToolbarView;
+	public override readonly toolbar: ToolbarView;
 
 	/**
 	 * The offset from the top edge of the web browser's viewport which makes the

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditoruiview.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditoruiview.ts
@@ -24,7 +24,7 @@ export default class MultiRootEditorUIView extends EditorUIView {
 	/**
 	 * The main toolbar of the multi-root editor UI.
 	 */
-	public readonly toolbar: ToolbarView;
+	public override readonly toolbar: ToolbarView;
 
 	/**
 	 * Editable elements used by the multi-root editor UI.

--- a/packages/ckeditor5-fullscreen/src/fullscreencommand.ts
+++ b/packages/ckeditor5-fullscreen/src/fullscreencommand.ts
@@ -49,7 +49,7 @@ export default class FullscreenCommand extends Command {
 		} else if ( editor instanceof DecoupledEditor ) {
 			this._fullscreenHandler = new DecoupledEditorHandler( editor );
 		} else {
-			this._fullscreenHandler = new AbstractEditorHandler();
+			this._fullscreenHandler = new AbstractEditorHandler( editor );
 		}
 	}
 

--- a/packages/ckeditor5-fullscreen/src/handlers/abstracteditor.ts
+++ b/packages/ckeditor5-fullscreen/src/handlers/abstracteditor.ts
@@ -82,7 +82,7 @@ export default class AbstractEditorHandler {
 	/**
 	 * Returns a single moved element to its original place.
 	 */
-	public returnMovedElement( placeholderName: string ): void {
+	public restoreMovedElementLocation( placeholderName: string ): void {
 		if ( !this._placeholderMap.has( placeholderName ) ) {
 			return;
 		}
@@ -160,7 +160,7 @@ export default class AbstractEditorHandler {
 		}
 
 		for ( const placeholderName of this._placeholderMap.keys() ) {
-			this.returnMovedElement( placeholderName );
+			this.restoreMovedElementLocation( placeholderName );
 		}
 
 		if ( this._placeholderMap.size === 0 ) {
@@ -190,8 +190,8 @@ export default class AbstractEditorHandler {
 		this._editor.config.set( 'revisionHistory.showRevisionViewerCallback', async () => {
 			const revisionViewer = await this._showRevisionViewerCallback!();
 
-			this.returnMovedElement( 'editable' );
-			this.returnMovedElement( 'toolbar' );
+			this.restoreMovedElementLocation( 'editable' );
+			this.restoreMovedElementLocation( 'toolbar' );
 
 			if ( this._editor.ui.view.menuBarView ) {
 				this._editor.ui.view.menuBarView.disable();
@@ -210,9 +210,9 @@ export default class AbstractEditorHandler {
 		// Code coverage is provided in the commercial package repository as integration unit tests.
 		/* istanbul ignore next -- @preserve */
 		this._editor.config.set( 'revisionHistory.closeRevisionViewerCallback', async () => {
-			this.returnMovedElement( 'toolbar' );
-			this.returnMovedElement( 'editable' );
-			this.returnMovedElement( 'right-sidebar' );
+			this.restoreMovedElementLocation( 'toolbar' );
+			this.restoreMovedElementLocation( 'editable' );
+			this.restoreMovedElementLocation( 'right-sidebar' );
 
 			await this._closeRevisionViewerCallback!();
 

--- a/packages/ckeditor5-fullscreen/src/handlers/classiceditor.ts
+++ b/packages/ckeditor5-fullscreen/src/handlers/classiceditor.ts
@@ -25,13 +25,9 @@ export default class ClassicEditorHandler extends AbstractEditorHandler {
 	 * @inheritDoc
 	 */
 	constructor( editor: ClassicEditor ) {
-		super();
+		super( editor );
 
 		this._editor = editor;
-
-		this._editor.on( 'destroy', () => {
-			this.disable();
-		} );
 	}
 
 	/**
@@ -41,7 +37,7 @@ export default class ClassicEditorHandler extends AbstractEditorHandler {
 		const editorUI = this._editor.ui;
 		const editorUIView = editorUI.view;
 
-		this.moveToFullscreen( editorUI.getEditableElement()!, 'editor' );
+		this.moveToFullscreen( editorUI.getEditableElement()!, 'editable' );
 		this.moveToFullscreen( editorUIView.toolbar.element!, 'toolbar' );
 
 		// In classic editor, the `dir` attribute is set on the top-level container and it affects the styling
@@ -49,6 +45,10 @@ export default class ClassicEditorHandler extends AbstractEditorHandler {
 		// Since we don't move the whole container but only parts, we need to reapply the attribute value manually.
 		// Decupled editor doesn't have this issue because there is no top-level container, so `dir` is set on each component separately.
 		this.getContainer().setAttribute( 'dir', editorUIView.element!.getAttribute( 'dir' )! );
+
+		if ( this._editor.plugins.has( 'RevisionHistory' ) ) {
+			this._overrideRevisionHistoryCallbacks();
+		}
 
 		if ( !this._editor.config.get( 'fullscreen.menuBar.isVisible' ) ) {
 			return;
@@ -67,6 +67,10 @@ export default class ClassicEditorHandler extends AbstractEditorHandler {
 	 * Restores the editor UI elements to their original positions.
 	 */
 	public override disable(): void {
+		if ( this._editor.plugins.has( 'RevisionHistory' ) ) {
+			this._restoreRevisionHistoryCallbacks();
+		}
+
 		this.returnMovedElements();
 	}
 }

--- a/packages/ckeditor5-fullscreen/src/handlers/decouplededitor.ts
+++ b/packages/ckeditor5-fullscreen/src/handlers/decouplededitor.ts
@@ -24,24 +24,24 @@ export default class DecoupledEditorHandler extends AbstractEditorHandler {
 	 * @inheritDoc
 	 */
 	constructor( editor: DecoupledEditor ) {
-		super();
+		super( editor );
 
 		this._editor = editor;
-
-		this._editor.on( 'destroy', () => {
-			this.disable();
-		} );
 	}
 
 	/**
 	 * Moves the editor UI elements to the fullscreen mode.
 	 */
 	public override enable(): void {
-		this.moveToFullscreen( this._editor.ui.getEditableElement()!, 'editor' );
+		this.moveToFullscreen( this._editor.ui.getEditableElement()!, 'editable' );
 		this.moveToFullscreen( this._editor.ui.view.toolbar.element!, 'toolbar' );
 
 		if ( this._editor.config.get( 'fullscreen.menuBar.isVisible' ) ) {
 			this.moveToFullscreen( this._editor.ui.view.menuBarView.element!, 'menu-bar' );
+		}
+
+		if ( this._editor.plugins.has( 'RevisionHistory' ) ) {
+			this._overrideRevisionHistoryCallbacks();
 		}
 	}
 
@@ -49,6 +49,10 @@ export default class DecoupledEditorHandler extends AbstractEditorHandler {
 	 * Restores the editor UI elements to their original positions.
 	 */
 	public override disable(): void {
+		if ( this._editor.plugins.has( 'RevisionHistory' ) ) {
+			this._restoreRevisionHistoryCallbacks();
+		}
+
 		this.returnMovedElements();
 	}
 }

--- a/packages/ckeditor5-fullscreen/tests/_utils/revisionhistorymock.js
+++ b/packages/ckeditor5-fullscreen/tests/_utils/revisionhistorymock.js
@@ -1,0 +1,31 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+import { Plugin } from '@ckeditor/ckeditor5-core';
+
+export default class RevisionHistoryMock extends Plugin {
+	static get pluginName() {
+		return 'RevisionHistory';
+	}
+
+	static get isOfficialPlugin() {
+		return true;
+	}
+
+	static showRevisionViewerCallback() {
+		return () => {};
+	}
+
+	static closeRevisionViewerCallback() {
+		return () => {};
+	}
+
+	constructor( editor ) {
+		super( editor );
+
+		editor.config.define( 'revisionHistory.showRevisionViewerCallback', RevisionHistoryMock.showRevisionViewerCallback );
+		editor.config.define( 'revisionHistory.closeRevisionViewerCallback', RevisionHistoryMock.closeRevisionViewerCallback );
+	}
+}

--- a/packages/ckeditor5-fullscreen/tests/fullscreenediting.js
+++ b/packages/ckeditor5-fullscreen/tests/fullscreenediting.js
@@ -43,4 +43,8 @@ describe( 'FullscreenEditing', () => {
 	it( 'should register the `fullscreen` command', () => {
 		expect( editor.commands.get( 'fullscreen' ) ).to.be.instanceOf( FullscreenCommand );
 	} );
+
+	it( 'should define the `fullscreen.menuBar.isVisible` config option to `true`', () => {
+		expect( editor.config.get( 'fullscreen.menuBar.isVisible' ) ).to.be.true;
+	} );
 } );

--- a/packages/ckeditor5-fullscreen/tests/handlers/abstracteditor.js
+++ b/packages/ckeditor5-fullscreen/tests/handlers/abstracteditor.js
@@ -69,10 +69,10 @@ describe( 'AbstractHandler', () => {
 		} );
 	} );
 
-	describe( '#returnMovedElement()', () => {
+	describe( '#restoreMovedElementLocation()', () => {
 		it( 'should not throw if map does not contain requested element', () => {
 			expect( abstractHandler._placeholderMap.has( 'menu-bar' ) ).to.be.false;
-			expect( () => abstractHandler.returnMovedElement( 'menu-bar' ) ).to.not.throw();
+			expect( () => abstractHandler.restoreMovedElementLocation( 'menu-bar' ) ).to.not.throw();
 		} );
 
 		it( 'should return only target moved element', () => {
@@ -86,13 +86,13 @@ describe( 'AbstractHandler', () => {
 			abstractHandler.moveToFullscreen( element2, 'editable' );
 
 			// Move `menu-bar` back.
-			abstractHandler.returnMovedElement( 'menu-bar' );
+			abstractHandler.restoreMovedElementLocation( 'menu-bar' );
 
 			expect( abstractHandler._placeholderMap.size ).to.equal( 1 );
 			expect( global.document.querySelector( '[data-ck-fullscreen-placeholder="menu-bar"' ) ).to.be.null;
 			expect( global.document.querySelector( '[data-ck-fullscreen-placeholder="editable"' ) ).to.not.be.null;
 
-			abstractHandler.returnMovedElement( 'editable' );
+			abstractHandler.restoreMovedElementLocation( 'editable' );
 			element.remove();
 			element2.remove();
 		} );
@@ -103,7 +103,7 @@ describe( 'AbstractHandler', () => {
 			global.document.body.appendChild( element );
 
 			abstractHandler.moveToFullscreen( element, 'menu-bar' );
-			abstractHandler.returnMovedElement( 'menu-bar' );
+			abstractHandler.restoreMovedElementLocation( 'menu-bar' );
 
 			expect( abstractHandler._container ).to.be.null;
 

--- a/packages/ckeditor5-fullscreen/tests/handlers/abstracteditor.js
+++ b/packages/ckeditor5-fullscreen/tests/handlers/abstracteditor.js
@@ -37,8 +37,7 @@ describe( 'AbstractHandler', () => {
 
 	describe( 'constructor', () => {
 		it( 'should create element maps', () => {
-			expect( abstractHandler._idToPlaceholder ).to.be.an.instanceOf( Map );
-			expect( abstractHandler._placeholderToElement ).to.be.an.instanceOf( Map );
+			expect( abstractHandler._placeholderMap ).to.be.an.instanceOf( Map );
 		} );
 
 		it( 'should set the editor instance as a property', () => {
@@ -71,6 +70,11 @@ describe( 'AbstractHandler', () => {
 	} );
 
 	describe( '#returnMovedElement()', () => {
+		it( 'should not throw if map does not contain requested element', () => {
+			expect( abstractHandler._placeholderMap.has( 'menu-bar' ) ).to.be.false;
+			expect( () => abstractHandler.returnMovedElement( 'menu-bar' ) ).to.not.throw();
+		} );
+
 		it( 'should return only target moved element', () => {
 			const element = global.document.createElement( 'div' );
 			const element2 = global.document.createElement( 'div' );
@@ -84,8 +88,7 @@ describe( 'AbstractHandler', () => {
 			// Move `menu-bar` back.
 			abstractHandler.returnMovedElement( 'menu-bar' );
 
-			expect( abstractHandler._idToPlaceholder.size ).to.equal( 1 );
-			expect( abstractHandler._placeholderToElement.size ).to.equal( 1 );
+			expect( abstractHandler._placeholderMap.size ).to.equal( 1 );
 			expect( global.document.querySelector( '[data-ck-fullscreen-placeholder="menu-bar"' ) ).to.be.null;
 			expect( global.document.querySelector( '[data-ck-fullscreen-placeholder="editable"' ) ).to.not.be.null;
 
@@ -184,18 +187,16 @@ describe( 'AbstractHandler', () => {
 			abstractHandler.moveToFullscreen( element2, 'editable' );
 
 			expect(
-				abstractHandler._placeholderToElement.has( global.document.querySelector( '[data-ck-fullscreen-placeholder="menu-bar"' ) )
+				abstractHandler._placeholderMap.has( 'menu-bar' )
 			).to.be.true;
 			expect(
-				abstractHandler._placeholderToElement.has( global.document.querySelector( '[data-ck-fullscreen-placeholder="editable"' ) )
+				abstractHandler._placeholderMap.has( 'editable' )
 			).to.be.true;
-			expect( abstractHandler._idToPlaceholder.size ).to.equal( 2 );
-			expect( abstractHandler._placeholderToElement.size ).to.equal( 2 );
+			expect( abstractHandler._placeholderMap.size ).to.equal( 2 );
 
 			abstractHandler.disable();
 
-			expect( abstractHandler._idToPlaceholder.size ).to.equal( 0 );
-			expect( abstractHandler._placeholderToElement.size ).to.equal( 0 );
+			expect( abstractHandler._placeholderMap.size ).to.equal( 0 );
 			expect( global.document.querySelector( '[data-ck-fullscreen-placeholder="menu-bar"' ) ).to.be.null;
 			expect( global.document.querySelector( '[data-ck-fullscreen-placeholder="editable"' ) ).to.be.null;
 

--- a/packages/ckeditor5-fullscreen/tests/handlers/decouplededitor.js
+++ b/packages/ckeditor5-fullscreen/tests/handlers/decouplededitor.js
@@ -9,6 +9,7 @@ import { DecoupledEditor } from '@ckeditor/ckeditor5-editor-decoupled';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global.js';
 
 import DecoupledEditorHandler from '../../src/handlers/decouplededitor.js';
+import RevisionHistoryMock from '../_utils/revisionhistorymock.js';
 
 describe( 'DecoupledEditorHandler', () => {
 	let decoupledEditorHandler, domElement, editor;
@@ -21,14 +22,19 @@ describe( 'DecoupledEditorHandler', () => {
 			plugins: [
 				Paragraph,
 				Essentials
-			]
+			],
+			fullscreen: {
+				menuBar: {
+					isVisible: true
+				}
+			}
 		} );
 
 		decoupledEditorHandler = new DecoupledEditorHandler( editor );
 	} );
 
 	afterEach( () => {
-		decoupledEditorHandler.getContainer().remove();
+		decoupledEditorHandler.disable();
 		domElement.remove();
 
 		return editor.destroy();
@@ -36,15 +42,7 @@ describe( 'DecoupledEditorHandler', () => {
 
 	describe( 'constructor', () => {
 		it( 'should set the editor instance as a property', () => {
-			expect( decoupledEditorHandler._editor ).to.equal( editor );
-		} );
-
-		it( 'should setup listener disabling fullscreen when editor is destroyed', async () => {
-			const spy = sinon.spy( decoupledEditorHandler, 'disable' );
-
-			await editor.destroy();
-
-			expect( spy ).to.have.been.calledOnce;
+			expect( decoupledEditorHandler._editor ).to.be.instanceOf( DecoupledEditor );
 		} );
 	} );
 
@@ -52,7 +50,7 @@ describe( 'DecoupledEditorHandler', () => {
 		it( 'should move the editable, toolbar and menu bar to the fullscreen container', () => {
 			decoupledEditorHandler.enable();
 
-			expect( decoupledEditorHandler.getContainer().querySelector( '[data-ck-fullscreen=editor]' ).children[ 0 ] )
+			expect( decoupledEditorHandler.getContainer().querySelector( '[data-ck-fullscreen=editable]' ).children[ 0 ] )
 				.to.equal( editor.editing.view.getDomRoot() );
 			expect( decoupledEditorHandler.getContainer().querySelector( '[data-ck-fullscreen=toolbar]' ).children[ 0 ] )
 				.to.equal( editor.ui.view.toolbar.element );
@@ -65,6 +63,63 @@ describe( 'DecoupledEditorHandler', () => {
 		it( 'should call #returnMovedElements()', () => {
 			const spy = sinon.spy( decoupledEditorHandler, 'returnMovedElements' );
 
+			decoupledEditorHandler.disable();
+
+			expect( spy ).to.have.been.calledOnce;
+		} );
+	} );
+
+	describe( 'with Revision history plugin', () => {
+		let domElementForRevisionHistory, editorWithRevisionHistory;
+
+		beforeEach( async () => {
+			domElementForRevisionHistory = global.document.createElement( 'div' );
+			global.document.body.appendChild( domElementForRevisionHistory );
+
+			editorWithRevisionHistory = await DecoupledEditor.create( domElementForRevisionHistory, {
+				plugins: [
+					Paragraph,
+					Essentials,
+					RevisionHistoryMock
+				]
+			} );
+
+			decoupledEditorHandler = new DecoupledEditorHandler( editorWithRevisionHistory );
+		} );
+
+		afterEach( async () => {
+			decoupledEditorHandler.disable();
+			domElementForRevisionHistory.remove();
+
+			return editorWithRevisionHistory.destroy();
+		} );
+
+		it( 'should override default RH callbacks when fullscreen mode is enabled', () => {
+			const spy = sinon.spy( decoupledEditorHandler, '_overrideRevisionHistoryCallbacks' );
+
+			expect( editorWithRevisionHistory.config.get( 'revisionHistory.showRevisionViewerCallback' ) ).to.equal(
+				RevisionHistoryMock.showRevisionViewerCallback
+			);
+			expect( editorWithRevisionHistory.config.get( 'revisionHistory.showRevisionViewerCallback' ) ).to.equal(
+				RevisionHistoryMock.showRevisionViewerCallback
+			);
+
+			decoupledEditorHandler.enable();
+
+			expect( editorWithRevisionHistory.config.get( 'revisionHistory.closeRevisionViewerCallback' ) ).to.not.equal(
+				RevisionHistoryMock.closeRevisionViewerCallback
+			);
+			expect( editorWithRevisionHistory.config.get( 'revisionHistory.closeRevisionViewerCallback' ) ).to.not.equal(
+				RevisionHistoryMock.closeRevisionViewerCallback
+			);
+
+			expect( spy ).to.have.been.calledOnce;
+		} );
+
+		it( 'should restore default RH callbacks when fullscreen mode is disabled', () => {
+			const spy = sinon.spy( decoupledEditorHandler, '_restoreRevisionHistoryCallbacks' );
+
+			decoupledEditorHandler.enable();
 			decoupledEditorHandler.disable();
 
 			expect( spy ).to.have.been.calledOnce;

--- a/packages/ckeditor5-fullscreen/theme/fullscreen.css
+++ b/packages/ckeditor5-fullscreen/theme/fullscreen.css
@@ -19,15 +19,15 @@ Fullscreen layout:
 		<div class="ck ck-fullscreen__menu-bar" data-ck-fullscreen="menu-bar"></div>
 		<div class="ck ck-fullscreen__toolbar" data-ck-fullscreen="toolbar"></div>
 	</div>
-	<div class="ck ck-fullscreen__editor-wrapper">
+	<div class="ck ck-fullscreen__editable-wrapper">
 		<div class="ck ck-fullscreen__sidebar" data-ck-fullscreen="left-sidebar"></div>
-		<div class="ck ck-fullscreen__editor" data-ck-fullscreen="editor"></div>
+		<div class="ck ck-fullscreen__editable" data-ck-fullscreen="editable"></div>
 		<div class="ck ck-fullscreen__sidebar" data-ck-fullscreen="right-sidebar"></div>
 	</div>
 </div>
 */
 
-.ck-fullscreen__main-container {
+.ck.ck-fullscreen__main-container {
 	position: fixed;
 	top: 0;
 	left: 0;
@@ -37,13 +37,18 @@ Fullscreen layout:
 	background: var(--ck-color-base-foreground);
 	display: flex;
 	flex-direction: column;
+
+	& .ck.ck-revision-history-ui__changes-navigation {
+		margin-top: 0px;
+		margin-bottom: 0px;
+	}
 }
 
 .ck-fullscreen__menu-bar .ck.ck-menu-bar {
 	border: none;
 }
 
-.ck-fullscreen__main-container .ck-fullscreen__editor-wrapper {
+.ck-fullscreen__main-container .ck-fullscreen__editable-wrapper {
 	display: flex;
 	justify-content: center;
 	overflow: auto;
@@ -51,7 +56,7 @@ Fullscreen layout:
 }
 
 .ck-fullscreen__main-container .ck-fullscreen__sidebar {
-	width: 270px;
+	width: 330px;
 	margin-top: 28px;
 	margin-left: 10px;
 	margin-right: 10px;
@@ -59,13 +64,13 @@ Fullscreen layout:
 	flex-shrink: 0;
 }
 
-.ck-fullscreen__main-container .ck-fullscreen__editor {
+.ck-fullscreen__main-container .ck-fullscreen__editable {
 	margin-top: 28px;
 	margin-bottom: 56px;
 	height: 100%;
 }
 
-.ck-fullscreen__main-container .ck-fullscreen__editor .ck.ck-editor__editable:not(.ck-editor__nested-editable) {
+.ck-fullscreen__main-container .ck-fullscreen__editable .ck.ck-editor__editable:not(.ck-editor__nested-editable) {
 	box-sizing: border-box;
 	min-width: calc(210mm + 2px);
 	max-width: calc(210mm + 2px);
@@ -77,6 +82,6 @@ Fullscreen layout:
 	box-shadow: 0 2px 3px hsla(0, 0%, 0%, 0.078);
 }
 
-.ck-fullscreen__main-container .ck-fullscreen__editor .ck-source-editing-area {
+.ck-fullscreen__main-container .ck-fullscreen__editable .ck-source-editing-area {
 	min-width: calc(210mm + 2px);
 }

--- a/packages/ckeditor5-ui/src/editorui/editoruiview.ts
+++ b/packages/ckeditor5-ui/src/editorui/editoruiview.ts
@@ -33,12 +33,21 @@ export default abstract class EditorUIView extends View {
 	public abstract get editable(): EditableUIView;
 
 	/**
-	 * Menu bar view instance. May not be initialized in some editor types.
+	 * Menu bar view instance. Initialized by default in:
+	 *
+	 * * balloon editor;
+	 * * decoupled editor;
+	 * * multiroot editor.
 	 */
 	public menuBarView?: MenuBarView;
 
 	/**
-	 * Toolbar view instance. May not be initialized in some editor types.
+	 * Toolbar view instance. Initialized by default in:
+	 *
+	 * * classic editor;
+	 * * decoupled editor;
+	 * * inline editor;
+	 * * multiroot editor.
 	 */
 	public toolbar?: ToolbarView;
 

--- a/packages/ckeditor5-ui/src/editorui/editoruiview.ts
+++ b/packages/ckeditor5-ui/src/editorui/editoruiview.ts
@@ -15,6 +15,7 @@ import type { Locale, LocaleTranslate } from '@ckeditor/ckeditor5-utils';
 
 import '../../theme/components/editorui/editorui.css';
 import type MenuBarView from '../menubar/menubarview.js';
+import type ToolbarView from '../toolbar/toolbarview.js';
 
 /**
  * The editor UI view class. Base class for the editor main views.
@@ -35,6 +36,11 @@ export default abstract class EditorUIView extends View {
 	 * Menu bar view instance. May not be initialized in some editor types.
 	 */
 	public menuBarView?: MenuBarView;
+
+	/**
+	 * Toolbar view instance. May not be initialized in some editor types.
+	 */
+	public toolbar?: ToolbarView;
 
 	/**
 	 * Creates an instance of the editor UI view class.

--- a/packages/ckeditor5-ui/src/menubar/menubarview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarview.ts
@@ -171,6 +171,24 @@ export default class MenuBarView extends View implements FocusableView {
 	}
 
 	/**
+	 * Disables all menus in the bar.
+	 */
+	public disable(): void {
+		for ( const topLevelCategoryMenuView of this.children ) {
+			topLevelCategoryMenuView.isEnabled = false;
+		}
+	}
+
+	/**
+	 * Enables all menus in the bar.
+	 */
+	public enable(): void {
+		for ( const topLevelCategoryMenuView of this.children ) {
+			topLevelCategoryMenuView.isEnabled = true;
+		}
+	}
+
+	/**
 	 * Registers a menu view in the menu bar. Every {@link module:ui/menubar/menubarmenuview~MenuBarMenuView} instance must be registered
 	 * in the menu bar to be properly managed.
 	 */

--- a/packages/ckeditor5-ui/src/menubar/utils.ts
+++ b/packages/ckeditor5-ui/src/menubar/utils.ts
@@ -210,7 +210,7 @@ export const MenuBarMenuBehaviors = {
 	 */
 	openAndFocusPanelOnArrowDownKey( menuView: MenuBarMenuView ): void {
 		menuView.keystrokes.set( 'arrowdown', ( data, cancel ) => {
-			if ( menuView.focusTracker.focusedElement === menuView.buttonView.element ) {
+			if ( menuView.isEnabled && menuView.focusTracker.focusedElement === menuView.buttonView.element ) {
 				if ( !menuView.isOpen ) {
 					menuView.isOpen = true;
 				}

--- a/packages/ckeditor5-ui/tests/editorui/editorui.js
+++ b/packages/ckeditor5-ui/tests/editorui/editorui.js
@@ -861,7 +861,7 @@ describe( 'EditorUI', () => {
 
 					ui.addToolbar( visibleToolbarA );
 					ui.addToolbar( visibleToolbarB );
-					ui._initMenuBar( visibleMenuBar );
+					ui.initMenuBar( visibleMenuBar );
 
 					editingAreaA = document.createElement( 'div' );
 					editingAreaB = document.createElement( 'div' );
@@ -1226,7 +1226,7 @@ describe( 'EditorUI', () => {
 				init() {
 					super.init();
 
-					this._initMenuBar( this.view.menuBarView );
+					this.initMenuBar( this.view.menuBarView );
 				}
 			}
 

--- a/packages/ckeditor5-ui/tests/menubar/menubarview.js
+++ b/packages/ckeditor5-ui/tests/menubar/menubarview.js
@@ -2204,6 +2204,89 @@ describe( 'MenuBarView', () => {
 		} );
 	} );
 
+	describe( 'disable()', () => {
+		it( 'should disable all top-level sub-menus', () => {
+			menuBarView.fillFromConfig( normalizeMenuBarConfig( {
+				items: [
+					{
+						menuId: 'edit',
+						label: 'Edit',
+						groups: [
+							{
+								groupId: '1',
+								items: [
+									'item1'
+								]
+							}
+						]
+					},
+					{
+						menuId: 'format',
+						label: 'Format',
+						groups: [
+							{
+								groupId: '1',
+								items: [
+									'item1'
+								]
+							}
+						]
+					}
+				]
+			} ), factory );
+
+			menuBarView.render();
+
+			getMenuByLabel( menuBarView, 'Edit' ).isOpen = true;
+
+			menuBarView.disable();
+
+			expect( getMenuByLabel( menuBarView, 'Edit' ).isEnabled ).to.be.false;
+			expect( getMenuByLabel( menuBarView, 'Format' ).isEnabled ).to.be.false;
+		} );
+	} );
+
+	describe( 'enable()', () => {
+		it( 'should enable all top-level sub-menus', () => {
+			menuBarView.fillFromConfig( normalizeMenuBarConfig( {
+				items: [
+					{
+						menuId: 'edit',
+						label: 'Edit',
+						groups: [
+							{
+								groupId: '1',
+								items: [
+									'item1'
+								]
+							}
+						]
+					},
+					{
+						menuId: 'format',
+						label: 'Format',
+						groups: [
+							{
+								groupId: '1',
+								items: [
+									'item1'
+								]
+							}
+						]
+					}
+				]
+			} ), factory );
+
+			menuBarView.render();
+
+			menuBarView.disable();
+			menuBarView.enable();
+
+			expect( getMenuByLabel( menuBarView, 'Edit' ).isEnabled ).to.be.true;
+			expect( getMenuByLabel( menuBarView, 'Format' ).isEnabled ).to.be.true;
+		} );
+	} );
+
 	describe( 'registerMenu()', () => {
 		it( 'should set all properties and add the menu to the list of known menus', () => {
 			const menuViewA = new MenuBarMenuView( locale );

--- a/packages/ckeditor5-ui/tests/menubar/utils.js
+++ b/packages/ckeditor5-ui/tests/menubar/utils.js
@@ -1062,6 +1062,30 @@ describe( 'MenuBarView utils', () => {
 						]
 					);
 				} );
+
+				it( 'should do nothing on arrow down key if menu is disabled', () => {
+					const menuA = getMenuByLabel( menuBarView, 'A' );
+					const keyEvtData = {
+						keyCode: keyCodes.arrowdown,
+						preventDefault: sinon.spy(),
+						stopPropagation: sinon.spy()
+					};
+
+					menuA.isEnabled = false;
+
+					menuA.buttonView.focus();
+					menuA.keystrokes.press( keyEvtData );
+
+					expect( barDump( menuBarView ) ).to.deep.equal(
+						[
+							{
+								label: 'A', isOpen: false, isFocused: true,
+								items: []
+							}
+
+						]
+					);
+				} );
 			} );
 
 			describe( 'toggleOnButtonClick()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (fullscreen): Add integration with revision history.

Fix (ui): Do not open disabled menu bar menu on arrow down press. Closes https://github.com/ckeditor/ckeditor5/issues/17915.

Feature (ui): Add `MenuBarView#disable()` and `MenuBarView#enable()` methods. They disable/enable all top-level menus in menu bar. Closes https://github.com/ckeditor/ckeditor5/issues/17940.

Internal (ui): Add a `toolbar` property to the `EditorUIView` class for coherent access for all editor types.

Internal (ui): Make `EditorUI#_initMenuBar()` method public and rename it accordingly to allow for runtime toolbar creation.

---

### Additional information

* Requires `ck/fullscreen-revision-history` in the related repository (one of the used types needs to be exported).
* Disabling menu bar was supposed to be done through a flag. However looking at API I proposed to use `disable()` and `enable()` methods instead as it will be simpler and more coherent with the rest of the component code.
* Following the idea to have as little code in separate editor handlers (https://github.com/ckeditor/ckeditor5/pull/17897#discussion_r1952523571), most of the RH integration was put in the `AbstractEditorHandler` class. It should be treated as a go-to class, not the one that only throws errors for unsupported editor types.
* I added a `RevisionHistoryMock` class in unit tests providing as much integration as I found useful. It's arbitrary and I'm open for suggestions.
* `EditorUIView#toolbar` was introduced to make the editor types UIs more coherent and better accessible. Without it here we'd have to use `as` keyword to narrow the editor types used in `AbstractEditorHandler`.
* As discussed, for now the CC for revision history integration implementation details is skipped. We're waiting for some decisions regarding how to approach the problem of testing premium features integration in the public repo.