### PR TITLE
Improve source editing integration with document outline in fullscreen mode

### DIFF
--- a/packages/ckeditor5-fullscreen/src/handlers/abstracteditor.ts
+++ b/packages/ckeditor5-fullscreen/src/handlers/abstracteditor.ts
@@ -43,6 +43,16 @@ export default class AbstractEditorHandler {
 	private _annotationsUIsData: Map<string, Record<string, any>> | null = null;
 
 	/**
+	 * A callback that hides the document outline header when the source editing mode is enabled.
+	 * Document outline element itself is hidden by source editing plugin.
+	 */
+	/* istanbul ignore next -- @preserve */
+	private _sourceEditingCallback = ( _evt: EventInfo, _name: string, value: boolean ) => {
+		( this.getWrapper().querySelector( '.ck-fullscreen__document-outline-header' ) as HTMLElement ).style.display =
+			value ? 'none' : '';
+	};
+
+	/**
 	 * A callback that shows the revision viewer, stored to restore the original one after exiting the fullscreen mode.
 	 */
 	protected _showRevisionViewerCallback: ( ( config?: EditorConfig ) => Promise<RevisionViewerEditor | null> ) | null = null;
@@ -204,6 +214,10 @@ export default class AbstractEditorHandler {
 			this._overrideRevisionHistoryCallbacks();
 		}
 
+		if ( this._editor.plugins.has( 'SourceEditing' ) && this._editor.plugins.has( 'DocumentOutlineUI' ) ) {
+			this._editor.plugins.get( 'SourceEditing' ).on( 'change:isSourceEditingMode', this._sourceEditingCallback );
+		}
+
 		// Hide all other elements in the container to ensure they don't create an empty unscrollable space.
 		for ( const element of this._editor.config.get( 'fullscreen.container' )!.children ) {
 			if ( element !== this._wrapper ) {
@@ -241,6 +255,10 @@ export default class AbstractEditorHandler {
 
 		if ( this._editor.plugins.has( 'RevisionHistory' ) ) {
 			this._restoreRevisionHistoryCallbacks();
+		}
+
+		if ( this._editor.plugins.has( 'SourceEditing' ) && this._editor.plugins.has( 'DocumentOutlineUI' ) ) {
+			this._editor.plugins.get( 'SourceEditing' ).off( 'change:isSourceEditingMode', this._sourceEditingCallback );
 		}
 
 		for ( const placeholderName of this._placeholderMap.keys() ) {

--- a/packages/ckeditor5-fullscreen/tests/handlers/abstracteditor.js
+++ b/packages/ckeditor5-fullscreen/tests/handlers/abstracteditor.js
@@ -378,6 +378,8 @@ describe( 'AbstractHandler', () => {
 			static get pluginName() {
 				return 'DocumentOutlineUI';
 			}
+
+			view = { element: global.document.createElement( 'div' ) };
 		}
 
 		beforeEach( async () => {

--- a/packages/ckeditor5-source-editing/src/sourceediting.ts
+++ b/packages/ckeditor5-source-editing/src/sourceediting.ts
@@ -15,6 +15,7 @@ import { ButtonView, MenuBarMenuListItemButtonView, type Dialog } from 'ckeditor
 import { CKEditorError, createElement, ElementReplacer } from 'ckeditor5/src/utils.js';
 import { formatHtml } from './utils/formathtml.js';
 
+import type { DocumentOutlineUI } from '@ckeditor/ckeditor5-document-outline';
 import type { Annotations } from '@ckeditor/ckeditor5-comments';
 
 import '../theme/sourceediting.css';
@@ -322,8 +323,8 @@ export default class SourceEditing extends Plugin {
 	 * Hides the document outline if it is configured.
 	 */
 	private _hideDocumentOutline() {
-		if ( this.editor.plugins.has( 'DocumentOutline' ) ) {
-			( this.editor.plugins.get( 'DocumentOutlineUI' ) as any ).view.element.style.display = 'none';
+		if ( this.editor.plugins.has( 'DocumentOutlineUI' ) ) {
+			( this.editor.plugins.get( 'DocumentOutlineUI' ) as DocumentOutlineUI ).view!.element!.style.display = 'none';
 		}
 	}
 
@@ -331,8 +332,8 @@ export default class SourceEditing extends Plugin {
 	 * Shows the document outline if it was hidden when entering the source editing.
 	 */
 	private _showDocumentOutline() {
-		if ( this.editor.plugins.has( 'DocumentOutline' ) ) {
-			( this.editor.plugins.get( 'DocumentOutlineUI' ) as any ).view.element.style.display = '';
+		if ( this.editor.plugins.has( 'DocumentOutlineUI' ) ) {
+			( this.editor.plugins.get( 'DocumentOutlineUI' ) as DocumentOutlineUI ).view!.element!.style.display = '';
 		}
 	}
 

--- a/packages/ckeditor5-source-editing/src/sourceediting.ts
+++ b/packages/ckeditor5-source-editing/src/sourceediting.ts
@@ -322,8 +322,8 @@ export default class SourceEditing extends Plugin {
 	 * Hides the document outline if it is configured.
 	 */
 	private _hideDocumentOutline() {
-		if ( document.querySelector( '.ck-document-outline' ) ) {
-			( document.querySelector( '.ck-document-outline' )! as HTMLElement ).style.visibility = 'hidden';
+		if ( this.editor.plugins.has( 'DocumentOutline' ) ) {
+			( this.editor.plugins.get( 'DocumentOutlineUI' ) as any ).view.element.style.display = 'none';
 		}
 	}
 
@@ -331,8 +331,8 @@ export default class SourceEditing extends Plugin {
 	 * Shows the document outline if it was hidden when entering the source editing.
 	 */
 	private _showDocumentOutline() {
-		if ( document.querySelector( '.ck-document-outline' ) ) {
-			( document.querySelector( '.ck-document-outline' )! as HTMLElement ).style.visibility = '';
+		if ( this.editor.plugins.has( 'DocumentOutline' ) ) {
+			( this.editor.plugins.get( 'DocumentOutlineUI' ) as any ).view.element.style.display = '';
 		}
 	}
 

--- a/packages/ckeditor5-source-editing/tests/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/sourceediting.js
@@ -840,32 +840,50 @@ describe( 'SourceEditing', () => {
 	} );
 
 	describe( 'integration with document outline', () => {
-		it( 'should hide the document outline container when entering the source editing mode', () => {
-			const documentOutlineElement = document.createElement( 'div' );
+		let documentOutlineElement, documentOutlineEditor, documentOutlineEditorElement, documentOutlineEditorButton;
 
-			documentOutlineElement.classList.add( 'ck-document-outline' );
-			document.body.appendChild( documentOutlineElement );
+		class DocumentOutlineUIMock extends Plugin {
+			static get pluginName() {
+				return 'DocumentOutlineUI';
+			}
 
-			button.fire( 'execute' );
+			view = { element: document.createElement( 'div' ) };
+		}
 
-			expect( documentOutlineElement.style.visibility ).to.equal( 'hidden' );
+		beforeEach( async () => {
+			documentOutlineEditorElement = document.body.appendChild( document.createElement( 'div' ) );
+
+			documentOutlineEditor = await ClassicEditor.create( documentOutlineEditorElement, {
+				plugins: [ Paragraph, Heading, SourceEditing, DocumentOutlineUIMock ],
+				toolbar: [ 'heading' ]
+			} );
+
+			documentOutlineElement = documentOutlineEditor.plugins.get( 'DocumentOutlineUI' ).view.element;
+			documentOutlineEditorButton = documentOutlineEditor.ui.componentFactory.create( 'sourceEditing' );
+		} );
+
+		afterEach( async () => {
+			documentOutlineEditorElement.remove();
+
+			return documentOutlineEditor.destroy();
+		} );
+
+		it( 'should hide the document outline container when entering the source editing mode', async () => {
+			documentOutlineEditorButton.fire( 'execute' );
+
+			expect( documentOutlineElement.style.display ).to.equal( 'none' );
 
 			documentOutlineElement.remove();
 		} );
 
-		it( 'should show the document outline container when leaving the source editing mode', () => {
-			const documentOutlineElement = document.createElement( 'div' );
+		it( 'should show the document outline container when leaving the source editing mode', async () => {
+			documentOutlineEditorButton.fire( 'execute' );
 
-			documentOutlineElement.classList.add( 'ck-document-outline' );
-			document.body.appendChild( documentOutlineElement );
+			expect( documentOutlineElement.style.display ).to.equal( 'none' );
 
-			button.fire( 'execute' );
+			documentOutlineEditorButton.fire( 'execute' );
 
-			expect( documentOutlineElement.style.visibility ).to.equal( 'hidden' );
-
-			button.fire( 'execute' );
-
-			expect( documentOutlineElement.style.visibility ).to.equal( '' );
+			expect( documentOutlineElement.style.display ).to.equal( '' );
 
 			documentOutlineElement.remove();
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (fullscreen): Improve source editing integration with document outline in fullscreen mode.

---

### Additional information

1. Source editing integration was not perfect, it didn't take into account a situation when there are multiple document outline containers on the page.
2. Fullscreen has to detect when source mode is open and toggle "Document outline" header visibility.