### PR TITLE
Set equal column width while creating layout tables.

### DIFF
--- a/packages/ckeditor5-table/src/commands/inserttablelayoutcommand.ts
+++ b/packages/ckeditor5-table/src/commands/inserttablelayoutcommand.ts
@@ -74,7 +74,7 @@ export default class InsertTableLayoutCommand extends Command {
 			const columnWidths = Array( normalizedOptions.columns ).fill( singleColumnWidth );
 			const tableWidthsCommand: TableWidthsCommand = editor.commands.get( 'resizeColumnWidths' )!;
 
-			// Make the table full-width with equal columns.
+			// Make the table full-width with equal columns width.
 			tableWidthsCommand.execute( { tableWidth: '100%', columnWidths, table } );
 
 			writer.setSelection( writer.createPositionAt( table.getNodeByPath( [ 0, 0, 0 ] ), 0 ) );

--- a/packages/ckeditor5-table/src/commands/inserttablelayoutcommand.ts
+++ b/packages/ckeditor5-table/src/commands/inserttablelayoutcommand.ts
@@ -17,6 +17,7 @@ import type {
 } from 'ckeditor5/src/engine.js';
 
 import type TableUtils from '../tableutils.js';
+import type TableWidthsCommand from '../../src/tablecolumnresize/tablewidthscommand.js';
 
 /**
  * The insert table layout command.
@@ -62,13 +63,19 @@ export default class InsertTableLayoutCommand extends Command {
 		const tableUtils: TableUtils = editor.plugins.get( 'TableUtils' );
 
 		model.change( writer => {
-			const normalizedOptions = { rows: options.rows, columns: options.columns };
+			const normalizedOptions = { rows: options.rows || 2, columns: options.columns || 2 };
 			const table = tableUtils.createTable( writer, normalizedOptions );
 
-			writer.setAttribute( 'tableWidth', '100%', table );
 			writer.setAttribute( 'tableType', 'layout', table );
 
 			model.insertObject( table, null, null, { findOptimalPosition: 'auto' } );
+
+			const singleColumnWidth = `${ 100 / normalizedOptions.columns! }%`;
+			const columnWidths = Array( normalizedOptions.columns ).fill( singleColumnWidth );
+			const tableWidthsCommand: TableWidthsCommand = editor.commands.get( 'resizeColumnWidths' )!;
+
+			// Make the table full-width with equal columns.
+			tableWidthsCommand.execute( { tableWidth: '100%', columnWidths, table } );
 
 			writer.setSelection( writer.createPositionAt( table.getNodeByPath( [ 0, 0, 0 ] ), 0 ) );
 		} );

--- a/packages/ckeditor5-table/tests/commands/inserttablelayoutcommand.js
+++ b/packages/ckeditor5-table/tests/commands/inserttablelayoutcommand.js
@@ -21,7 +21,7 @@ describe( 'InsertTableLayoutCommand', () => {
 	beforeEach( () => {
 		return ModelTestEditor
 			.create( {
-				plugins: [ Paragraph, TableEditing, TableCaptionEditing, TableLayoutEditing ]
+				plugins: [ Paragraph, TableEditing, TableCaptionEditing, TableLayoutEditing, TableColumnResize ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;
@@ -107,7 +107,7 @@ describe( 'InsertTableLayoutCommand', () => {
 						[ '[]', '' ],
 						[ '', '' ]
 					],
-					{ tableType: 'layout' } )
+					{ tableType: 'layout', tableWidth: '100%', columnWidths: '50%,50%' } )
 				);
 			} );
 
@@ -122,7 +122,7 @@ describe( 'InsertTableLayoutCommand', () => {
 						[ '[]', '' ],
 						[ '', '' ]
 					],
-					{ tableType: 'layout' } )
+					{ tableType: 'layout', tableWidth: '100%', columnWidths: '50%,50%' } )
 				);
 			} );
 
@@ -138,7 +138,7 @@ describe( 'InsertTableLayoutCommand', () => {
 						[ '', '', '', '' ],
 						[ '', '', '', '' ]
 					],
-					{ tableType: 'layout' } )
+					{ tableType: 'layout', tableWidth: '100%', columnWidths: '25%,25%,25%,25%' } )
 				);
 			} );
 
@@ -153,7 +153,7 @@ describe( 'InsertTableLayoutCommand', () => {
 						[ '[]', '', '', '' ],
 						[ '', '', '', '' ],
 						[ '', '', '', '' ]
-					], { tableType: 'layout' } )
+					], { tableType: 'layout', tableWidth: '100%', columnWidths: '25%,25%,25%,25%' } )
 				);
 			} );
 
@@ -167,7 +167,7 @@ describe( 'InsertTableLayoutCommand', () => {
 						[ '[]', '' ],
 						[ '', '' ]
 					],
-					{ tableType: 'layout' } ) +
+					{ tableType: 'layout', tableWidth: '100%', columnWidths: '50%,50%' } ) +
 					'<paragraph>foo</paragraph>'
 				);
 			} );
@@ -183,7 +183,7 @@ describe( 'InsertTableLayoutCommand', () => {
 						[ '', '', '', '' ],
 						[ '', '', '', '' ]
 					],
-					{ tableType: 'layout' } )
+					{ tableType: 'layout', tableWidth: '100%', columnWidths: '25%,25%,25%,25%' } )
 				);
 			} );
 		} );
@@ -199,7 +199,7 @@ describe( 'InsertTableLayoutCommand', () => {
 
 				expect( getData( model ) ).to.equal(
 					'<paragraph>foo</paragraph>' + modelTable( [ [ '[]', '' ] ],
-						{ tableType: 'layout' } ) + '<paragraph>bar</paragraph>'
+						{ tableType: 'layout', tableWidth: '100%', columnWidths: '50%,50%' } ) + '<paragraph>bar</paragraph>'
 				);
 			} );
 
@@ -210,7 +210,7 @@ describe( 'InsertTableLayoutCommand', () => {
 
 				expect( getData( model ) ).to.equal(
 					'<paragraph>foo</paragraph>' + modelTable( [ [ '[]', '' ] ],
-						{ tableType: 'layout' } ) + '<paragraph>bar</paragraph>'
+						{ tableType: 'layout', tableWidth: '100%', columnWidths: '50%,50%' } ) + '<paragraph>bar</paragraph>'
 				);
 			} );
 		} );
@@ -245,7 +245,7 @@ describe( 'InsertTableLayoutCommand', () => {
 							[ '[]', '' ],
 							[ '', '' ]
 						],
-						{ tableType: 'layout', tableWidth: '100%' } )
+						{ tableType: 'layout', tableWidth: '100%', columnWidths: '50%,50%' } )
 					);
 				} );
 
@@ -260,7 +260,7 @@ describe( 'InsertTableLayoutCommand', () => {
 							[ '[]', '' ],
 							[ '', '' ]
 						],
-						{ tableType: 'layout', tableWidth: '100%' } )
+						{ tableType: 'layout', tableWidth: '100%', columnWidths: '50%,50%' } )
 					);
 				} );
 
@@ -276,7 +276,7 @@ describe( 'InsertTableLayoutCommand', () => {
 							[ '', '', '', '' ],
 							[ '', '', '', '' ]
 						],
-						{ tableType: 'layout', tableWidth: '100%' } )
+						{ tableType: 'layout', tableWidth: '100%', columnWidths: '25%,25%,25%,25%' } )
 					);
 				} );
 
@@ -292,7 +292,7 @@ describe( 'InsertTableLayoutCommand', () => {
 							[ '', '', '', '' ],
 							[ '', '', '', '' ]
 						],
-						{ tableType: 'layout', tableWidth: '100%' } )
+						{ tableType: 'layout', tableWidth: '100%', columnWidths: '25%,25%,25%,25%' } )
 					);
 				} );
 
@@ -306,7 +306,7 @@ describe( 'InsertTableLayoutCommand', () => {
 							[ '[]', '' ],
 							[ '', '' ]
 						],
-						{ tableType: 'layout', tableWidth: '100%' } ) +
+						{ tableType: 'layout', tableWidth: '100%', columnWidths: '50%,50%' } ) +
 						'<paragraph>foo</paragraph>'
 					);
 				} );
@@ -322,7 +322,7 @@ describe( 'InsertTableLayoutCommand', () => {
 							[ '', '', '', '' ],
 							[ '', '', '', '' ]
 						],
-						{ tableType: 'layout', tableWidth: '100%' } )
+						{ tableType: 'layout', tableWidth: '100%', columnWidths: '25%,25%,25%,25%' } )
 					);
 				} );
 			} );
@@ -338,7 +338,7 @@ describe( 'InsertTableLayoutCommand', () => {
 
 					expect( getData( model ) ).to.equal(
 						'<paragraph>foo</paragraph>' + modelTable( [ [ '[]', '' ] ],
-							{ tableType: 'layout', tableWidth: '100%' } ) + '<paragraph>bar</paragraph>'
+							{ tableType: 'layout', tableWidth: '100%', columnWidths: '50%,50%' } ) + '<paragraph>bar</paragraph>'
 					);
 				} );
 
@@ -351,7 +351,7 @@ describe( 'InsertTableLayoutCommand', () => {
 
 					expect( getData( model ) ).to.equal(
 						'<paragraph>foo</paragraph>' + modelTable( [ [ '[]', '' ] ],
-							{ tableType: 'layout', tableWidth: '100%' } ) + '<paragraph>bar</paragraph>'
+							{ tableType: 'layout', tableWidth: '100%', columnWidths: '50%,50%' } ) + '<paragraph>bar</paragraph>'
 					);
 				} );
 			} );
@@ -361,7 +361,7 @@ describe( 'InsertTableLayoutCommand', () => {
 			it( 'should not have first row as a heading by default', async () => {
 				const editor = await ModelTestEditor
 					.create( {
-						plugins: [ Paragraph, TableEditing ],
+						plugins: [ Paragraph, TableEditing, TableColumnResize ],
 						table: {
 							defaultHeadings: { rows: 1 }
 						}
@@ -378,7 +378,7 @@ describe( 'InsertTableLayoutCommand', () => {
 					modelTable( [
 						[ '[]', '', '' ],
 						[ '', '', '' ]
-					] )
+					], { tableWidth: '100%', columnWidths: '33.33%,33.33%,33.34%' } )
 				);
 
 				await editor.destroy();
@@ -387,7 +387,7 @@ describe( 'InsertTableLayoutCommand', () => {
 			it( 'should not have first column as a heading by default', async () => {
 				const editor = await ModelTestEditor
 					.create( {
-						plugins: [ Paragraph, TableEditing ],
+						plugins: [ Paragraph, TableEditing, TableColumnResize ],
 						table: {
 							defaultHeadings: { columns: 1 }
 						}
@@ -404,7 +404,7 @@ describe( 'InsertTableLayoutCommand', () => {
 					modelTable( [
 						[ '[]', '', '' ],
 						[ '', '', '' ]
-					] )
+					], { tableWidth: '100%', columnWidths: '33.33%,33.33%,33.34%' } )
 				);
 
 				await editor.destroy();
@@ -413,7 +413,7 @@ describe( 'InsertTableLayoutCommand', () => {
 			it( 'should not have first row and first column as a heading by default', async () => {
 				const editor = await ModelTestEditor
 					.create( {
-						plugins: [ Paragraph, TableEditing ],
+						plugins: [ Paragraph, TableEditing, TableColumnResize ],
 						table: {
 							defaultHeadings: { rows: 1, columns: 1 }
 						}
@@ -431,7 +431,7 @@ describe( 'InsertTableLayoutCommand', () => {
 						[ '[]', '', '' ],
 						[ '', '', '' ],
 						[ '', '', '' ]
-					] )
+					], { tableWidth: '100%', columnWidths: '33.33%,33.33%,33.34%' } )
 				);
 
 				await editor.destroy();
@@ -440,7 +440,7 @@ describe( 'InsertTableLayoutCommand', () => {
 			it( 'should not have first three rows and two columns as a heading by default', async () => {
 				const editor = await ModelTestEditor
 					.create( {
-						plugins: [ Paragraph, TableEditing ],
+						plugins: [ Paragraph, TableEditing, TableColumnResize ],
 						table: {
 							defaultHeadings: { rows: 3, columns: 2 }
 						}
@@ -459,7 +459,7 @@ describe( 'InsertTableLayoutCommand', () => {
 						[ '', '', '' ],
 						[ '', '', '' ],
 						[ '', '', '' ]
-					] )
+					], { tableWidth: '100%', columnWidths: '33.33%,33.33%,33.34%' } )
 				);
 
 				await editor.destroy();
@@ -468,7 +468,7 @@ describe( 'InsertTableLayoutCommand', () => {
 			it( 'should not have auto headings not to be greater than table rows and columns', async () => {
 				const editor = await ModelTestEditor
 					.create( {
-						plugins: [ Paragraph, TableEditing ],
+						plugins: [ Paragraph, TableEditing, TableColumnResize ],
 						table: {
 							defaultHeadings: { rows: 3, columns: 3 }
 						}
@@ -485,7 +485,7 @@ describe( 'InsertTableLayoutCommand', () => {
 					modelTable( [
 						[ '[]', '' ],
 						[ '', '' ]
-					] )
+					], { tableWidth: '100%', columnWidths: '50%,50%' } )
 				);
 
 				await editor.destroy();
@@ -499,7 +499,7 @@ describe( 'InsertTableLayoutCommand', () => {
 			beforeEach( async () => {
 				editor = await ModelTestEditor
 					.create( {
-						plugins: [ Paragraph, TableEditing ],
+						plugins: [ Paragraph, TableEditing, TableColumnResize ],
 						table: {
 							defaultHeadings: { rows: 1 }
 						}
@@ -538,7 +538,7 @@ describe( 'InsertTableLayoutCommand', () => {
 					modelTable( [
 						[ '[]', '' ],
 						[ '', '' ]
-					], { pretty: true, smart: true } )
+					], { pretty: true, smart: true, tableWidth: '100%', columnWidths: '50%,50%' } )
 				);
 			} );
 
@@ -551,7 +551,7 @@ describe( 'InsertTableLayoutCommand', () => {
 					modelTable( [
 						[ '[]', '' ],
 						[ '', '' ]
-					], { pretty: true } ) +
+					], { pretty: true, tableWidth: '100%', columnWidths: '50%,50%' } ) +
 					'<paragraph pretty="true">foo</paragraph>' +
 					'<paragraph smart="true">bar</paragraph>'
 				);
@@ -566,7 +566,7 @@ describe( 'InsertTableLayoutCommand', () => {
 					modelTable( [
 						[ '[]', '' ],
 						[ '', '' ]
-					], { pretty: true, smart: true } )
+					], { pretty: true, smart: true, tableWidth: '100%', columnWidths: '50%,50%' } )
 				);
 			} );
 
@@ -582,7 +582,7 @@ describe( 'InsertTableLayoutCommand', () => {
 					modelTable( [
 						[ '[]', '' ],
 						[ '', '' ]
-					], { pretty: true, smart: true } )
+					], { pretty: true, smart: true, tableWidth: '100%', columnWidths: '50%,50%' } )
 				);
 			} );
 		} );

--- a/packages/ckeditor5-table/tests/tablelayout/tablelayoutui.js
+++ b/packages/ckeditor5-table/tests/tablelayout/tablelayoutui.js
@@ -12,6 +12,7 @@ import { ListItemView } from '@ckeditor/ckeditor5-ui';
 import TableEditing from '../../src/tableediting.js';
 import TableLayoutUI from '../../src/tablelayout/tablelayoutui.js';
 import TableLayoutEditing from '../../src/tablelayout/tablelayoutediting.js';
+import TableColumnResize from '../../src/tablecolumnresize.js';
 import InsertTableView from '../../src/ui/inserttableview.js';
 import DropdownView from '@ckeditor/ckeditor5-ui/src/dropdown/dropdownview.js';
 import { IconTableLayout, IconTableProperties } from '@ckeditor/ckeditor5-icons';
@@ -31,7 +32,7 @@ describe( 'TableLayoutUI', () => {
 
 		return ClassicTestEditor
 			.create( element, {
-				plugins: [ TableEditing, TableLayoutUI, TableLayoutEditing ]
+				plugins: [ TableEditing, TableLayoutUI, TableLayoutEditing, TableColumnResize ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Should make the layout table full-width with equal columns width while creating. See #18132.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
