### PR TITLE
Avoid defining fallback for crypto when building snippets

### DIFF
--- a/scripts/docs/snippetadapter.mjs
+++ b/scripts/docs/snippetadapter.mjs
@@ -478,6 +478,9 @@ function getWebpackConfig( snippets, config ) {
 			extensions: [ '.ts', '.js', '.json' ],
 			extensionAlias: {
 				'.js': [ '.js', '.ts' ]
+			},
+			fallback: {
+				crypto: false
 			}
 		},
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Avoid defining fallback for crypto when building snippets. Closes #17991.
