### PR TITLE
Remove `role=textbox` from `td` / `th` cell editables.

### DIFF
--- a/packages/ckeditor5-table/src/converters/downcast.ts
+++ b/packages/ckeditor5-table/src/converters/downcast.ts
@@ -112,7 +112,7 @@ export function downcastCell( options: { asWidget?: boolean } = {} ): ElementCre
 				const cellElementName = isHeading ? 'th' : 'td';
 
 				result = options.asWidget ?
-					toWidgetEditable( writer.createEditableElement( cellElementName ), writer ) :
+					toWidgetEditable( writer.createEditableElement( cellElementName ), writer, { withAriaRole: false } ) :
 					writer.createContainerElement( cellElementName );
 				break;
 			}

--- a/packages/ckeditor5-table/tests/_utils/utils.js
+++ b/packages/ckeditor5-table/tests/_utils/utils.js
@@ -379,7 +379,6 @@ function makeRows( tableData, options ) {
 				if ( asWidget ) {
 					attributes.class = getClassToSet( attributes );
 					attributes.contenteditable = 'true';
-					attributes.role = 'textbox';
 					attributes.tabindex = '-1';
 				}
 

--- a/packages/ckeditor5-table/tests/converters/downcast.js
+++ b/packages/ckeditor5-table/tests/converters/downcast.js
@@ -43,7 +43,7 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph"></span>' +
 									'</td>' +
@@ -66,13 +66,13 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</td>' +
 								'</tr>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">10</span>' +
 									'</td>' +
@@ -99,7 +99,7 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<thead>' +
 								'<tr>' +
-									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</th>' +
@@ -107,7 +107,7 @@ describe( 'downcast converters', () => {
 							'</thead>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">10</span>' +
 									'</td>' +
@@ -824,13 +824,13 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</td>' +
 								'</tr>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph"></span>' +
 									'</td>' +
@@ -859,11 +859,11 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</td>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">01</span>' +
 									'</td>' +
@@ -892,11 +892,11 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">10</span>' +
 									'</td>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">11</span>' +
 									'</td>' +
@@ -927,11 +927,11 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<thead>' +
 								'<tr>' +
-									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">10</span>' +
 									'</th>' +
-									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">11</span>' +
 									'</th>' +
@@ -962,11 +962,11 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<thead>' +
 								'<tr>' +
-									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</th>' +
-									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">01</span>' +
 									'</th>' +
@@ -999,25 +999,25 @@ describe( 'downcast converters', () => {
 							'<tbody>' +
 								'<tr>' +
 									'<td class="ck-editor__editable ck-editor__nested-editable" ' +
-											'colspan="2" contenteditable="true" role="textbox" ' +
+											'colspan="2" contenteditable="true" ' +
 											'rowspan="2" tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">10</span>' +
 									'</td>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">12</span>' +
 									'</td>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">13</span>' +
 									'</td>' +
 								'</tr>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">22</span>' +
 									'</td>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">23</span>' +
 									'</td>' +
@@ -1048,11 +1048,11 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">10</span>' +
 									'</td>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">11</span>' +
 									'</td>' +
@@ -1081,11 +1081,11 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<thead>' +
 								'<tr>' +
-									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</th>' +
-									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">01</span>' +
 									'</th>' +
@@ -1215,11 +1215,11 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</td>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph"></span>' +
 									'</td>' +
@@ -1326,7 +1326,8 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
+									'role="textbox" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</td>' +
@@ -1406,7 +1407,7 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<thead>' +
 								'<tr>' +
-									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</th>' +
@@ -1694,7 +1695,7 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</th>' +
@@ -1768,7 +1769,6 @@ describe( 'downcast converters', () => {
 							'<tbody>' +
 								'<tr>' +
 									'<td class="ck-editor__editable ck-editor__nested-editable highlight-yellow" contenteditable="true" ' +
-										'role="textbox" ' +
 										'tabindex="-1">' +
 											'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</td>' +
@@ -1788,7 +1788,7 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</td>' +
@@ -1826,14 +1826,13 @@ describe( 'downcast converters', () => {
 					'<table>' +
 						'<tbody>' +
 							'<tr>' +
-								'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+								'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 								'tabindex="-1">' +
 									'<span class="ck-table-bogus-paragraph">00</span>' +
 								'</td>' +
 							'</tr>' +
 							'<tr>' +
 								'<td class="ck-editor__editable ck-editor__nested-editable highlight-yellow" contenteditable="true" ' +
-									'role="textbox" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph"></span>' +
 								'</td>' +
@@ -1853,13 +1852,13 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</td>' +
 								'</tr>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph"></span>' +
 									'</td>' +
@@ -1895,12 +1894,11 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</td>' +
 									'<td class="ck-editor__editable ck-editor__nested-editable highlight-yellow" contenteditable="true" ' +
-										'role="textbox" ' +
 										'tabindex="-1">' +
 											'<span class="ck-table-bogus-paragraph"></span>' +
 									'</td>' +
@@ -1920,11 +1918,11 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</td>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph"></span>' +
 									'</td>' +
@@ -2037,7 +2035,7 @@ describe( 'downcast converters', () => {
 							'<tbody>' +
 								'<tr>' +
 									'<td class="ck-editor__editable ck-editor__nested-editable highlight-yellow marker user-marker"' +
-										' contenteditable="true" role="textbox" ' +
+										' contenteditable="true" ' +
 										'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</td>' +
@@ -2057,7 +2055,7 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</td>' +
@@ -2101,7 +2099,7 @@ describe( 'downcast converters', () => {
 							'<tbody>' +
 								'<tr>' +
 									'<td class="ck-editor__editable ck-editor__nested-editable highlight-yellow"' +
-										' contenteditable="true" data-abc="xyz" data-foo="bar" role="textbox" ' +
+										' contenteditable="true" data-abc="xyz" data-foo="bar" ' +
 										'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</td>' +
@@ -2121,7 +2119,7 @@ describe( 'downcast converters', () => {
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox" ' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
 									'tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">00</span>' +
 									'</td>' +

--- a/packages/ckeditor5-table/tests/tablecaption/tablecaptionediting.js
+++ b/packages/ckeditor5-table/tests/tablecaption/tablecaptionediting.js
@@ -309,7 +309,7 @@ describe( 'TableCaptionEditing', () => {
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
-									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" role="textbox"' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true"' +
 										' tabindex="-1">' +
 										'<span class="ck-table-bogus-paragraph">xyz</span>' +
 									'</td>' +

--- a/packages/ckeditor5-widget/src/utils.ts
+++ b/packages/ckeditor5-widget/src/utils.ts
@@ -243,6 +243,7 @@ export function getLabel( element: ViewElement ): string {
  * * adds the `ck-editor__editable` and `ck-editor__nested-editable` CSS classes,
  * * adds the `ck-editor__nested-editable_focused` CSS class when the editable is focused and removes it when it is blurred.
  * * implements the {@link ~setHighlightHandling view highlight on widget's editable}.
+ * * sets the `role` attribute to `textbox` for accessibility purposes.
  *
  * Similarly to {@link ~toWidget `toWidget()`} this function should be used in `editingDowncast` only and it is usually
  * used together with {@link module:engine/conversion/downcasthelpers~DowncastHelpers#elementToElement `elementToElement()`}.
@@ -275,6 +276,7 @@ export function getLabel( element: ViewElement ): string {
  *
  * @param options Additional options.
  * @param options.label Editable's label used by assistive technologies (e.g. screen readers).
+ * @param options.withAriaRole Whether to add the role="textbox" attribute on the editable. Defaults to `true`.
  * @returns Returns the same element that was provided in the `editable` parameter
  */
 export function toWidgetEditable(
@@ -282,11 +284,16 @@ export function toWidgetEditable(
 	writer: DowncastWriter,
 	options: {
 		label?: string;
+		withAriaRole?: boolean;
 	} = {}
 ): ViewEditableElement {
 	writer.addClass( [ 'ck-editor__editable', 'ck-editor__nested-editable' ], editable );
 
-	writer.setAttribute( 'role', 'textbox', editable );
+	// Set role="textbox" only if explicitly requested (defaults to true for backward compatibility)
+	if ( options.withAriaRole !== false ) {
+		writer.setAttribute( 'role', 'textbox', editable );
+	}
+
 	writer.setAttribute( 'tabindex', '-1', editable );
 
 	if ( options.label ) {

--- a/packages/ckeditor5-widget/tests/utils.js
+++ b/packages/ckeditor5-widget/tests/utils.js
@@ -240,6 +240,27 @@ describe( 'widget utils', () => {
 			expect( element.getAttribute( 'tabindex' ) ).to.equal( '-1' );
 		} );
 
+		it( 'should add role attribute by default for backward compatibility', () => {
+			const element = new ViewEditableElement( viewDocument, 'div' );
+			toWidgetEditable( element, writer );
+
+			expect( element.getAttribute( 'role' ) ).to.equal( 'textbox' );
+		} );
+
+		it( 'should add role attribute when withAriaRole is set to true', () => {
+			const element = new ViewEditableElement( viewDocument, 'div' );
+			toWidgetEditable( element, writer, { withAriaRole: true } );
+
+			expect( element.getAttribute( 'role' ) ).to.equal( 'textbox' );
+		} );
+
+		it( 'should not add role attribute when withAriaRole is set to false', () => {
+			const element = new ViewEditableElement( viewDocument, 'div' );
+			toWidgetEditable( element, writer, { withAriaRole: false } );
+
+			expect( element.hasAttribute( 'role' ) ).to.be.false;
+		} );
+
 		it( 'should add label if it was passed through options', () => {
 			toWidgetEditable( element, writer, { label: 'foo' } );
 			expect( element.getAttribute( 'aria-label' ) ).to.equal( 'foo' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (table): Removed `role: textbox` from `td` / `th` in editables. Windows Narrator no longer reads table dimensions as 0 by 0.  Closes https://github.com/ckeditor/ckeditor5/issues/16923

---

### Additional information

Testing summary: https://github.com/ckeditor/ckeditor5/issues/16923#issuecomment-2733427130

> As removing role=textbox doesn't degrade the experience in most screen readers, but rather improves it (with table dimensions appearing in NVDA, Narrator, JAWS) we decided to implement this solution.
