### PR TITLE
Remove `role=textbox` from editing downcast layout tables tests.

### DIFF
--- a/packages/ckeditor5-table/tests/tablelayout/tablelayoutediting.js
+++ b/packages/ckeditor5-table/tests/tablelayout/tablelayoutediting.js
@@ -170,7 +170,7 @@ describe( 'TableLayoutEditing', () => {
 						'<tbody>' +
 							'<tr>' +
 								'<td class="ck-editor__editable ck-editor__nested-editable" ' +
-									'contenteditable="true" role="textbox" tabindex="-1">' +
+									'contenteditable="true" tabindex="-1">' +
 									'<span class="ck-table-bogus-paragraph">foo</span>' +
 									'<div class="ck-table-column-resizer"></div>' +
 								'</td>' +
@@ -201,7 +201,7 @@ describe( 'TableLayoutEditing', () => {
 						'<tbody>' +
 							'<tr>' +
 								'<td class="ck-editor__editable ck-editor__nested-editable" ' +
-									'contenteditable="true" role="textbox" tabindex="-1">' +
+									'contenteditable="true" tabindex="-1">' +
 									'<span class="ck-table-bogus-paragraph">foo</span>' +
 									'<div class="ck-table-column-resizer"></div>' +
 								'</td>' +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (table): Remove `role=textbox` from editing downcast layout tables tests.