### PR TITLE
Export `SchemaContext` from engine package.

### DIFF
--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -93,7 +93,6 @@ export { default as DocumentFragment } from './model/documentfragment.js';
 export { default as History } from './model/history.js';
 export { default as Text } from './model/text.js';
 export { default as TextProxy } from './model/textproxy.js';
-export { SchemaContext } from './model/schema.js';
 export type { default as Document, ModelPostFixer } from './model/document.js';
 export type { Marker } from './model/markercollection.js';
 export type { default as Batch } from './model/batch.js';
@@ -101,14 +100,15 @@ export type { default as Differ, DiffItem, DiffItemAttribute, DiffItemInsert, Di
 export type { default as Item } from './model/item.js';
 export type { default as Node, NodeAttributes } from './model/node.js';
 export type { default as RootElement } from './model/rootelement.js';
-export type {
-	default as Schema,
-	SchemaAttributeCheckCallback,
-	SchemaChildCheckCallback,
-	AttributeProperties,
-	SchemaItemDefinition,
-	SchemaCompiledItemDefinition,
-	SchemaContextDefinition
+export {
+	SchemaContext,
+	type default as Schema,
+	type SchemaAttributeCheckCallback,
+	type SchemaChildCheckCallback,
+	type AttributeProperties,
+	type SchemaItemDefinition,
+	type SchemaCompiledItemDefinition,
+	type SchemaContextDefinition
 } from './model/schema.js';
 export type { default as Selection, Selectable } from './model/selection.js';
 export type { default as TypeCheckable } from './model/typecheckable.js';

--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -93,6 +93,7 @@ export { default as DocumentFragment } from './model/documentfragment.js';
 export { default as History } from './model/history.js';
 export { default as Text } from './model/text.js';
 export { default as TextProxy } from './model/textproxy.js';
+export { SchemaContext } from './model/schema.js';
 export type { default as Document, ModelPostFixer } from './model/document.js';
 export type { Marker } from './model/markercollection.js';
 export type { default as Batch } from './model/batch.js';
@@ -107,7 +108,6 @@ export type {
 	AttributeProperties,
 	SchemaItemDefinition,
 	SchemaCompiledItemDefinition,
-	SchemaContext,
 	SchemaContextDefinition
 } from './model/schema.js';
 export type { default as Selection, Selectable } from './model/selection.js';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (engine): Export `SchemaContext` class from package. Closes https://github.com/ckeditor/ckeditor5/issues/18003