### PR TITLE
Improving table styles.

### DIFF
--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -3,41 +3,64 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-.ck-content .table {
+
+/* Text alignment of the table header should match the editor settings and override the native browser styling,
+when content is available outside the editor. See https://github.com/ckeditor/ckeditor5/issues/6638 */
+.ck-content[dir="rtl"] .table th {
+	text-align: right;
+}
+
+.ck-content[dir="ltr"] .table th {
+	text-align: left;
+}
+
+.ck-content figure.table:not(.layout-table) {
+	display: table;
+
+	& > table {
+		width: 100%;
+		height: 100%;
+	}
+}
+
+.ck-content figure.table:not(.layout-table),
+.ck-content table.table:not(.layout-table) {
 	/* Give the table widget some air and center it horizontally */
 	/* The first value should be equal to --ck-spacing-large variable if used in the editor context
 	to avoid the content jumping (See https://github.com/ckeditor/ckeditor5/issues/9825). */
 	margin: 0.9em auto;
-	display: table;
+}
 
-	& table {
-		/* The table cells should have slight borders */
-		border-collapse: collapse;
-		border-spacing: 0;
+.ck-content table.table:not(.layout-table),
+.ck-content figure.table:not(.layout-table) > table {
+	/* The table cells should have slight borders */
+	border-collapse: collapse;
+	border-spacing: 0;
 
-		/* Table width and height are set on the parent <figure>. Make sure the table inside stretches
-		to the full dimensions of the container (https://github.com/ckeditor/ckeditor5/issues/6186). */
-		width: 100%;
-		height: 100%;
+	/* The outer border of the table should be slightly darker than the inner lines.
+	Also see https://github.com/ckeditor/ckeditor5-table/issues/50. */
+	border: 1px double hsl(0, 0%, 70%);
 
-		/* The outer border of the table should be slightly darker than the inner lines.
-		Also see https://github.com/ckeditor/ckeditor5-table/issues/50. */
-		border: 1px double hsl(0, 0%, 70%);
+	& > thead,
+	& > tbody {
+		/* stylelint-disable no-descending-specificity */
+		& > tr {
+			& > th {
+				font-weight: bold;
+				background: hsla(0, 0%, 0%, 5%);
+			}
 
-		& td,
-		& th {
-			min-width: 2em;
-			padding: .4em;
+			& > td,
+			& > th {
+				/* stylelint-enable no-descending-specificity */
+				min-width: 2em;
+				padding: .4em;
 
-			/* The border is inherited from .ck-editor__nested-editable styles, so theoretically it's not necessary here.
-			However, the border is a content style, so it should use .ck-content (so it works outside the editor).
-			Hence, the duplication. See https://github.com/ckeditor/ckeditor5/issues/6314 */
-			border: 1px solid hsl(0, 0%, 75%);
-		}
-
-		& th {
-			font-weight: bold;
-			background: hsla(0, 0%, 0%, 5%);
+				/* The border is inherited from .ck-editor__nested-editable styles, so theoretically it's not necessary here.
+				However, the border is a content style, so it should use .ck-content (so it works outside the editor).
+				Hence, the duplication. See https://github.com/ckeditor/ckeditor5/issues/6314 */
+				border: 1px solid hsl(0, 0%, 75%);
+			}
 		}
 	}
 }
@@ -54,19 +77,9 @@
  * For now, resetting the height to `initial` in the print mode works as a workaround.
  */
 @media print {
-	.ck-content .table table {
+	.ck-content figure.table > table {
 		height: initial;
 	}
-}
-
-/* Text alignment of the table header should match the editor settings and override the native browser styling,
-when content is available outside the editor. See https://github.com/ckeditor/ckeditor5/issues/6638 */
-.ck-content[dir="rtl"] .table th {
-	text-align: right;
-}
-
-.ck-content[dir="ltr"] .table th {
-	text-align: left;
 }
 
 .ck-editor__editable .ck-table-bogus-paragraph {

--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -3,63 +3,67 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-
-/* Text alignment of the table header should match the editor settings and override the native browser styling,
-when content is available outside the editor. See https://github.com/ckeditor/ckeditor5/issues/6638 */
-.ck-content[dir="rtl"] .table th {
-	text-align: right;
-}
-
-.ck-content[dir="ltr"] .table th {
-	text-align: left;
-}
-
-.ck-content figure.table:not(.layout-table) {
-	display: table;
-
-	& > table {
-		width: 100%;
-		height: 100%;
+.ck-content {
+	/* Text alignment of the table header should match the editor settings and override the native browser styling,
+	when content is available outside the editor. See https://github.com/ckeditor/ckeditor5/issues/6638 */
+	&[dir="rtl"] .table th {
+		text-align: right;
 	}
-}
 
-.ck-content figure.table:not(.layout-table),
-.ck-content table.table:not(.layout-table) {
-	/* Give the table widget some air and center it horizontally */
-	/* The first value should be equal to --ck-spacing-large variable if used in the editor context
-	to avoid the content jumping (See https://github.com/ckeditor/ckeditor5/issues/9825). */
-	margin: 0.9em auto;
-}
+	&[dir="ltr"] .table th {
+		text-align: left;
+	}
 
-.ck-content table.table:not(.layout-table),
-.ck-content figure.table:not(.layout-table) > table {
-	/* The table cells should have slight borders */
-	border-collapse: collapse;
-	border-spacing: 0;
+	& figure.table:not(.layout-table) {
+		display: table;
 
-	/* The outer border of the table should be slightly darker than the inner lines.
-	Also see https://github.com/ckeditor/ckeditor5-table/issues/50. */
-	border: 1px double hsl(0, 0%, 70%);
+		& > table {
+			width: 100%;
+			height: 100%;
+		}
+	}
 
-	& > thead,
-	& > tbody {
-		/* stylelint-disable no-descending-specificity */
-		& > tr {
-			& > th {
-				font-weight: bold;
-				background: hsla(0, 0%, 0%, 5%);
-			}
+	& figure.table:not(.layout-table),
+	& table.table:not(.layout-table) {
+		/* Give the table widget some air and center it horizontally */
+		/* The first value should be equal to --ck-spacing-large variable if used in the editor context
+		to avoid the content jumping (See https://github.com/ckeditor/ckeditor5/issues/9825). */
+		margin: 0.9em auto;
+	}
 
-			& > td,
-			& > th {
-				/* stylelint-enable no-descending-specificity */
-				min-width: 2em;
-				padding: .4em;
+	& table.table:not(.layout-table),
+	& figure.table:not(.layout-table) > table {
+		/* The table cells should have slight borders */
+		border-collapse: collapse;
+		border-spacing: 0;
 
-				/* The border is inherited from .ck-editor__nested-editable styles, so theoretically it's not necessary here.
-				However, the border is a content style, so it should use .ck-content (so it works outside the editor).
-				Hence, the duplication. See https://github.com/ckeditor/ckeditor5/issues/6314 */
-				border: 1px solid hsl(0, 0%, 75%);
+		/* The outer border of the table should be slightly darker than the inner lines.
+		Also see https://github.com/ckeditor/ckeditor5-table/issues/50. */
+		border: 1px double hsl(0, 0%, 70%);
+
+		& > thead,
+		& > tbody {
+			/* The linter is disabled here because linter is confused when resolving the `table.table:not(.layout-table)`
+			and `figure.table:not(.layout-table) > table` selectors combined with below selectors.
+			There is no need to split it into two large structures with same code just to make linter happy. */
+			/* stylelint-disable no-descending-specificity */
+			& > tr {
+				& > th {
+					font-weight: bold;
+					background: hsla(0, 0%, 0%, 5%);
+				}
+
+				& > td,
+				& > th {
+					/* stylelint-enable no-descending-specificity */
+					min-width: 2em;
+					padding: .4em;
+
+					/* The border is inherited from .ck-editor__nested-editable styles, so theoretically it's not necessary here.
+					However, the border is a content style, so it should use .ck-content (so it works outside the editor).
+					Hence, the duplication. See https://github.com/ckeditor/ckeditor5/issues/6314 */
+					border: 1px solid hsl(0, 0%, 75%);
+				}
 			}
 		}
 	}

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -25,6 +25,11 @@
 	/* To prevent text overflowing beyond its cell when columns are resized by resize handler
 	(https://github.com/ckeditor/ckeditor5/pull/14379#issuecomment-1589460978). */
 	overflow-wrap: break-word;
+}
+
+.ck.ck-editor__editable .table td,
+.ck.ck-editor__editable .table th {
+	/* The resizer element is placed inside each cell, so it must be positioned relatively to the cell. */
 	position: relative;
 }
 

--- a/packages/ckeditor5-table/theme/tablelayout.css
+++ b/packages/ckeditor5-table/theme/tablelayout.css
@@ -22,9 +22,8 @@
 	}
 
 	& .table.layout-table {
-		/* Do not reserve space above and below the layout table. */
-		margin-top: 0;
-		margin-bottom: 0;
+		display: table;
+		margin: 0;
 
 		/* Widget type around overrides. */
 		&.ck-widget {
@@ -45,5 +44,19 @@
 				visibility: hidden;
 			}
 		}
+	}
+}
+
+.ck-content {
+	& table.table.layout-table,
+	& figure.table.layout-table {
+		/* Do not reserve space above and below the layout table. */
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+
+	& table.table.layout-table,
+	& figure.table.layout-table> table {
+		border-spacing: 0;
 	}
 }

--- a/packages/ckeditor5-table/theme/tablelayout.css
+++ b/packages/ckeditor5-table/theme/tablelayout.css
@@ -56,7 +56,7 @@
 	}
 
 	& table.table.layout-table,
-	& figure.table.layout-table> table {
+	& figure.table.layout-table > table {
 		border-spacing: 0;
 	}
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
@@ -15,9 +15,7 @@
 .ck-editor__editable {
 	& .table.layout-table {
 		& > table {
-			/* Resetting the table border-collapse property to the user agent styles. */
-			border-collapse: separate;
-
+			width: 100%;
 			/* Styles to make the layout table outline visible when the layout table is inside another layout table inside edge cells.
 			Currently, this solution works on every browser except Safari. */
 			overflow: clip;
@@ -42,6 +40,7 @@
 		& > table > tbody > tr > td {
 			box-shadow: none;
 			padding: 0;
+			min-width: 2em;
 			/* To make the caret visible. */
 			text-indent: 1px;
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
@@ -38,8 +38,8 @@
 		}
 
 		& > table > tbody > tr > td {
-			box-shadow: none;
-			padding: 0;
+			box-shadow: revert;
+			padding: revert;
 			min-width: 2em;
 			/* To make the caret visible. */
 			text-indent: 1px;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix(table): Improved CSS scoping for table wrapped and not wrapped with `<figure>`. Closes #18169.

---

### Additional information

_These changes introduce a more refined approach to styling figure wrappers for tables and defining styles when a table does not have a wrapper. This enhancement is particularly useful when utilizing the PlainTableOutput plugin. Additionally, an adjustment has been made to ensure that styles apply only to the direct children of a table, preventing any unintended impact on nested tables._
