### PR TITLE
Fix for overflow on nested layout tables.

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
@@ -21,7 +21,7 @@
 			/* To make the layout table outline visible when layout table is inside another layout table inside edge cells.
 			Currently this solution works on every browser except Safari. */
 			overflow: clip;
-			overflow-clip-margin: 3px;
+			overflow-clip-margin: var(--ck-widget-outline-thickness);
 
 			/* The default table layout style in the editing view when the border is unset. */
 			&:not(

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
@@ -14,9 +14,14 @@
 
 .ck-editor__editable {
 	& .table.layout-table {
-		/* Resetting the table border-collapse property to the user agent styles. */
 		& > table {
+			/* Resetting the table border-collapse property to the user agent styles. */
 			border-collapse: separate;
+
+			/* To make the layout table outline visible when layout table is inside another layout table inside edge cells.
+			Currently this solution works on every browser except Safari. */
+			overflow: clip;
+			overflow-clip-margin: 3px;
 
 			/* The default table layout style in the editing view when the border is unset. */
 			&:not(

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
@@ -18,8 +18,8 @@
 			/* Resetting the table border-collapse property to the user agent styles. */
 			border-collapse: separate;
 
-			/* To make the layout table outline visible when layout table is inside another layout table inside edge cells.
-			Currently this solution works on every browser except Safari. */
+			/* Styles to make the layout table outline visible when the layout table is inside another layout table inside edge cells.
+			Currently, this solution works on every browser except Safari. */
 			overflow: clip;
 			overflow-clip-margin: var(--ck-widget-outline-thickness);
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Make the layout table outline visible when layout table is inside another layout table inside edge cells.

---

### Additional information

CSS Fix - works on every modern browser except `Safari`.

_Before:_

https://github.com/user-attachments/assets/92cc208b-4d37-4234-804f-347398b97cd8

_After:_

https://github.com/user-attachments/assets/e765d456-57a8-470d-b8e1-fe658026ce2e

