### PR TITLE
Fix snippet adapter is global docs deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@listr2/prompt-adapter-inquirer": "^2.0.16",
     "@ocular-d/vale-bin": "^2.29.1",
     "@webspellchecker/wproofreader-ckeditor5": "^3.0.0",
-    "@wiris/mathtype-ckeditor5": "^8.10.0",
+    "@wiris/mathtype-ckeditor5": "8.12.0",
     "acorn": "^8.11.3",
     "assert": "^2.0.0",
     "chalk": "^5.0.0",

--- a/scripts/docs/snippetadapter.mjs
+++ b/scripts/docs/snippetadapter.mjs
@@ -103,7 +103,14 @@ async function buildSnippets( snippets, paths, constants, imports ) {
 		define: Object.fromEntries( Object.entries( constants ).map( ( [ key, value ] ) => [ key, JSON.stringify( value ) ] ) ),
 		outdir: paths.snippetsOutput,
 		entryNames: '[dir]/[name]/snippet',
-		nodePaths: [ upath.resolve( CKEDITOR5_ROOT_PATH, 'node_modules' ) ],
+		nodePaths: [
+			/**
+			 * This script can be run from a location where the local `node_modules` directory is not available
+			 * (e.g. in https://github.com/cksource/docs/). To ensure that all dependencies can be resolved,
+			 * we need to add the local `node_modules` directory to the list of node paths.
+			 */
+			upath.join( CKEDITOR5_ROOT_PATH, 'node_modules' )
+		],
 		bundle: true,
 		minify: true,
 		treeShaking: true,

--- a/scripts/docs/snippetadapter.mjs
+++ b/scripts/docs/snippetadapter.mjs
@@ -103,6 +103,7 @@ async function buildSnippets( snippets, paths, constants, imports ) {
 		define: Object.fromEntries( Object.entries( constants ).map( ( [ key, value ] ) => [ key, JSON.stringify( value ) ] ) ),
 		outdir: paths.snippetsOutput,
 		entryNames: '[dir]/[name]/snippet',
+		nodePaths: [ upath.resolve( CKEDITOR5_ROOT_PATH, 'node_modules' ) ],
 		bundle: true,
 		minify: true,
 		treeShaking: true,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Snippet adapter should always check `node_modules` of `ckeditor5` repository when resolving dependencies.

Internal: Lock `@wiris/mathtype-ckeditor5` version to fix issues present in the latest release.

---

* Closes https://github.com/cksource/ckeditor5-internal/issues/3976.
* Link to `@wiris/mathtype-ckeditor5` issue: https://github.com/wiris/html-integrations/issues/1093

