### PR TITLE
Docs: Fix images in `Export to PDF` and `Export to Word` examples

### DIFF
--- a/scripts/docs/snippetadapter.mjs
+++ b/scripts/docs/snippetadapter.mjs
@@ -172,8 +172,8 @@ async function buildDocuments( snippets, paths, constants, imports, getSnippetPl
 	const globalTags = [
 		`<script type="importmap">${ JSON.stringify( { imports } ) }</script>`,
 		`<script>window.CKEDITOR_GLOBAL_LICENSE_KEY = '${ constants.LICENSE_KEY }';</script>`,
-		'<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>',
-		'<script src="%BASE_PATH%/assets/global.js"></script>',
+		'<script defer src="%BASE_PATH%/assets/global.js"></script>',
+		'<script defer src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>',
 		getStyle( '%BASE_PATH%/assets/ckeditor5/ckeditor5.css' ),
 		getStyle( '%BASE_PATH%/assets/ckeditor5-premium-features/ckeditor5-premium-features.css' ),
 		getStyle( '%BASE_PATH%/assets/global.css' ),


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Fix images in `Export to PDF` and `Export to Word` examples. Closes #18142.

---

### Additional information

This PR adds `defer` to `global.js` and `ckbox.js` scripts, so they load only once the entire HTML is loaded. Also, the scripts are re-ordered, so the `global.js` always runs first.
