### PR TITLE
Internal: Always build fresh `.js` and `.d.ts` files, ignoring the cache.

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "translations:synchronize": "node ./scripts/translations/synchronize.mjs",
     "translations:validate": "node ./scripts/translations/synchronize.mjs --validate-only",
     "translations:move": "node ./scripts/translations/move.mjs",
-    "build": "tsc -p ./tsconfig.release-ckeditor5.json",
+    "build": "tsc --build --force ./tsconfig.release-ckeditor5.json",
     "build:dist": "node scripts/nim/build-ckeditor5.mjs",
     "predll:build": "npm run build",
     "dll:build": "node scripts/dll/build-dlls.mjs --base-dll-config ./scripts/dll/webpack.config.dll.mjs",

--- a/packages/ckeditor5-adapter-ckfinder/package.json
+++ b/packages/ckeditor5-adapter-ckfinder/package.json
@@ -55,7 +55,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-alignment/package.json
+++ b/packages/ckeditor5-alignment/package.json
@@ -56,7 +56,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-autoformat/package.json
+++ b/packages/ckeditor5-autoformat/package.json
@@ -60,7 +60,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-autosave/package.json
+++ b/packages/ckeditor5-autosave/package.json
@@ -49,7 +49,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-basic-styles/package.json
+++ b/packages/ckeditor5-basic-styles/package.json
@@ -52,7 +52,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-block-quote/package.json
+++ b/packages/ckeditor5-block-quote/package.json
@@ -57,7 +57,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-bookmark/package.json
+++ b/packages/ckeditor5-bookmark/package.json
@@ -65,7 +65,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-ckbox/package.json
+++ b/packages/ckeditor5-ckbox/package.json
@@ -61,7 +61,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-ckfinder/package.json
+++ b/packages/ckeditor5-ckfinder/package.json
@@ -54,7 +54,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-clipboard/package.json
+++ b/packages/ckeditor5-clipboard/package.json
@@ -77,7 +77,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-cloud-services/package.json
+++ b/packages/ckeditor5-cloud-services/package.json
@@ -45,7 +45,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-code-block/package.json
+++ b/packages/ckeditor5-code-block/package.json
@@ -62,7 +62,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-core/package.json
+++ b/packages/ckeditor5-core/package.json
@@ -65,7 +65,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-easy-image/package.json
+++ b/packages/ckeditor5-easy-image/package.json
@@ -51,7 +51,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-editor-balloon/package.json
+++ b/packages/ckeditor5-editor-balloon/package.json
@@ -54,7 +54,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-editor-classic/package.json
+++ b/packages/ckeditor5-editor-classic/package.json
@@ -54,7 +54,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-editor-decoupled/package.json
+++ b/packages/ckeditor5-editor-decoupled/package.json
@@ -54,7 +54,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-editor-inline/package.json
+++ b/packages/ckeditor5-editor-inline/package.json
@@ -54,7 +54,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-editor-multi-root/package.json
+++ b/packages/ckeditor5-editor-multi-root/package.json
@@ -59,7 +59,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-editor-multi-root/tsconfig.json
+++ b/packages/ckeditor5-editor-multi-root/tsconfig.json
@@ -6,5 +6,9 @@
   ],
   "exclude": [
     "tests"
-  ]
+  ],
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo"
+	}
 }

--- a/packages/ckeditor5-emoji/package.json
+++ b/packages/ckeditor5-emoji/package.json
@@ -59,7 +59,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   },
   "sideEffects": [

--- a/packages/ckeditor5-engine/package.json
+++ b/packages/ckeditor5-engine/package.json
@@ -70,7 +70,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-enter/package.json
+++ b/packages/ckeditor5-enter/package.json
@@ -47,7 +47,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-essentials/package.json
+++ b/packages/ckeditor5-essentials/package.json
@@ -52,7 +52,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-find-and-replace/package.json
+++ b/packages/ckeditor5-find-and-replace/package.json
@@ -63,7 +63,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-font/package.json
+++ b/packages/ckeditor5-font/package.json
@@ -53,7 +53,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-heading/package.json
+++ b/packages/ckeditor5-heading/package.json
@@ -60,7 +60,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-highlight/package.json
+++ b/packages/ckeditor5-highlight/package.json
@@ -56,7 +56,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-horizontal-line/package.json
+++ b/packages/ckeditor5-horizontal-line/package.json
@@ -54,7 +54,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-html-embed/package.json
+++ b/packages/ckeditor5-html-embed/package.json
@@ -57,7 +57,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-html-support/package.json
+++ b/packages/ckeditor5-html-support/package.json
@@ -81,7 +81,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-icons/package.json
+++ b/packages/ckeditor5-icons/package.json
@@ -33,7 +33,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.json && node ../../scripts/update-icons-typings.mjs",
+    "build": "tsc --build --force ./tsconfig.json && node ../../scripts/update-icons-typings.mjs",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-icons/tsconfig.json
+++ b/packages/ckeditor5-icons/tsconfig.json
@@ -6,5 +6,9 @@
 	],
 	"exclude": [
 		"tests"
-	]
+	],
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo"
+	}
 }

--- a/packages/ckeditor5-image/package.json
+++ b/packages/ckeditor5-image/package.json
@@ -76,7 +76,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-indent/package.json
+++ b/packages/ckeditor5-indent/package.json
@@ -52,7 +52,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-language/package.json
+++ b/packages/ckeditor5-language/package.json
@@ -49,7 +49,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-link/package.json
+++ b/packages/ckeditor5-link/package.json
@@ -64,7 +64,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-list/package.json
+++ b/packages/ckeditor5-list/package.json
@@ -77,7 +77,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-markdown-gfm/package.json
+++ b/packages/ckeditor5-markdown-gfm/package.json
@@ -80,7 +80,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-media-embed/package.json
+++ b/packages/ckeditor5-media-embed/package.json
@@ -60,7 +60,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-mention/package.json
+++ b/packages/ckeditor5-mention/package.json
@@ -60,7 +60,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-minimap/package.json
+++ b/packages/ckeditor5-minimap/package.json
@@ -58,7 +58,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-page-break/package.json
+++ b/packages/ckeditor5-page-break/package.json
@@ -54,7 +54,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-paragraph/package.json
+++ b/packages/ckeditor5-paragraph/package.json
@@ -51,7 +51,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-paste-from-office/package.json
+++ b/packages/ckeditor5-paste-from-office/package.json
@@ -63,7 +63,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-remove-format/package.json
+++ b/packages/ckeditor5-remove-format/package.json
@@ -57,7 +57,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-restricted-editing/package.json
+++ b/packages/ckeditor5-restricted-editing/package.json
@@ -59,7 +59,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-select-all/package.json
+++ b/packages/ckeditor5-select-all/package.json
@@ -49,7 +49,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-show-blocks/package.json
+++ b/packages/ckeditor5-show-blocks/package.json
@@ -81,7 +81,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-source-editing/package.json
+++ b/packages/ckeditor5-source-editing/package.json
@@ -54,7 +54,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-special-characters/package.json
+++ b/packages/ckeditor5-special-characters/package.json
@@ -52,7 +52,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-style/package.json
+++ b/packages/ckeditor5-style/package.json
@@ -78,7 +78,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-table/package.json
+++ b/packages/ckeditor5-table/package.json
@@ -70,7 +70,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-typing/package.json
+++ b/packages/ckeditor5-typing/package.json
@@ -60,7 +60,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-ui/package.json
+++ b/packages/ckeditor5-ui/package.json
@@ -82,7 +82,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-undo/package.json
+++ b/packages/ckeditor5-undo/package.json
@@ -51,7 +51,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-upload/package.json
+++ b/packages/ckeditor5-upload/package.json
@@ -39,7 +39,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-utils/package.json
+++ b/packages/ckeditor5-utils/package.json
@@ -42,7 +42,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-watchdog/package.json
+++ b/packages/ckeditor5-watchdog/package.json
@@ -43,7 +43,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-widget/package.json
+++ b/packages/ckeditor5-widget/package.json
@@ -58,7 +58,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }

--- a/packages/ckeditor5-word-count/package.json
+++ b/packages/ckeditor5-word-count/package.json
@@ -58,7 +58,7 @@
   ],
   "scripts": {
     "dll:build": "webpack",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc --build --force ./tsconfig.json",
     "build:dist": "node ../../scripts/nim/build-package.mjs"
   }
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Always build fresh `.js` and `.d.ts` files, ignoring the cache. Closes #18102.
