### PR TITLE
POC: Remove `role=textbox` from `td` / `th` editable widgets.

### DIFF
--- a/packages/ckeditor5-widget/src/utils.ts
+++ b/packages/ckeditor5-widget/src/utils.ts
@@ -286,7 +286,10 @@ export function toWidgetEditable(
 ): ViewEditableElement {
 	writer.addClass( [ 'ck-editor__editable', 'ck-editor__nested-editable' ], editable );
 
-	writer.setAttribute( 'role', 'textbox', editable );
+	if ( editable.name !== 'td' && editable.name !== 'th' ) {
+		writer.setAttribute( 'role', 'textbox', editable );
+	}
+
 	writer.setAttribute( 'tabindex', '-1', editable );
 
 	if ( options.label ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Remove `role=textbox` from `td` / `th` editable widgets. 

---

### Additional information

Parent issue https://github.com/ckeditor/ckeditor5/issues/16923
