### PR TITLE
Added `dryRun` parameter to `commitAndTag()` function to run commit validations during a release.

### DIFF
--- a/scripts/release/preparepackages.mjs
+++ b/scripts/release/preparepackages.mjs
@@ -296,6 +296,7 @@ const tasks = new Listr( [
 		task: ctx => {
 			return releaseTools.commitAndTag( {
 				version: latestVersion,
+				dryRun: cliArguments.compileOnly,
 				files: [
 					'package.json',
 					`${ PACKAGES_DIRECTORY }/*/package.json`,
@@ -305,11 +306,6 @@ const tasks = new Listr( [
 		},
 		skip: () => {
 			if ( isNonCommittableRelease( cliArguments ) ) {
-				return true;
-			}
-
-			// When compiling the packages only, do not commit anything.
-			if ( cliArguments.compileOnly ) {
 				return true;
 			}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Added `dryRun` parameter to `commitAndTag()` function to run commit validations during a release. See #17967.

---

### Additional information

⚠️ Depends on https://github.com/ckeditor/ckeditor5-dev/pull/1077.
