### PR TITLE
Added missing converterPriority type definition to HeadingOption interface

### DIFF
--- a/packages/ckeditor5-heading/src/headingconfig.ts
+++ b/packages/ckeditor5-heading/src/headingconfig.ts
@@ -106,6 +106,11 @@ export interface HeadingElementOption {
 	 * An array with all matched elements that the view-to-model conversion should also accept.
 	 */
 	upcastAlso?: ArrayOrItem<ViewElementDefinition | MatcherPattern>;
+
+	/**
+	 * The priority with which the converter will be run. Possible values: 'low', 'normal', 'high'.
+	 */
+	converterPriority?: 'low' | 'normal' | 'high';
 }
 
 export interface HeadingParagraphOption {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (heading): Added missing `converterPriority` type definition to `HeadingOption` interface. Closes #18182.

---

### Additional information

_The test in_ [_https://github.com/ckeditor/ckeditor5/blob/6fc725f9264aa4e279d13862e9dea2a1a110755e/packages/ckeditor5-heading/tests/integration.js#L126-L146_](https://github.com/ckeditor/ckeditor5/blob/6fc725f9264aa4e279d13862e9dea2a1a110755e/packages/ckeditor5-heading/tests/integration.js#L126-L146) _covers this property._