### PR TITLE
Internal: Revert MathType downgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@listr2/prompt-adapter-inquirer": "^2.0.16",
     "@ocular-d/vale-bin": "^2.29.1",
     "@webspellchecker/wproofreader-ckeditor5": "^3.0.0",
-    "@wiris/mathtype-ckeditor5": "8.12.0",
+    "@wiris/mathtype-ckeditor5": "^8.13.1",
     "acorn": "^8.11.3",
     "assert": "^2.0.0",
     "chalk": "^5.0.0",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Revert MathType downgrade.

---

### Additional information

This PR reverts change made in #18141, because new MathType release fixed the original issue.
