### PR TITLE
Docs: Fix snippets

### DIFF
--- a/docs/_snippets/examples/balloon-block-editor.js
+++ b/docs/_snippets/examples/balloon-block-editor.js
@@ -11,6 +11,9 @@ import {
 
 BalloonBlockEditor
 	.create( document.querySelector( '#snippet-balloon-block-editor' ), {
+		removePlugins: [
+			'CKBox'
+		],
 		cloudServices: CS_CONFIG,
 		ui: {
 			viewportOffset: {

--- a/docs/_snippets/examples/balloon-editor.js
+++ b/docs/_snippets/examples/balloon-editor.js
@@ -11,6 +11,9 @@ import {
 
 BalloonEditor
 	.create( document.querySelector( '#snippet-balloon-editor' ), {
+		removePlugins: [
+			'CKBox'
+		],
 		cloudServices: CS_CONFIG,
 		ui: {
 			viewportOffset: {

--- a/docs/_snippets/examples/inline-editor.js
+++ b/docs/_snippets/examples/inline-editor.js
@@ -9,6 +9,9 @@ const inlineInjectElements = document.querySelectorAll( '#snippet-inline-editor 
 
 Array.from( inlineInjectElements ).forEach( inlineElement => {
 	const config = {
+		removePlugins: [
+			'CKBox'
+		],
 		ui: {
 			viewportOffset: {
 				top: getViewportTopOffsetConfig()
@@ -28,6 +31,7 @@ Array.from( inlineInjectElements ).forEach( inlineElement => {
 
 	if ( inlineElement.tagName.toLowerCase() == 'header' ) {
 		config.removePlugins = [
+			...config.removePlugins,
 			'Blockquote',
 			'Image',
 			'ImageCaption',

--- a/docs/_snippets/examples/multi-root-editor.js
+++ b/docs/_snippets/examples/multi-root-editor.js
@@ -16,6 +16,9 @@ MultiRootEditor
 		},
 		// Editor configration:
 		{
+			removePlugins: [
+				'CKBox'
+			],
 			cloudServices: CS_CONFIG
 		}
 	)

--- a/docs/_snippets/features/build-image-upload-source.html
+++ b/docs/_snippets/features/build-image-upload-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/docs/_snippets/features/build-ui-language-source.html
+++ b/docs/_snippets/features/build-ui-language-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/docs/_snippets/features/image-upload.html
+++ b/docs/_snippets/features/image-upload.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="ck ck-content" id="snippet-image-upload">
 	<h2>Uploading images</h2>
 	<p>To upload an image, do the following:</p>

--- a/docs/_snippets/features/keyboard-support.html
+++ b/docs/_snippets/features/keyboard-support.html
@@ -1,6 +1,3 @@
-<!-- include CKBox from CDN -->
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
-
 <div id="keyboard-support">
 	<p>Press <kbd>Alt</kbd>+<kbd>0</kbd> (<kbd>⌥0</kbd> on Mac) while editing to display the list of available keyboard shortcuts.</p>
 </div>

--- a/docs/_snippets/features/keyboard-support.js
+++ b/docs/_snippets/features/keyboard-support.js
@@ -215,8 +215,8 @@ ClassicEditor
 		exportPdf: {
 			stylesheets: [
 				'../../assets/pagination-fonts.css',
-				'EDITOR_STYLES',
-				'../../snippets/features/pagination/snippet.css',
+				'../../assets/ckeditor5/ckeditor5.css',
+				'../../assets/ckeditor5-premium-features/ckeditor5-premium-features.css',
 				'../../assets/pagination.css'
 			],
 			fileName: 'export-pdf-demo.pdf',
@@ -232,7 +232,10 @@ ClassicEditor
 			tokenUrl: false
 		},
 		exportWord: {
-			stylesheets: [ 'EDITOR_STYLES' ],
+			stylesheets: [
+				'../../assets/ckeditor5/ckeditor5.css',
+				'../../assets/ckeditor5-premium-features/ckeditor5-premium-features.css'
+			],
 			fileName: 'export-word-demo.docx',
 			appID: 'cke5-docs',
 			converterOptions: {

--- a/docs/_snippets/features/mathtype.html
+++ b/docs/_snippets/features/mathtype.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <style>
 	.editor-icon__image[alt="MathType"],
 	.editor-icon__image[alt="ChemType"] {

--- a/docs/_snippets/features/mermaid.html
+++ b/docs/_snippets/features/mermaid.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="ck ck-content" id="mermaid">
     <h2>CKEditor timeline diagram</h2>
     <pre spellcheck="false"><code class="language-mermaid">

--- a/docs/_snippets/features/placeholder-build.html
+++ b/docs/_snippets/features/placeholder-build.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/docs/_snippets/features/read-only-build.html
+++ b/docs/_snippets/features/read-only-build.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/docs/_snippets/features/read-only.js
+++ b/docs/_snippets/features/read-only.js
@@ -41,7 +41,8 @@ ReadOnlyEditor
 		exportPdf: {
 			stylesheets: [
 				'../assets/fonts.css',
-				'EDITOR_STYLES',
+				'../assets/ckeditor5/ckeditor5.css',
+				'../assets/ckeditor5-premium-features/ckeditor5-premium-features.css',
 				'../assets/read-only-export-pdf.css'
 			],
 			fileName: 'export-pdf-demo.pdf',

--- a/docs/_snippets/features/wproofreader.html
+++ b/docs/_snippets/features/wproofreader.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="ck ck-content" id="snippet-wproofreader">
 	<p>Warsaw is the capital adn largest city of Poland. The metropolis stands on the Vistula River in east-central Poland and its population is officially estimatd at 1.8 million residents within a greater metropolitan area of 3.1 million residents, which makes Warsaw the 7th most-populous capital city in the European Union. Warsaw is an alpha-global city, a major international tourist destination, and a significaant cultural, political, and economic hub. Its historical Old Town was designated a UNESCO World Heritage Site.</p>
 

--- a/docs/_snippets/installation/setup/blocktoolbar.html
+++ b/docs/_snippets/installation/setup/blocktoolbar.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="ck ck-content" id="snippet-block-toolbar">
 	<h2>The great things you learn from traveling</h2>
 	<figure class="image image-style-side">

--- a/docs/_snippets/installation/setup/toolbar-breakpoint.html
+++ b/docs/_snippets/installation/setup/toolbar-breakpoint.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div id="toolbar-breakpoint">
 	<h3>Seedless plants</h3>
 	<p>Plants in this group, called <em>cryptogams</em>, do not produce seeds.</p>

--- a/docs/_snippets/installation/setup/toolbar-grouping.html
+++ b/docs/_snippets/installation/setup/toolbar-grouping.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div id="toolbar-grouping">
 	<h3>What doesn’t kill me…</h3>
 	<p>

--- a/docs/_snippets/installation/setup/toolbar-nested-icon.html
+++ b/docs/_snippets/installation/setup/toolbar-nested-icon.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div id="toolbar-nested-icon">
 	<h5>Conifers</h5>
 	<p>

--- a/docs/_snippets/installation/setup/toolbar-nested-label.html
+++ b/docs/_snippets/installation/setup/toolbar-nested-label.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div id="toolbar-nested-label">
 	<h3>Seed-producing plants</h3>
 	<p>

--- a/docs/_snippets/installation/setup/toolbar-nested-simple.html
+++ b/docs/_snippets/installation/setup/toolbar-nested-simple.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div id="toolbar-nested-simple">
 	<h4>Mosses and liverworts</h4>
 	<p>

--- a/docs/_snippets/installation/setup/toolbar-nested-tooltip.html
+++ b/docs/_snippets/installation/setup/toolbar-nested-tooltip.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div id="toolbar-nested-tooltip">
 	<h4>Flowering plants</h4>
 	<p>

--- a/docs/_snippets/installation/setup/toolbar-separator.html
+++ b/docs/_snippets/installation/setup/toolbar-separator.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div id="toolbar-separator">
 	<h3>A brief history of a tiny beast</h3>
 	<p>

--- a/docs/_snippets/installation/setup/toolbar-wrapping.html
+++ b/docs/_snippets/installation/setup/toolbar-wrapping.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div id="toolbar-wrapping">
 	<h2>The plant kingdom</h2>
 	<p>The plant kingdom is a diverse group of organisms that includes both tiny algae and giant sequoias. Despite this diversity, all plants have a few things in common.</p>

--- a/docs/_snippets/mini-inspector.js
+++ b/docs/_snippets/mini-inspector.js
@@ -54,6 +54,9 @@ export class MiniInspectorEditor extends DecoupledEditor {
 	];
 
 	static defaultConfig = {
+		removePlugins: [
+			'CKBox'
+		],
 		toolbar: {
 			items: [
 				'heading',

--- a/docs/getting-started/advanced/dll-builds.md
+++ b/docs/getting-started/advanced/dll-builds.md
@@ -6,6 +6,8 @@ order: 20
 modified_at: 2022-02-22
 ---
 
+{@snippet installation/advanced/dll-builds}
+
 # (Legacy) CKEditor 5 DLL builds
 
 <info-box warning>

--- a/docs/getting-started/advanced/dll-builds.md
+++ b/docs/getting-started/advanced/dll-builds.md
@@ -6,8 +6,6 @@ order: 20
 modified_at: 2022-02-22
 ---
 
-{@snippet installation/advanced/dll-builds}
-
 # (Legacy) CKEditor 5 DLL builds
 
 <info-box warning>

--- a/docs/getting-started/integrations-cdn/angular.md
+++ b/docs/getting-started/integrations-cdn/angular.md
@@ -6,8 +6,6 @@ category: cloud
 order: 30
 ---
 
-{@snippet installation/integrations/framework-integration}
-
 # Angular rich text editor component (CDN)
 
 <p>

--- a/docs/getting-started/integrations-cdn/quick-start.md
+++ b/docs/getting-started/integrations-cdn/quick-start.md
@@ -6,8 +6,6 @@ category: cloud
 order: 20
 ---
 
-{@snippet installation/integrations/framework-integration}
-
 # Installing Vanilla JS CKEditor&nbsp;5 using CDN
 
 CKEditor&nbsp;5 is a powerful, rich text editor you can embed in your web application. This guide will show you the fastest way to start using it.

--- a/docs/getting-started/integrations-cdn/react-default-cdn.md
+++ b/docs/getting-started/integrations-cdn/react-default-cdn.md
@@ -6,8 +6,6 @@ category: react-cdn
 order: 10
 ---
 
-{@snippet installation/integrations/framework-integration}
-
 # React rich text editor component (CDN)
 
 <p>

--- a/docs/getting-started/integrations-cdn/react-multiroot-cdn.md
+++ b/docs/getting-started/integrations-cdn/react-multiroot-cdn.md
@@ -7,8 +7,6 @@ order: 20
 modified_at: 2024-04-25
 ---
 
-{@snippet installation/integrations/framework-integration}
-
 # React rich text multi-root editor hook with CDN
 
 <p>

--- a/docs/getting-started/integrations-cdn/vuejs-v2.md
+++ b/docs/getting-started/integrations-cdn/vuejs-v2.md
@@ -6,8 +6,6 @@ category: cloud
 order: 40
 ---
 
-{@snippet installation/integrations/framework-integration}
-
 # Vue.js 2.x rich text editor component
 
 <p>

--- a/docs/getting-started/integrations-cdn/vuejs-v3.md
+++ b/docs/getting-started/integrations-cdn/vuejs-v3.md
@@ -6,8 +6,6 @@ category: cloud
 order: 50
 ---
 
-{@snippet installation/integrations/framework-integration}
-
 # Vue.js 3+ rich text editor component (CDN)
 
 <p>

--- a/docs/getting-started/integrations/angular.md
+++ b/docs/getting-started/integrations/angular.md
@@ -6,8 +6,6 @@ category: self-hosted
 order: 30
 ---
 
-{@snippet installation/integrations/framework-integration}
-
 # Angular rich text editor component (npm)
 
 <p>

--- a/docs/getting-started/integrations/quick-start.md
+++ b/docs/getting-started/integrations/quick-start.md
@@ -6,8 +6,6 @@ category: self-hosted
 order: 20
 ---
 
-{@snippet installation/integrations/framework-integration}
-
 # Installing Vanilla JS CKEditor&nbsp;5 using npm or ZIP
 
 CKEditor&nbsp;5 is a powerful, rich text editor you can embed in your web application. This guide will show you the fastest way to use it with npm or a ZIP package.

--- a/docs/getting-started/integrations/react-default-npm.md
+++ b/docs/getting-started/integrations/react-default-npm.md
@@ -6,8 +6,6 @@ category: react-npm
 order: 10
 ---
 
-{@snippet installation/integrations/framework-integration}
-
 # React rich text editor component (npm)
 
 <p>

--- a/docs/getting-started/integrations/react-multiroot-npm.md
+++ b/docs/getting-started/integrations/react-multiroot-npm.md
@@ -7,8 +7,6 @@ order: 20
 modified_at: 2024-04-25
 ---
 
-{@snippet installation/integrations/framework-integration}
-
 # React rich text multi-root editor hook with npm
 
 <p>

--- a/docs/getting-started/integrations/vuejs-v2.md
+++ b/docs/getting-started/integrations/vuejs-v2.md
@@ -6,8 +6,6 @@ category: self-hosted
 order: 40
 ---
 
-{@snippet installation/integrations/framework-integration}
-
 # Vue.js 2.x rich text editor component (npm)
 
 <p>

--- a/docs/getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/integrations/vuejs-v3.md
@@ -6,8 +6,6 @@ category: self-hosted
 order: 50
 ---
 
-{@snippet installation/integrations/framework-integration}
-
 # Vue.js 3+ rich text editor component (npm)
 
 <p>

--- a/docs/getting-started/legacy-getting-started/integrations/angular.md
+++ b/docs/getting-started/legacy-getting-started/integrations/angular.md
@@ -5,8 +5,6 @@ category: legacy-integrations
 order: 20
 ---
 
-{@snippet installation/integrations/framework-integration}
-
 # (Legacy) Angular rich text editor component
 
 <info-box warning>

--- a/docs/getting-started/legacy-getting-started/integrations/react.md
+++ b/docs/getting-started/legacy-getting-started/integrations/react.md
@@ -5,8 +5,6 @@ category: legacy-integrations
 order: 30
 ---
 
-{@snippet installation/integrations/framework-integration}
-
 # (Legacy) React rich text editor component
 
 <info-box warning>

--- a/docs/getting-started/legacy-getting-started/integrations/vuejs-v2.md
+++ b/docs/getting-started/legacy-getting-started/integrations/vuejs-v2.md
@@ -5,8 +5,6 @@ category: legacy-integrations
 order: 40
 ---
 
-{@snippet installation/integrations/framework-integration}
-
 # (Legacy) Vue.js 2.x rich text editor component
 
 <info-box warning>

--- a/docs/getting-started/legacy-getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/legacy-getting-started/integrations/vuejs-v3.md
@@ -5,8 +5,6 @@ category: legacy-integrations
 order: 50
 ---
 
-{@snippet installation/integrations/framework-integration}
-
 # Vue.js 3+ rich text editor component &ndash; Legacy guide
 
 <info-box warning>

--- a/packages/ckeditor5-alignment/docs/_snippets/features/build-text-alignment-source.html
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/build-text-alignment-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-autoformat/docs/_snippets/features/autoformat.html
+++ b/packages/ckeditor5-autoformat/docs/_snippets/features/autoformat.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="ck ck-content" id="snippet-autoformat">
 	<p>This is the <a href="https://ckeditor.com">CKEditor&nbsp;5</a> autoformatting feature.</p>
 	<p>Use Markdown syntax shortcodes to format content on the go. For example:</p>

--- a/packages/ckeditor5-basic-styles/docs/_snippets/features/build-basic-styles-source.html
+++ b/packages/ckeditor5-basic-styles/docs/_snippets/features/build-basic-styles-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote-source.html
+++ b/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-ckbox/docs/_snippets/features/build-ckbox-source.html
+++ b/packages/ckeditor5-ckbox/docs/_snippets/features/build-ckbox-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder-upload-only.js
+++ b/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder-upload-only.js
@@ -12,6 +12,9 @@ import { CKFinderEditor } from './build-ckfinder-source.js';
 
 CKFinderEditor
 	.create( document.querySelector( '#snippet-ckfinder-upload-only' ), {
+		removePlugins: [
+			'CKBox'
+		],
 		toolbar: {
 			items: [
 				'undo', 'redo',

--- a/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder.js
+++ b/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder.js
@@ -12,6 +12,9 @@ import { CKFinderEditor } from './build-ckfinder-source.js';
 
 CKFinderEditor
 	.create( document.querySelector( '#snippet-ckfinder' ), {
+		removePlugins: [
+			'CKBox'
+		],
 		toolbar: {
 			items: [
 				'undo', 'redo',

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/build-drag-drop-source.html
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/build-drag-drop-source.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <style>
 	/* Set the default font for the "page" of the content. */
 	.experimental-d-d .ck-content,

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/build-paste-source.html
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/build-paste-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-code-block/docs/_snippets/features/build-code-block-source.html
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/build-code-block-source.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <style>
 	/* Override documentation styles for <pre> and <code>. */
 

--- a/packages/ckeditor5-emoji/docs/_snippets/features/emoji-source.html
+++ b/packages/ckeditor5-emoji/docs/_snippets/features/emoji-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-find-and-replace/docs/_snippets/features/build-find-and-replace-source.html
+++ b/packages/ckeditor5-find-and-replace/docs/_snippets/features/build-find-and-replace-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-font/docs/_snippets/features/build-font-source.html
+++ b/packages/ckeditor5-font/docs/_snippets/features/build-font-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-heading/docs/_snippets/features/heading-source.html
+++ b/packages/ckeditor5-heading/docs/_snippets/features/heading-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-heading/docs/_snippets/features/title.html
+++ b/packages/ckeditor5-heading/docs/_snippets/features/title.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="ck ck-content" id="snippet-title">
 	<h1></h1>
 	<p></p>

--- a/packages/ckeditor5-highlight/docs/_snippets/features/build-highlight-source.html
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/build-highlight-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-horizontal-line/docs/_snippets/features/horizontal-line.html
+++ b/packages/ckeditor5-horizontal-line/docs/_snippets/features/horizontal-line.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="ck ck-content" id="snippet-horizontal-line">
 	<h1>Bill’s Classifieds</h1>
 

--- a/packages/ckeditor5-html-embed/docs/_snippets/features/html-embed.html
+++ b/packages/ckeditor5-html-embed/docs/_snippets/features/html-embed.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="ck ck-content" id="snippet-html-embed"></div>
 
 <button type="button" id="preview-data-action">Preview editor data</button>

--- a/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support-source.html
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-image/docs/_snippets/features/build-image-source.html
+++ b/packages/ckeditor5-image/docs/_snippets/features/build-image-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-image/docs/_snippets/features/image-image-optimizer-ckbox.html
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-image-optimizer-ckbox.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="ck ck-content" id="image-optimizer-ckbox">
 	<h2>Warsaw's Charm</h2>
 	

--- a/packages/ckeditor5-image/docs/_snippets/features/image-responsive.html
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-responsive.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 
 <div class="ck ck-content" id="snippet-responsive">
 	<h2>Welcoming the spring</h2>

--- a/packages/ckeditor5-indent/docs/_snippets/features/build-indent-source.html
+++ b/packages/ckeditor5-indent/docs/_snippets/features/build-indent-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-language/docs/_snippets/features/textpartlanguage.html
+++ b/packages/ckeditor5-language/docs/_snippets/features/textpartlanguage.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="ck ck-content" id="snippet-text-part-language">
 	<p>
 		<strong>Language</strong> is the human ability to acquire and use complex systems of communication, and <strong>language</strong> is any specific example of such a system. The scientific study of language is called linguistics.

--- a/packages/ckeditor5-list/docs/_snippets/features/lists-source.html
+++ b/packages/ckeditor5-list/docs/_snippets/features/lists-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-list/docs/_snippets/features/todo-list.html
+++ b/packages/ckeditor5-list/docs/_snippets/features/todo-list.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="ck ck-content" id="snippet-todo-list">
 	<h2>Waffles</h2>
 

--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <textarea class="ck ck-content" id="snippet-markdown">
 
 <h2>Markdown output 🛫</h2>

--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/paste-from-markdown.html
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/paste-from-markdown.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <textarea id="snippet-paste-from-markdown">
 
 &lt;h2&gt;Markdown 🛫&lt;/h2&gt;

--- a/packages/ckeditor5-media-embed/docs/_snippets/features/build-media-source.html
+++ b/packages/ckeditor5-media-embed/docs/_snippets/features/build-media-source.html
@@ -1,2 +1,1 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <script async charset="utf-8" src="//cdn.iframe.ly/embed.js?cancel=0"></script> 

--- a/packages/ckeditor5-media-embed/docs/features/media-embed.md
+++ b/packages/ckeditor5-media-embed/docs/features/media-embed.md
@@ -5,6 +5,8 @@ meta-title: Media embed | CKEditor 5 Documentation
 modified_at: 2021-10-08
 ---
 
+{@snippet features/build-media-source}
+
 # Media embed
 
 The media embed feature lets you insert embeddable media such as YouTube or Vimeo videos and tweets into your rich text content.

--- a/packages/ckeditor5-mention/docs/_snippets/features/build-mention-source.html
+++ b/packages/ckeditor5-mention/docs/_snippets/features/build-mention-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-minimap/docs/_snippets/features/minimap.html
+++ b/packages/ckeditor5-minimap/docs/_snippets/features/minimap.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="document-container">
 	<div id="toolbar-container" class="toolbar-container"></div>
 	<div class="minimap-wrapper">

--- a/packages/ckeditor5-page-break/docs/_snippets/features/page-break.html
+++ b/packages/ckeditor5-page-break/docs/_snippets/features/page-break.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="ck ck-content" id="snippet-page-break">
 	<h2 style="text-align:center;">The Flavorful Tuscany Meetup</h2>
 	<h3 style="text-align:center;">Welcome letter</h3>

--- a/packages/ckeditor5-paste-from-office/docs/_snippets/features/build-paste-from-office-source.html
+++ b/packages/ckeditor5-paste-from-office/docs/_snippets/features/build-paste-from-office-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-remove-format/docs/_snippets/features/build-remove-format-source.html
+++ b/packages/ckeditor5-remove-format/docs/_snippets/features/build-remove-format-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-restricted-editing/docs/_snippets/features/restricted-editing.html
+++ b/packages/ckeditor5-restricted-editing/docs/_snippets/features/restricted-editing.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <p>
 	<b>Mode</b>:
 	<input type="radio" id="mode-standard" name="editor-restriction-mode" value="standard" checked><label for="mode-standard">Standard</label>

--- a/packages/ckeditor5-select-all/docs/_snippets/features/select-all.html
+++ b/packages/ckeditor5-select-all/docs/_snippets/features/select-all.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div id="editor">
 	<h2>The great things you learn from traveling</h2>
 

--- a/packages/ckeditor5-show-blocks/docs/_snippets/features/show-blocks.html
+++ b/packages/ckeditor5-show-blocks/docs/_snippets/features/show-blocks.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 
 <div class="ck ck-content" id="snippet-show-blocks">
 	<h2>The three greatest things you learn from traveling</h2>

--- a/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing-imports.html
+++ b/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing-imports.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-source.html
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.html
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <textarea class="ck ck-content" id="snippet-styles">
 	<h3 class="category">
 		Opinions

--- a/packages/ckeditor5-table/docs/_snippets/features/build-table-source.html
+++ b/packages/ckeditor5-table/docs/_snippets/features/build-table-source.html
@@ -1,7 +1,5 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
-
 <style>
-    figure.table {
-        overflow-x: auto;
-    }
+figure.table {
+  overflow-x: auto;
+}
 </style>

--- a/packages/ckeditor5-table/docs/features/tables-caption.md
+++ b/packages/ckeditor5-table/docs/features/tables-caption.md
@@ -8,6 +8,8 @@ modified_at: 2022-05-19
 
 # Table caption
 
+{@snippet features/build-table-source}
+
 The {@link module:table/tablecaption~TableCaption} plugin lets you add captions to your tables. Table captions also improve accessibility as they are recognized by screen readers.
 
 ## Demo

--- a/packages/ckeditor5-table/docs/features/tables-resize.md
+++ b/packages/ckeditor5-table/docs/features/tables-resize.md
@@ -7,6 +7,8 @@ modified_at: 2022-05-19
 ---
 # Table column resize
 
+{@snippet features/build-table-source}
+
 The {@link module:table/tablecolumnresize~TableColumnResize} plugin lets you resize tables and individual table columns. It gives you complete control over column width.
 
 ## Demo

--- a/packages/ckeditor5-table/docs/features/tables-styling.md
+++ b/packages/ckeditor5-table/docs/features/tables-styling.md
@@ -8,6 +8,8 @@ modified_at: 2022-05-19
 
 # Table and cell styling tools
 
+{@snippet features/build-table-source}
+
 CKEditor&nbsp;5 comes with some additional tools that help you change the look of tables and table cells. You can control border color and style, background color, padding, or text alignment.
 
 ## Demo

--- a/packages/ckeditor5-table/docs/features/tables.md
+++ b/packages/ckeditor5-table/docs/features/tables.md
@@ -8,6 +8,8 @@ modified_at: 2023-02-22
 
 # Tables in CKEditor&nbsp;5 (overview)
 
+{@snippet features/build-table-source}
+
 The table feature gives you tools to create and edit tables. Tables are great for organizing data in a clear, visually appealing way.
 
 ## Demo

--- a/packages/ckeditor5-typing/docs/_snippets/features/build-text-transformation-source.html
+++ b/packages/ckeditor5-typing/docs/_snippets/features/build-text-transformation-source.html
@@ -1,1 +1,0 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/packages/ckeditor5-undo/docs/_snippets/features/undo-redo.html
+++ b/packages/ckeditor5-undo/docs/_snippets/features/undo-redo.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="ck ck-content" id="undo-redo">
 	<h2>Diesel locos are really useful!</h2>
 

--- a/packages/ckeditor5-upload/docs/_snippets/features/base64-upload.js
+++ b/packages/ckeditor5-upload/docs/_snippets/features/base64-upload.js
@@ -15,6 +15,9 @@ ClassicEditor.builtinPlugins.push( Base64UploadAdapter );
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-base64-upload' ), {
+		removePlugins: [
+			'CKBox'
+		],
 		ui: {
 			viewportOffset: {
 				top: getViewportTopOffsetConfig()

--- a/packages/ckeditor5-word-count/docs/_snippets/features/build-word-count-source.html
+++ b/packages/ckeditor5-word-count/docs/_snippets/features/build-word-count-source.html
@@ -1,4 +1,3 @@
-<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <style>
 	.word-count {
 		padding: 10px 20px;

--- a/packages/ckeditor5-word-count/docs/features/word-count.md
+++ b/packages/ckeditor5-word-count/docs/features/word-count.md
@@ -4,6 +4,8 @@ menu-title: Word and character count
 meta-title: Word and character count | CKEditor 5 Documentation
 ---
 
+{@snippet features/build-word-count-source}
+
 # Word count and character count
 
 The word count feature lets you track the number of words and characters in the editor. This helps you control the volume of your content and check the progress of your work.

--- a/scripts/docs/snippetadapter.mjs
+++ b/scripts/docs/snippetadapter.mjs
@@ -191,7 +191,8 @@ async function buildDocuments( snippets, getSnippetPlaceholder, constants, impor
 			getStyle( upath.join( relativeOutputPath, 'assets', 'ckeditor5', 'ckeditor5.css' ) ),
 			getStyle( upath.join( relativeOutputPath, 'assets', 'ckeditor5-premium-features', 'ckeditor5-premium-features.css' ) ),
 			getStyle( upath.join( relativeOutputPath, 'assets', 'global.css' ) ),
-			getScript( upath.join( relativeOutputPath, 'assets', 'global.js' ) )
+			getScript( upath.join( relativeOutputPath, 'assets', 'global.js' ) ),
+			'<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>'
 		];
 
 		let documentContent = await readFile( document, { encoding: 'utf-8' } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Fix snippets.

---

### Additional information

Changes introduced in this PR:

* Always load CKBox from CDN, as it's used in most snippets.
* Disable CKBox plugins in few snippets that are incompatible with it.
* Remove snippets that only included CKBox script tag.
* Fix paths to editor styles in snippets using `Export to PDF` and `Export to Word` features.
* Restore a few “snippet builds” that included some content or styles.
* Fix Bootstrap example.
