### PR TITLE
Add authorize private categories access call to CKBox API after start of the editor.

### DIFF
--- a/packages/ckeditor5-ckbox/tests/ckboxediting.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxediting.js
@@ -38,6 +38,8 @@ describe( 'CKBoxEditing', () => {
 	beforeEach( async () => {
 		TokenMock.initialToken = 'ckbox-token';
 
+		sinon.stub( CKBoxUtils.prototype, '_authorizePrivateCategoriesAccess' ).resolves();
+
 		originalCKBox = window.CKBox;
 		window.CKBox = {};
 

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
@@ -29,6 +29,7 @@ import CKBoxEditing from '../../src/ckboxediting.js';
 import CKBoxImageEditEditing from '../../src/ckboximageedit/ckboximageeditediting.js';
 
 import { blurHashToDataUrl } from '../../src/utils.js';
+import CKBoxUtils from '../../src/ckboxutils.js';
 
 const CKBOX_API_URL = 'https://upload.example.com';
 
@@ -46,6 +47,8 @@ describe( 'CKBoxImageEditCommand', () => {
 			// Signature.
 			'signature'
 		].join( '.' );
+
+		sinon.stub( CKBoxUtils.prototype, '_authorizePrivateCategoriesAccess' ).resolves();
 
 		domElement = global.document.createElement( 'div' );
 		global.document.body.appendChild( domElement );

--- a/packages/ckeditor5-ckbox/tests/ckboxuploadadapter.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxuploadadapter.js
@@ -44,6 +44,8 @@ describe( 'CKBoxUploadAdapter', () => {
 
 		TokenMock.initialToken = jwtToken;
 
+		sinon.stub( CKBoxUtils.prototype, '_authorizePrivateCategoriesAccess' ).resolves();
+
 		return ClassicTestEditor
 			.create( editorElement, {
 				plugins: [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ckbox): Resolved issue where images from private categories were not appearing in the selector.  Closes #18044

---

### Additional information

This PR align CKBox plugin to support new authorization process call just after startup of the editor. 

See more: https://ckeditor.com/docs/ckbox/latest/features/private-categories.html#authorization-process
Caused by https://github.com/cksource/ckeditor5-commercial/issues/7158
