### PR TITLE
Fix outdated angular snippets in docs

### DIFF
--- a/docs/getting-started/integrations-cdn/angular.md
+++ b/docs/getting-started/integrations-cdn/angular.md
@@ -200,12 +200,7 @@ export class MyComponent {
 An instance of the {@link module:watchdog/contextwatchdog~ContextWatchdog `ContextWatchdog`} class that is responsible for providing the same context to multiple editor instances and restarting the whole structure in case of crashes.
 
 ```ts
-import CKSource from 'path/to/custom/build';
 import { loadCKEditorCloud } from '@ckeditor/ckeditor5-angular';
-
-const Context = CKSource.Context;
-const Editor = CKSource.Editor;
-const ContextWatchdog = CKSource.ContextWatchdog;
 
 @Component( {
 	// ...
@@ -223,9 +218,14 @@ export class MyComponent {
 
 	private _setupEditor( cloud ) {
 		const {
-			ClassicEditor
+			ClassicEditor,
+			ContextWatchdog,
+			Context
 		} = cloud.CKEditor;
-		const contextConfig = {};
+
+		const contextConfig = {
+			// Your context configuration.
+		};
 
 		this.Editor = ClassicEditor;
 		this.ready = false;

--- a/docs/getting-started/integrations/angular.md
+++ b/docs/getting-started/integrations/angular.md
@@ -264,11 +264,7 @@ export class MyComponent {
 An instance of the {@link module:watchdog/contextwatchdog~ContextWatchdog `ContextWatchdog`} class that is responsible for providing the same context to multiple editor instances and restarting the whole structure in case of crashes.
 
 ```ts
-import CKSource from 'path/to/custom/build';
-
-const Context = CKSource.Context;
-const Editor = CKSource.Editor;
-const ContextWatchdog = CKSource.ContextWatchdog;
+import { Editor, Context, ContextWatchdog } from 'ckeditor5';
 
 @Component( {
 	// ...


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Fix outdated Angular snippets in docs.

---

### Additional information

Notion issue https://www.notion.so/Fix-outdated-Angular-snippets-in-installation-guide-1abbb9a6723280a6b142c09d0b116461