### PR TITLE
Add text overflow ellipsis to link providers form header and items.

### DIFF
--- a/packages/ckeditor5-link/tests/manual/linkproviders.js
+++ b/packages/ckeditor5-link/tests/manual/linkproviders.js
@@ -28,7 +28,7 @@ const createPredefinedLinksProvider = provider => class MyLinkProvider extends P
 };
 
 const SocialLinksPlugin = createPredefinedLinksProvider( {
-	label: '🌐 Social links',
+	label: '🌐 Social links 🌐 Social links 🌐 Social links 🌐 Social links 🌐 Social links',
 	getListItems: () => [
 		{
 			id: 'facebook',

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkform.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkform.css
@@ -52,7 +52,6 @@
 			& > .ck-button__label {
 				overflow: hidden;
 				text-overflow: ellipsis;
-				white-space: nowrap;
 			}
 		}
 	}

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkform.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkform.css
@@ -48,6 +48,12 @@
 		& .ck-link__button {
 			padding: var(--ck-spacing-small) var(--ck-spacing-large);
 			border-radius: 0;
+
+			& > .ck-button__label {
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
 		}
 	}
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkprovideritems.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkprovideritems.css
@@ -20,6 +20,12 @@
 .ck.ck-link-providers {
 	width: var(--ck-link-providers-width);
 
+	& .ck-form__header__label {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
 	& > .ck-link-providers__list {
 		max-height: min( var(--ck-link-list-view-max-height), 40vh );
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkprovideritems.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkprovideritems.css
@@ -37,6 +37,7 @@
 			& > .ck-button__label {
 				overflow: hidden;
 				text-overflow: ellipsis;
+				white-space: nowrap;
 			}
 		}
 	}

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkprovideritems.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkprovideritems.css
@@ -23,7 +23,6 @@
 	& .ck-form__header__label {
 		overflow: hidden;
 		text-overflow: ellipsis;
-		white-space: nowrap;
 	}
 
 	& > .ck-link-providers__list {
@@ -38,7 +37,6 @@
 			& > .ck-button__label {
 				overflow: hidden;
 				text-overflow: ellipsis;
-				white-space: nowrap;
 			}
 		}
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (link): Add text overflow ellipsis to link providers form header and items. Closes https://github.com/ckeditor/ckeditor5/issues/18018

---

### Additional information

**Before**

![obraz](https://github.com/user-attachments/assets/47e46ee8-1495-4968-be36-8f213265a5ec)
![obraz](https://github.com/user-attachments/assets/34a802d3-4255-4482-a992-895114176ac4)

**After**

![obraz](https://github.com/user-attachments/assets/bd02980f-5408-4d01-9180-e10cb8d610e5)
![obraz](https://github.com/user-attachments/assets/608cf4f1-5396-4bb2-b103-bfd892f35505)
