### PR TITLE
Pass path to a dynamically imported file as `file://` protocol URL to make it work in Windows

### DIFF
--- a/scripts/constants.mjs
+++ b/scripts/constants.mjs
@@ -12,7 +12,7 @@ const __filename = fileURLToPath( import.meta.url );
 const __dirname = upath.dirname( __filename );
 
 export const CKEDITOR5_ROOT_PATH = upath.join( __dirname, '..' );
-export const CKEDITOR5_COMMERCIAL_PATH = upath.resolve( CKEDITOR5_ROOT_PATH, 'external', 'ckeditor5-commercial' );
+export const CKEDITOR5_COMMERCIAL_PATH = upath.join( CKEDITOR5_ROOT_PATH, 'external', 'ckeditor5-commercial' );
 export const CKEDITOR5_PREMIUM_FEATURES_PATH = upath.join( CKEDITOR5_COMMERCIAL_PATH, PACKAGES_DIRECTORY, 'ckeditor5-premium-features' );
 
 export const CKEDITOR5_INDEX = upath.join( CKEDITOR5_ROOT_PATH, 'src', 'index.ts' );

--- a/scripts/docs/snippetadapter.mjs
+++ b/scripts/docs/snippetadapter.mjs
@@ -5,6 +5,7 @@
 
 /* eslint-env node */
 
+import url from 'url';
 import { constants, readFile, writeFile, copyFile, access, mkdir } from 'fs/promises';
 import upath from 'upath';
 import { build as esbuild } from 'esbuild';
@@ -213,7 +214,10 @@ async function buildDocuments( snippets, paths, constants, imports, getSnippetPl
  */
 async function getConstants() {
 	try {
-		const { default: constants } = await import( upath.resolve( CKEDITOR5_COMMERCIAL_PATH, 'docs', 'constants.cjs' ) );
+		const scriptPath = upath.join( CKEDITOR5_COMMERCIAL_PATH, 'docs', 'constants.cjs' );
+		const { href } = url.pathToFileURL( scriptPath );
+		const { default: constants } = await import( href );
+
 		return constants;
 	} catch {
 		return { LICENSE_KEY: 'GPL' };


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Fixed path calculation to a dynamically imported file in snippets adapter to work independently of the OS. Previously, it did not work in Windows, because there is a specific requirement that absolute path loaded in `import()` must be valid `file://` protocol URL.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
