### PR TITLE
Added localhost to known domains in the Autolink feature

### DIFF
--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -48,6 +48,9 @@ const URL_REG_EXP = new RegExp(
 					// TLD identifier name.
 					'(?:[a-z\\u00a1-\\uffff]{2,63})' +
 				')' +
+				'|' +
+				// Allow localhost as a valid hostname
+				'localhost' +
 			')' +
 			// port number (optional)
 			'(?::\\d{2,5})?' +

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -516,7 +516,9 @@ describe( 'AutoLink', () => {
 				'http://127.0.0.1:8080/ckeditor5/latest/features/link.html',
 				'http://192.168.43.58/ckeditor5/latest/features/link.html',
 				'http://83.127.13.40',
-				'http://userid@83.127.13.40'
+				'http://userid@83.127.13.40',
+				'http://localhost',
+				'http://localhost:8080'
 			];
 
 			for ( const supportedURL of supportedURLs ) {
@@ -553,7 +555,6 @@ describe( 'AutoLink', () => {
 				':// foo bar',
 				'ftps://foo.bar/',
 				'http://-error-.invalid/',
-				'http://localhost',
 				'http:/cksource.com',
 				'http://www.cksource', // https://github.com/ckeditor/ckeditor5/issues/8050.
 				'cksource.com',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (link): The Autolink feature will now correctly autolink `http://localhost` and `http://localhost:port`. Closes #18185

---

### Additional information

The fact that localhost wasn't handled was an explicit decision, but I don't understand it. It's a known domain, present on all OSes. The only one of this kind, so special treatment makes sense.

Some more context (dunno if it opens for others, I can paste here if not):

* https://chatgpt.com/share/e/67e1daba-87d4-8001-aac4-bcded82d2402
