### PR TITLE
Added additional logging for the Emoji Plugin when the emoji font is not installed on the OS.

### DIFF
--- a/packages/ckeditor5-emoji/docs/features/emoji.md
+++ b/packages/ckeditor5-emoji/docs/features/emoji.md
@@ -169,7 +169,7 @@ The {@link module:emoji/emojipicker~EmojiPicker} plugin registers the UI button 
 
 ## Troubleshooting
 
-If you're experiencing issues with the Emoji plugin in CKEditor 5 and the `emoji-repository-load-failed` is displayed in the console, it may be due to missing system support for emoji fonts or problems loading the emoji repository. Below are some common issues and their solutions.
+If you're experiencing issues with the Emoji plugin in CKEditor 5 and the `emoji-repository-empty` is displayed in the console, it may be due to missing system support for emoji fonts or problems loading the emoji repository. Below are some common issues and their solutions.
 
 #### 1. No Emoji Font Installed
 

--- a/packages/ckeditor5-emoji/docs/features/emoji.md
+++ b/packages/ckeditor5-emoji/docs/features/emoji.md
@@ -167,6 +167,49 @@ The {@link module:emoji/emojipicker~EmojiPicker} plugin registers the UI button 
 	We recommend using the official {@link framework/development-tools/inspector CKEditor&nbsp;5 inspector} for development and debugging. It will give you tons of useful information about the state of the editor, such as internal data structures, selection, commands, and many more.
 </info-box>
 
+## Troubleshooting
+
+If you're experiencing issues with the Emoji plugin in CKEditor 5 and the `emoji-repository-load-failed` is displayed in the console, it may be due to missing system support for emoji fonts or problems loading the emoji repository. Below are some common issues and their solutions.
+
+#### 1. No Emoji Font Installed
+
+**Problem**:
+The system does not have an emoji font installed, preventing the Emoji plugin from rendering emojis correctly.
+
+**Solution**:
+To use the Emoji plugin, install an emoji font on your operating system:
+
+* macOS: `Apple Color Emoji`
+* Windows: `Segoe UI Emoji`
+* Linux: `Noto Color Emoji` (or an alternative like `Twemoji`)
+
+Once installed, restart your browser and reload the editor.
+
+#### 2. Server Error When Loading the Emoji Repository
+
+**Problem**:
+The request to load the emoji repository was completed, but the server returned an error (e.g., 404 Not Found, 500 Internal Server Error).
+
+**Solution**:
+
+* Ensure the emoji repository URL is correct and accessible.
+* If using a custom emoji repository, verify that it is properly configured.
+
+#### 3. Network Issues Preventing the Emoji Repository from Loading
+
+**Problem**:
+The emoji repository could not be loaded due to a network issue, CORS restriction, or blocked request.
+
+**Solution**:
+
+* Verify that the URL is correct and accessible.
+* Check your internet connection.
+* If applicable, update your Content Security Policy (CSP) settings to allow connections to the emoji repository.
+
+For more details on configuring CSP, see the {@link getting-started/setup/csp Content Security Policy guide.}
+
+By following these steps, you should be able to resolve common issues with the Emoji plugin in CKEditor 5. If problems persist, check your browser console for additional error messages or consult the CKEditor 5 [GitHub repository for support](https://github.com/ckeditor/ckeditor5/issues).
+
 ## Contribute
 
 The source code of the feature is available at GitHub in [https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-emoji](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-emoji).

--- a/packages/ckeditor5-emoji/docs/features/emoji.md
+++ b/packages/ckeditor5-emoji/docs/features/emoji.md
@@ -204,7 +204,7 @@ To use the Emoji plugin, install an emoji font on your operating system:
 
 Once installed, restart your browser and reload the editor.
 
-#### 2. Server Error When Loading the Emoji Repository
+#### Server error when loading the emoji repository
 
 **Problem**:
 The request to load the emoji repository was completed, but the server returned an error (e.g., 404 Not Found, 500 Internal Server Error).

--- a/packages/ckeditor5-emoji/docs/features/emoji.md
+++ b/packages/ckeditor5-emoji/docs/features/emoji.md
@@ -27,10 +27,6 @@ The selected emoji category and skin tone are remembered by the feature, so next
 	This demo presents a limited set of features. Visit the {@link examples/builds/full-featured-editor feature-rich editor example} to see more in action.
 </info-box>
 
-<info-box warning>
-	The availability of the emojis and their appearance depends on the operating system. If you want to standardize both the appearance and availability of emojis, please consider using an external font in your integration, such as [Noto Color Emoji](https://fonts.google.com/noto/specimen/Noto+Color+Emoji).
-</info-box>
-
 ## Installation
 
 <info-box info>
@@ -133,6 +129,29 @@ The feature can be configured via the {@link module:emoji/emojiconfig~EmojiConfi
 		.then( /* ... */ )
 		.catch( /* ... */ );
 	```
+
+### Emoji's availability and appearance
+
+The availability of the emoji depends on the operating system. Different systems will have different Unicode support. You can decide that you want to lower the amount of newer emoji by setting a lower version of Unicode of the emoji repository (CKEditor hosts v15 and v16). This way the users with newer systems will not be able to use newer emoji. Keep in mind that this only affects the editor's feature. A user will still be able to use the native emoji insertion methods. The availability may also increase with the usage of a custom font. To learn more, read the next paragraph.
+
+If you want to standardize the appearance emojis accross operating systems, please consider using an external font in your integration, such as [Noto Color Emoji](https://fonts.google.com/noto/specimen/Noto+Color+Emoji). In the setup make sure to:
+
+1. Set in the `font-family` for the content, this way the emoji in the editable will use the custom font. For example:
+
+    ```css
+    body {
+    	font-family: 'Lato', 'Noto Color Emoji', sans-serif;
+    }
+    ```
+
+2. Update the `--ck-font-face` variable, so that emoji in the picker and mention use the custom font.
+
+    ```css
+    :root {
+        --ck-font-face: Helvetica, Arial, Tahoma, Verdana, 'Noto Color Emoji';
+    }
+    ```
+
 
 ### Emoji source
 

--- a/packages/ckeditor5-emoji/docs/features/emoji.md
+++ b/packages/ckeditor5-emoji/docs/features/emoji.md
@@ -130,6 +130,20 @@ The feature can be configured via the {@link module:emoji/emojiconfig~EmojiConfi
 		.catch( /* ... */ );
 	```
 
+* `useCustomFont` &ndash; if you customize the {@link features/emoji#emoji-availability-and-appearance emoji availability and appearance}. It that case, it is highly recommended to disable the filtering mechanism because it uses a font built-in to your system.
+
+	```js
+	ClassicEditor
+		.create( document.querySelector( '#editor' ), {
+			// ... Other configuration options ...
+			emoji: {
+				useCustomFont: true
+			}
+		} )
+		.then( /* ... */ )
+		.catch( /* ... */ );
+	```
+
 ### Emoji availability and appearance
 
 The availability of the emoji depends on the operating system. Different systems will have different Unicode support. You can decide that you want to lower the number of newer emoji by setting a lower version of Unicode of the emoji repository (CKEditor&nbsp;5 hosts v15 and v16). This way the users with newer systems will not be able to use newer emoji. Keep in mind that this only affects the editor feature. A user will still be able to use the native emoji insertion methods. The availability may also increase with the usage of a custom font.
@@ -149,6 +163,17 @@ If you want to standardize the appearance of emoji accross operating systems, pl
 	```css
 	:root {
 		--ck-font-face: Helvetica, Arial, Tahoma, Verdana, 'Noto Color Emoji';
+	}
+	```
+	
+3. Update the {@link module:core/editor/editorconfig~EditorConfig editor configuration} by adding the {@link module:emoji/emojiconfig~EmojiConfig#useCustomFont `emoji.useCustomFont`} option.
+
+	```js
+	{
+		// ... Other configuration options ...
+		emoji: {
+			useCustomFont: true
+		}
 	}
 	```
 

--- a/packages/ckeditor5-emoji/docs/features/emoji.md
+++ b/packages/ckeditor5-emoji/docs/features/emoji.md
@@ -214,7 +214,7 @@ The request to load the emoji repository was completed, but the server returned 
 * Ensure the emoji repository URL is correct and accessible.
 * If using a custom emoji repository, verify that it is properly configured.
 
-#### 3. Network Issues Preventing the Emoji Repository from Loading
+#### Network issues preventing the emoji repository from loading
 
 **Problem**:
 The emoji repository could not be loaded due to a network issue, CORS restriction, or blocked request.

--- a/packages/ckeditor5-emoji/docs/features/emoji.md
+++ b/packages/ckeditor5-emoji/docs/features/emoji.md
@@ -130,28 +130,27 @@ The feature can be configured via the {@link module:emoji/emojiconfig~EmojiConfi
 		.catch( /* ... */ );
 	```
 
-### Emoji's availability and appearance
+### Emoji availability and appearance
 
-The availability of the emoji depends on the operating system. Different systems will have different Unicode support. You can decide that you want to lower the amount of newer emoji by setting a lower version of Unicode of the emoji repository (CKEditor hosts v15 and v16). This way the users with newer systems will not be able to use newer emoji. Keep in mind that this only affects the editor's feature. A user will still be able to use the native emoji insertion methods. The availability may also increase with the usage of a custom font. To learn more, read the next paragraph.
+The availability of the emoji depends on the operating system. Different systems will have different Unicode support. You can decide that you want to lower the number of newer emoji by setting a lower version of Unicode of the emoji repository (CKEditor&nbsp;5 hosts v15 and v16). This way the users with newer systems will not be able to use newer emoji. Keep in mind that this only affects the editor feature. A user will still be able to use the native emoji insertion methods. The availability may also increase with the usage of a custom font.
 
-If you want to standardize the appearance emojis accross operating systems, please consider using an external font in your integration, such as [Noto Color Emoji](https://fonts.google.com/noto/specimen/Noto+Color+Emoji). In the setup make sure to:
+If you want to standardize the appearance of emoji accross operating systems, please consider using an external font in your integration, such as [Noto Color Emoji](https://fonts.google.com/noto/specimen/Noto+Color+Emoji). In the setup make sure to:
 
-1. Set in the `font-family` for the content, this way the emoji in the editable will use the custom font. For example:
+1. Set the `font-family` for the content, this way the emoji in the editable will use the custom font. For example:
 
-    ```css
-    body {
-    	font-family: 'Lato', 'Noto Color Emoji', sans-serif;
-    }
-    ```
+	```css
+	body {
+		font-family: 'Lato', 'Noto Color Emoji', sans-serif;
+	}
+	```
 
-2. Update the `--ck-font-face` variable, so that emoji in the picker and mention use the custom font.
+2. Update the `--ck-font-face` variable, so that emoji in the picker and mention will use the custom font.
 
-    ```css
-    :root {
-        --ck-font-face: Helvetica, Arial, Tahoma, Verdana, 'Noto Color Emoji';
-    }
-    ```
-
+	```css
+	:root {
+		--ck-font-face: Helvetica, Arial, Tahoma, Verdana, 'Noto Color Emoji';
+	}
+	```
 
 ### Emoji source
 
@@ -171,6 +170,49 @@ The Emoji feature uses the `:` marker that opens a panel with a table of selecta
 
 To prevent conflicts, make sure that the {@link module:mention/mentionconfig~MentionFeed#marker mention's `marker`} and {@link module:merge-fields/mergefieldsconfig~MergeFieldsConfig#prefix merge field's `prefix`} configuration options are not defined as `:`.
 
+## Troubleshooting
+
+If you are experiencing issues with the emoji feature in CKEditor&nbsp;5 and the `emoji-repository-empty` is displayed in the console, it may be due to missing system support for emoji fonts or problems loading the emoji repository. Below are some common issues and their solutions.
+
+### No emoji font installed
+
+**Problem**:
+The system does not have an emoji font installed, preventing the emoji feature from rendering emoji correctly.
+
+**Solution**:
+To use the emoji feature, install an emoji font on your operating system:
+
+* macOS: `Apple Color Emoji`
+* Windows: `Segoe UI Emoji`
+* Linux: `Noto Color Emoji` (or an alternative like `Twemoji`)
+
+Once installed, restart your browser and reload the editor.
+
+### Server error when loading the emoji repository
+
+**Problem**:
+The request to load the emoji repository was completed, but the server returned an error (such as `404 Not Found`, or `500 Internal Server Error`).
+
+**Solution**:
+
+* Ensure the emoji repository URL is correct and accessible.
+* If using a custom emoji repository, verify that it is properly configured.
+
+### Network issues preventing the emoji repository from loading
+
+**Problem**:
+The emoji repository could not be loaded due to a network issue, CORS restriction, or blocked request.
+
+**Solution**:
+
+* Verify that the URL is correct and accessible.
+* Check your internet connection.
+* If applicable, update your Content Security Policy (CSP) settings to allow connections to the emoji repository.
+
+For more details on configuring CSP, see the {@link getting-started/setup/csp Content Security Policy} guide.
+
+By following these steps, you should be able to resolve common issues with the Emoji plugin in CKEditor&nbsp;5. If problems persist, check your browser console for additional error messages or consult the CKEditor 5 [GitHub repository for support](https://github.com/ckeditor/ckeditor5/issues).
+
 ## Related features
 
 In addition to enabling the Emoji feature, you may want to check the following related features:
@@ -185,49 +227,6 @@ The {@link module:emoji/emojipicker~EmojiPicker} plugin registers the UI button 
 <info-box>
 	We recommend using the official {@link framework/development-tools/inspector CKEditor&nbsp;5 inspector} for development and debugging. It will give you tons of useful information about the state of the editor, such as internal data structures, selection, commands, and many more.
 </info-box>
-
-## Troubleshooting
-
-If you're experiencing issues with the Emoji plugin in CKEditor 5 and the `emoji-repository-empty` is displayed in the console, it may be due to missing system support for emoji fonts or problems loading the emoji repository. Below are some common issues and their solutions.
-
-#### No emoji font installed
-
-**Problem**:
-The system does not have an emoji font installed, preventing the Emoji plugin from rendering emojis correctly.
-
-**Solution**:
-To use the Emoji plugin, install an emoji font on your operating system:
-
-* macOS: `Apple Color Emoji`
-* Windows: `Segoe UI Emoji`
-* Linux: `Noto Color Emoji` (or an alternative like `Twemoji`)
-
-Once installed, restart your browser and reload the editor.
-
-#### Server error when loading the emoji repository
-
-**Problem**:
-The request to load the emoji repository was completed, but the server returned an error (e.g., 404 Not Found, 500 Internal Server Error).
-
-**Solution**:
-
-* Ensure the emoji repository URL is correct and accessible.
-* If using a custom emoji repository, verify that it is properly configured.
-
-#### Network issues preventing the emoji repository from loading
-
-**Problem**:
-The emoji repository could not be loaded due to a network issue, CORS restriction, or blocked request.
-
-**Solution**:
-
-* Verify that the URL is correct and accessible.
-* Check your internet connection.
-* If applicable, update your Content Security Policy (CSP) settings to allow connections to the emoji repository.
-
-For more details on configuring CSP, see the {@link getting-started/setup/csp Content Security Policy guide.}
-
-By following these steps, you should be able to resolve common issues with the Emoji plugin in CKEditor 5. If problems persist, check your browser console for additional error messages or consult the CKEditor 5 [GitHub repository for support](https://github.com/ckeditor/ckeditor5/issues).
 
 ## Contribute
 

--- a/packages/ckeditor5-emoji/docs/features/emoji.md
+++ b/packages/ckeditor5-emoji/docs/features/emoji.md
@@ -190,7 +190,7 @@ The {@link module:emoji/emojipicker~EmojiPicker} plugin registers the UI button 
 
 If you're experiencing issues with the Emoji plugin in CKEditor 5 and the `emoji-repository-empty` is displayed in the console, it may be due to missing system support for emoji fonts or problems loading the emoji repository. Below are some common issues and their solutions.
 
-#### 1. No Emoji Font Installed
+#### No emoji font installed
 
 **Problem**:
 The system does not have an emoji font installed, preventing the Emoji plugin from rendering emojis correctly.

--- a/packages/ckeditor5-emoji/src/emojiconfig.ts
+++ b/packages/ckeditor5-emoji/src/emojiconfig.ts
@@ -99,6 +99,18 @@ export interface EmojiConfig {
 	 * option is provided, `version` is ignored as the defined URL takes precedence over the `version`.
 	 */
 	version?: EmojiVersion;
+
+	/**
+	 * The availability of the emoji depends on the operating system. Different systems will have different Unicode support.
+	 *
+	 * By default, the feature tries to filter out emojis not supported by your operating system.
+	 * This means that instead of previewing an emoji, the feature renders a black square.
+	 *
+	 * If you customize the {@glink features/emoji#emoji-availability-and-appearance emoji availability and appearance}, it is
+	 * highly recommended to disable the filtering mechanism because it uses a font built into your system
+	 * instead of the provided custom font.
+	 */
+	useCustomFont?: boolean;
 }
 
 export type SkinToneId = 'default' | 'light' | 'medium-light' | 'medium' | 'medium-dark' | 'dark';

--- a/packages/ckeditor5-emoji/src/emojirepository.ts
+++ b/packages/ckeditor5-emoji/src/emojirepository.ts
@@ -102,16 +102,14 @@ export default class EmojiRepository extends Plugin {
 
 		if ( !this._items ) {
 			/**
-			 * Unable to load the emoji repository from the URL.
+			 * Unable to identify the available emoji to display
 			 *
-			 * If the URL works properly and there is no disruption of communication, please check your
-			 * {@glink getting-started/setup/csp Content Security Policy (CSP)} setting and make sure
-			 * the URL connection is allowed by the editor.
-			 * Also make sure, that proper emoji font is installed on your OS.
+			 * See the {@glink features/emoji#troubleshooting troubleshooting} section in the {@glink features/emoji Emoji feature} guide
+			 * for more details.
 			 *
-			 * @error emoji-repository-load-failed
+			 * @error emoji-repository-empty
 			 */
-			logWarning( 'emoji-repository-load-failed' );
+			logWarning( 'emoji-repository-empty' );
 
 			return this._repositoryPromiseResolveCallback( false );
 		}

--- a/packages/ckeditor5-emoji/src/emojirepository.ts
+++ b/packages/ckeditor5-emoji/src/emojirepository.ts
@@ -101,6 +101,18 @@ export default class EmojiRepository extends Plugin {
 		this._items = this._getItems();
 
 		if ( !this._items ) {
+			/**
+			 * Unable to load the emoji repository from the URL.
+			 *
+			 * If the URL works properly and there is no disruption of communication, please check your
+			 * {@glink getting-started/setup/csp Content Security Policy (CSP)} setting and make sure
+			 * the URL connection is allowed by the editor.
+			 * Also make sure, that proper emoji font is installed on your OS.
+			 *
+			 * @error emoji-repository-load-failed
+			 */
+			logWarning( 'emoji-repository-load-failed' );
+
 			return this._repositoryPromiseResolveCallback( false );
 		}
 
@@ -313,19 +325,6 @@ export default class EmojiRepository extends Plugin {
 			.catch( () => {
 				return [];
 			} );
-
-		if ( !result.length ) {
-			/**
-			 * Unable to load the emoji repository from the URL.
-			 *
-			 * If the URL works properly and there is no disruption of communication, please check your
-			 * {@glink getting-started/setup/csp Content Security Policy (CSP)} setting and make sure
-			 * the URL connection is allowed by the editor.
-			 *
-			 * @error emoji-repository-load-failed
-			 */
-			logWarning( 'emoji-repository-load-failed' );
-		}
 
 		EmojiRepository._results[ this._url.href ] = this._normalizeEmoji( result );
 	}

--- a/packages/ckeditor5-emoji/src/emojirepository.ts
+++ b/packages/ckeditor5-emoji/src/emojirepository.ts
@@ -102,7 +102,7 @@ export default class EmojiRepository extends Plugin {
 
 		if ( !this._items ) {
 			/**
-			 * Unable to identify the available emoji to display
+			 * Unable to identify the available emoji to display.
 			 *
 			 * See the {@glink features/emoji#troubleshooting troubleshooting} section in the {@glink features/emoji Emoji feature} guide
 			 * for more details.
@@ -427,3 +427,13 @@ export type SkinTone = {
 	icon: string;
 	tooltip: string;
 };
+
+/**
+ * Unable to load the emoji repository from the URL.
+ *
+ * If the URL works properly and there is no disruption of communication, please check your
+ * {@glink getting-started/setup/csp Content Security Policy (CSP)} setting and make sure
+ * the URL connection is allowed by the editor.
+ *
+ * @error emoji-repository-load-failed
+ */

--- a/packages/ckeditor5-emoji/tests/emojirepository.js
+++ b/packages/ckeditor5-emoji/tests/emojirepository.js
@@ -375,8 +375,8 @@ describe( 'EmojiRepository', () => {
 
 			expect( results ).to.deep.equal( [] );
 
-			expect( consoleStub.calledOnce ).to.equal( true );
-			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( 'emoji-repository-load-failed' );
+			expect( consoleStub.called ).to.equal( true );
+			sinon.assert.calledWith( consoleStub, 'emoji-repository-load-failed' );
 
 			domElement.remove();
 			await editor.destroy();
@@ -391,8 +391,26 @@ describe( 'EmojiRepository', () => {
 
 			expect( results ).to.deep.equal( [] );
 
-			expect( consoleStub.calledOnce ).to.equal( true );
-			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( 'emoji-repository-load-failed' );
+			expect( consoleStub.called ).to.equal( true );
+			sinon.assert.calledWith( consoleStub, 'emoji-repository-load-failed' );
+
+			domElement.remove();
+			await editor.destroy();
+		} );
+
+		it( 'should log a warning if there are no supported emojis', async () => {
+			sinon.stub( EmojiUtils, '_isEmojiSupported' ).returns( false );
+
+			const { editor, domElement } = await createTestEditor( resolve => {
+				const response = JSON.stringify( [
+					{ annotation: 'smiling face', emoji: '🙂', group: 1, version: 15 }
+				] );
+
+				resolve( new Response( response ) );
+			} );
+
+			expect( consoleStub.called ).to.equal( true );
+			sinon.assert.calledWith( consoleStub, 'emoji-repository-load-failed' );
 
 			domElement.remove();
 			await editor.destroy();
@@ -413,8 +431,8 @@ describe( 'EmojiRepository', () => {
 				}
 			} );
 
-			expect( consoleStub.calledOnce ).to.equal( true );
-			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( 'emoji-repository-redundant-version' );
+			expect( consoleStub.called ).to.equal( true );
+			sinon.assert.calledWith( consoleStub, 'emoji-repository-redundant-version' );
 
 			domElement.remove();
 			await editor.destroy();
@@ -434,8 +452,8 @@ describe( 'EmojiRepository', () => {
 				licenseKey
 			} );
 
-			expect( consoleStub.calledOnce ).to.equal( true );
-			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( 'emoji-repository-cdn-use' );
+			expect( consoleStub.called ).to.equal( true );
+			sinon.assert.calledWith( consoleStub, 'emoji-repository-cdn-use' );
 
 			domElement.remove();
 			await editor.destroy();
@@ -453,7 +471,7 @@ describe( 'EmojiRepository', () => {
 				licenseKey: 'GPL'
 			} );
 
-			expect( consoleStub.calledOnce ).to.equal( false );
+			expect( consoleStub ).to.not.have.been.calledWith( 'emoji-repository-redundant-version' );
 
 			domElement.remove();
 			await editor.destroy();
@@ -478,7 +496,7 @@ describe( 'EmojiRepository', () => {
 				licenseKey
 			} );
 
-			expect( consoleStub.calledOnce ).to.equal( false );
+			expect( consoleStub ).to.not.have.been.calledWith( 'emoji-repository-redundant-version' );
 
 			domElement.remove();
 			await editor.destroy();
@@ -502,7 +520,7 @@ describe( 'EmojiRepository', () => {
 				}
 			} );
 
-			expect( consoleStub.calledOnce ).to.equal( false );
+			expect( consoleStub ).to.not.have.been.calledWith( 'emoji-repository-redundant-version' );
 
 			domElement.remove();
 			await editor.destroy();

--- a/packages/ckeditor5-emoji/tests/emojirepository.js
+++ b/packages/ckeditor5-emoji/tests/emojirepository.js
@@ -376,7 +376,7 @@ describe( 'EmojiRepository', () => {
 			expect( results ).to.deep.equal( [] );
 
 			expect( consoleStub.called ).to.equal( true );
-			sinon.assert.calledWith( consoleStub, 'emoji-repository-load-failed' );
+			sinon.assert.calledWith( consoleStub, 'emoji-repository-empty' );
 
 			domElement.remove();
 			await editor.destroy();
@@ -392,7 +392,7 @@ describe( 'EmojiRepository', () => {
 			expect( results ).to.deep.equal( [] );
 
 			expect( consoleStub.called ).to.equal( true );
-			sinon.assert.calledWith( consoleStub, 'emoji-repository-load-failed' );
+			sinon.assert.calledWith( consoleStub, 'emoji-repository-empty' );
 
 			domElement.remove();
 			await editor.destroy();
@@ -410,7 +410,7 @@ describe( 'EmojiRepository', () => {
 			} );
 
 			expect( consoleStub.called ).to.equal( true );
-			sinon.assert.calledWith( consoleStub, 'emoji-repository-load-failed' );
+			sinon.assert.calledWith( consoleStub, 'emoji-repository-empty' );
 
 			domElement.remove();
 			await editor.destroy();

--- a/packages/ckeditor5-emoji/tests/manual/emoji.html
+++ b/packages/ckeditor5-emoji/tests/manual/emoji.html
@@ -2,6 +2,9 @@
     <!-- Required to fetch emoji database from https://cdn.jsdelivr.net -->
     <meta http-equiv="Content-Security-Policy"
           content="connect-src 'self' https://cksource.com http://*.cke-cs.com https://cdn.ckeditor.com">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Color+Emoji&display=swap" rel="stylesheet">
 </head>
 
 <p>
@@ -9,7 +12,7 @@
     <input type="radio" id="unicode-15" name="unicode" value="15"><label for="unicode-15">15</label>
     <input type="radio" id="unicode-16" name="unicode" value="16"><label for="unicode-16">16</label>
     <input type="radio" id="unicode-null" name="unicode" value="null" checked><label for="unicode-null">use the plugin default</label>
-    <input type="radio" id="unicode-6" name="unicode" value="6"><label for="unicode-6">invalid value</label>
+    <input type="radio" id="unicode-666" name="unicode" value="666"><label for="unicode-666">invalid value</label>
 </p>
 
 <p>
@@ -21,6 +24,12 @@
     <input type="radio" id="skin-medium-dark" name="skin" value="medium-dark"><label for="skin-medium-dark">👋🏾</label>
     <input type="radio" id="skin-dark" name="skin" value="dark"><label for="skin-dark">👋🏿</label>
     <input type="radio" id="skin-null" name="skin" value="null" checked><label for="skin-null">use the plugin default</label>
+</p>
+
+<p>
+    <b>Use "Noto Color Emoji" font</b>:
+    <input type="radio" id="custom-font-apply" name="custom-font" value="true"><label for="custom-font-apply">Apply</label>
+    <input type="radio" id="custom-font-reject" name="custom-font" value="false" checked><label for="custom-font-reject">Reject</label>
 </p>
 
 <h3><code>EmojiMention</code> + <code>EmojiPicker</code></h3>

--- a/packages/ckeditor5-emoji/tests/manual/emoji.js
+++ b/packages/ckeditor5-emoji/tests/manual/emoji.js
@@ -6,13 +6,22 @@
 /* globals console, document */
 
 import { ClassicEditor } from '@ckeditor/ckeditor5-editor-classic';
-import { Emoji, EmojiMention, EmojiPicker } from '../../src/index.js';
+import { Emoji, EmojiMention, EmojiPicker, EmojiRepository } from '../../src/index.js';
 import { Mention } from '@ckeditor/ckeditor5-mention';
 import { Essentials } from '@ckeditor/ckeditor5-essentials';
 import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
 import { List } from '@ckeditor/ckeditor5-list';
 import { Heading } from '@ckeditor/ckeditor5-heading';
 import { Bold } from '@ckeditor/ckeditor5-basic-styles';
+
+const cssValue = [
+	':root {',
+	'	--ck-font-face: Helvetica, Arial, Tahoma, Verdana, \'Noto Color Emoji\';',
+	'}',
+	'body {',
+	'	font-family: Helvetica, Arial, Tahoma, Verdana, \'Noto Color Emoji\';',
+	'}'
+].join( '\n' );
 
 const elements = {
 	template: document.querySelector( '#content' ),
@@ -29,7 +38,12 @@ await reloadEditor();
 
 // Reload editors whenever the radio button is clicked.
 [ ...document.querySelectorAll( 'input[type="radio"]' ) ].forEach( element => {
-	element.addEventListener( 'input', async () => {
+	element.addEventListener( 'input', async event => {
+		// Clear the internal cache when messing up with the filtering mechanism.
+		if ( event.target.name === 'custom-font' ) {
+			EmojiRepository._results = {};
+		}
+
 		await reloadEditor();
 	} );
 } );
@@ -39,6 +53,17 @@ async function reloadEditor() {
 	await Promise.all(
 		editors.map( editor => editor.destroy() )
 	);
+
+	// Remove the custom style definitions.
+	document.getElementById( 'custom-emoji-style' )?.remove();
+
+	// Create new styles depending on a radio button.
+	if ( document.querySelector( 'input[name="custom-font"]:checked' ).value === 'true' ) {
+		const styleElement = document.createElement( 'style' );
+		styleElement.id = 'custom-emoji-style';
+		styleElement.appendChild( document.createTextNode( cssValue ) );
+		document.head.appendChild( styleElement );
+	}
 
 	// Clear references.
 	editors.length = 0;
@@ -67,7 +92,6 @@ async function reloadEditor() {
 			.catch( err => {
 				console.error( err.stack );
 			} )
-
 	];
 
 	// Store references.
@@ -85,12 +109,16 @@ function getEditorConfig( { extraPlugins, emojiButtonInToolbar = true } ) {
 
 	const dbVersion = document.querySelector( 'input[name="unicode"]:checked' ).value;
 	const skinTone = document.querySelector( 'input[name="skin"]:checked' ).value;
+	const customFont = document.querySelector( 'input[name="custom-font"]:checked' ).value;
 
 	if ( dbVersion !== 'null' ) {
 		emoji.version = parseInt( dbVersion );
 	}
 	if ( skinTone !== 'null' ) {
 		emoji.skinTone = skinTone;
+	}
+	if ( customFont === 'true' ) {
+		emoji.useCustomFont = true;
 	}
 
 	return {

--- a/packages/ckeditor5-emoji/tests/manual/emoji.md
+++ b/packages/ckeditor5-emoji/tests/manual/emoji.md
@@ -34,5 +34,15 @@ If it couldn't be loaded, `EmojiMention` should not show auto-complete options, 
 
 * **`Unicode version`** - its value is passed as `emoji.version` in the configuration.
 * **`Default skin tone`** - its value is passed as `emoji.skinTone` in the configuration.
+* **Use "Noto Color Emoji" font** - this option allow using the `Noto Color Emoji` font in the editor. It applies the following CSS rules to the document
+    ```css
+    :root {
+        --ck-font-face: Helvetica, Arial, Tahoma, Verdana, 'Noto Color Emoji';
+    }
+    
+    body {
+        font-family: Helvetica, Arial, Tahoma, Verdana, 'Noto Color Emoji';
+    }
+    ```
 
 Selecting the `use the plugin default` option does not pass anything. This way plugins use the default values.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (emoji): Introduced the `emoji.useCustomFont` option to disable the filtering mechanism. Closes #18029.

Internal: Added additional logging for the Emoji Plugin when the emoji font is not installed on the OS. Closes #17988.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
