### PR TITLE
Separate table and table cell properties view instances for separate defaults

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.ts
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.ts
@@ -330,7 +330,8 @@ export default class UpcastHelpers extends ConversionHelpers<UpcastDispatcher> {
 		};
 		model: string | {
 			key: string;
-			value: unknown | ( ( viewElement: ViewElement, conversionApi: UpcastConversionApi ) => unknown );
+			value: unknown |
+				( ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => unknown );
 			name?: string;
 		};
 		converterPriority?: PriorityString;
@@ -685,7 +686,8 @@ function upcastAttributeToAttribute( config: {
 	};
 	model: string | {
 		key: string;
-		value: unknown | ( ( viewElement: ViewElement, conversionApi: UpcastConversionApi ) => unknown );
+		value: unknown |
+			( ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => unknown );
 	};
 	converterPriority?: PriorityString;
 } ) {
@@ -1067,7 +1069,7 @@ function prepareToAttributeConverter(
 
 		const modelKey = config.model.key;
 		const modelValue: unknown = typeof config.model.value == 'function' ?
-			config.model.value( data.viewItem, conversionApi ) : config.model.value;
+			config.model.value( data.viewItem, conversionApi, data ) : config.model.value;
 
 		// Do not convert if attribute building function returned falsy value.
 		if ( modelValue === null ) {

--- a/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
@@ -251,12 +251,17 @@ describe( 'UpcastHelpers', () => {
 				},
 				model: {
 					key: 'fontSize',
-					value: ( viewElement, conversionApi ) => {
+					value: ( viewElement, conversionApi, data ) => {
 						const fontSize = viewElement.getStyle( 'font-size' );
 						const value = fontSize.substr( 0, fontSize.length - 2 );
 
 						// To ensure conversion API is provided.
 						expect( conversionApi.writer ).to.instanceof( Writer );
+
+						// To ensure upcast conversion data is provided.
+						expect( data.modelCursor ).to.be.instanceof( ModelPosition );
+						expect( data.viewItem ).to.equal( viewElement );
+						expect( data.modelRange ).to.be.null;
 
 						if ( value <= 10 ) {
 							return 'small';
@@ -708,12 +713,19 @@ describe( 'UpcastHelpers', () => {
 				},
 				model: {
 					key: 'styled',
-					value: ( viewElement, conversionApi ) => {
+					value: ( viewElement, conversionApi, data ) => {
 						const regexp = /styled-([\S]+)/;
 						const match = viewElement.getAttribute( 'class' ).match( regexp );
 
 						// To ensure conversion API is provided.
 						expect( conversionApi.writer ).to.instanceof( Writer );
+
+						// To ensure upcast conversion data is provided.
+						expect( data.modelCursor ).to.be.instanceof( ModelPosition );
+						expect( data.viewItem ).to.equal( viewElement );
+						expect( data.modelRange ).to.be.instanceOf( ModelRange );
+						expect( data.modelRange.start.path ).to.be.deep.equal( [ 0 ] );
+						expect( data.modelRange.end.path ).to.be.deep.equal( [ 1 ] );
 
 						return match[ 1 ];
 					}

--- a/packages/ckeditor5-table/src/converters/tableproperties.ts
+++ b/packages/ckeditor5-table/src/converters/tableproperties.ts
@@ -7,7 +7,8 @@
  * @module table/converters/tableproperties
  */
 
-import type { Conversion, ViewElement } from 'ckeditor5/src/engine.js';
+import type { Conversion, UpcastConversionApi, UpcastConversionData, ViewElement } from 'ckeditor5/src/engine.js';
+import { first } from 'ckeditor5/src/utils.js';
 
 /**
  * Conversion helper for upcasting attributes using normalized styles.
@@ -47,15 +48,28 @@ export function upcastStyleToAttribute(
 		},
 		model: {
 			key: modelAttribute,
-			value: ( viewElement: ViewElement ) => {
+			value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
 				if ( !shouldUpcast( viewElement ) ) {
 					return;
+				}
+
+				let localDefaultValue = defaultValue;
+
+				// Adjust default for layout tables.
+				if ( data.modelRange ) {
+					const modelElement = first( data.modelRange.getItems( { shallow: true } ) );
+					const tableElement = modelElement && modelElement.is( 'element' ) &&
+						modelElement.findAncestor( 'table', { includeSelf: true } );
+
+					if ( tableElement && tableElement.getAttribute( 'tableType' ) == 'layout' ) {
+						localDefaultValue = '';
+					}
 				}
 
 				const normalized = viewElement.getNormalizedStyle( styleName ) as Record<Side, string>;
 				const value = reduceBoxSides ? reduceBoxSidesValue( normalized ) : normalized;
 
-				if ( defaultValue !== value ) {
+				if ( localDefaultValue !== value ) {
 					return value;
 				}
 			}
@@ -121,6 +135,17 @@ export function upcastBorderStyles(
 		}
 
 		const modelElement = [ ...data.modelRange.getItems( { shallow: true } ) ].pop();
+		const tableElement = modelElement.findAncestor( 'table', { includeSelf: true } );
+
+		let localDefaultBorder = defaultBorder;
+
+		if ( tableElement && tableElement.getAttribute( 'tableType' ) == 'layout' ) {
+			localDefaultBorder = {
+				style: 'none',
+				color: '',
+				width: ''
+			};
+		}
 
 		conversionApi.consumable.consume( data.viewItem, matcherPattern );
 
@@ -136,15 +161,15 @@ export function upcastBorderStyles(
 			width: reduceBoxSidesValue( normalizedBorder.width )
 		};
 
-		if ( reducedBorder.style !== defaultBorder.style ) {
+		if ( reducedBorder.style !== localDefaultBorder.style ) {
 			conversionApi.writer.setAttribute( modelAttributes.style, reducedBorder.style, modelElement );
 		}
 
-		if ( reducedBorder.color !== defaultBorder.color ) {
+		if ( reducedBorder.color !== localDefaultBorder.color ) {
 			conversionApi.writer.setAttribute( modelAttributes.color, reducedBorder.color, modelElement );
 		}
 
-		if ( reducedBorder.width !== defaultBorder.width ) {
+		if ( reducedBorder.width !== localDefaultBorder.width ) {
 			conversionApi.writer.setAttribute( modelAttributes.width, reducedBorder.width, modelElement );
 		}
 	} ) );

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellpropertycommand.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellpropertycommand.ts
@@ -52,7 +52,24 @@ export default class TableCellPropertyCommand extends Command {
 
 		this.attributeName = attributeName;
 		this._defaultContentTableValue = defaultValue;
-		this._defaultLayoutTableValue = attributeName === 'tableCellBorderStyle' ? 'none' : undefined;
+
+		// Hardcoded defaults for layout table.
+		switch ( attributeName ) {
+			case 'tableCellBorderStyle':
+				this._defaultLayoutTableValue = 'none';
+				break;
+
+			case 'tableCellHorizontalAlignment':
+				this._defaultLayoutTableValue = 'left';
+				break;
+
+			case 'tableCellVerticalAlignment':
+				this._defaultLayoutTableValue = 'middle';
+				break;
+
+			default:
+				this._defaultLayoutTableValue = undefined;
+		}
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellpropertycommand.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellpropertycommand.ts
@@ -10,6 +10,7 @@
 import { Command, type Editor } from 'ckeditor5/src/core.js';
 import type { Element, Batch } from 'ckeditor5/src/engine.js';
 import type TableUtils from '../../tableutils.js';
+import { getSelectionAffectedTable } from '../../utils/common.js';
 
 /**
  * The table cell attribute command.
@@ -24,8 +25,20 @@ export default class TableCellPropertyCommand extends Command {
 
 	/**
 	 * The default value for the attribute.
+	 *
+	 * @readonly
 	 */
-	protected readonly _defaultValue: string;
+	protected _defaultValue: string | undefined;
+
+	/**
+	 * The default value for the attribute for the content table.
+	 */
+	private readonly _defaultContentTableValue: string | undefined;
+
+	/**
+	 * The default value for the attribute for the layout table.
+	 */
+	private readonly _defaultLayoutTableValue: string | undefined;
 
 	/**
 	 * Creates a new `TableCellPropertyCommand` instance.
@@ -38,7 +51,8 @@ export default class TableCellPropertyCommand extends Command {
 		super( editor );
 
 		this.attributeName = attributeName;
-		this._defaultValue = defaultValue;
+		this._defaultContentTableValue = defaultValue;
+		this._defaultLayoutTableValue = attributeName === 'tableCellBorderStyle' ? 'none' : undefined;
 	}
 
 	/**
@@ -46,8 +60,15 @@ export default class TableCellPropertyCommand extends Command {
 	 */
 	public override refresh(): void {
 		const editor = this.editor;
+		const selection = editor.model.document.selection;
 		const tableUtils: TableUtils = this.editor.plugins.get( 'TableUtils' );
-		const selectedTableCells = tableUtils.getSelectionAffectedTableCells( editor.model.document.selection );
+
+		const selectedTableCells = tableUtils.getSelectionAffectedTableCells( selection );
+		const table = getSelectionAffectedTable( selection );
+
+		this._defaultValue = !table || table.getAttribute( 'tableType' ) !== 'layout' ?
+			this._defaultContentTableValue :
+			this._defaultLayoutTableValue;
 
 		this.isEnabled = !!selectedTableCells.length;
 		this.value = this._getSingleValue( selectedTableCells );

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.ts
@@ -8,16 +8,19 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core.js';
+import { first } from 'ckeditor5/src/utils.js';
 import {
 	addBorderRules,
 	addPaddingRules,
 	addBackgroundRules,
 	type Schema,
 	type Conversion,
-	type ViewElement
+	type ViewElement,
+	type UpcastConversionApi,
+	type UpcastConversionData
 } from 'ckeditor5/src/engine.js';
 
-import { downcastAttributeToStyle, upcastBorderStyles } from './../converters/tableproperties.js';
+import { downcastAttributeToStyle, upcastBorderStyles } from '../converters/tableproperties.js';
 import TableEditing from './../tableediting.js';
 import TableCellWidthEditing from '../tablecellwidth/tablecellwidthediting.js';
 import TableCellPaddingCommand from './commands/tablecellpaddingcommand.js';
@@ -207,10 +210,23 @@ function enableHorizontalAlignmentProperty( schema: Schema, conversion: Conversi
 			},
 			model: {
 				key: 'tableCellHorizontalAlignment',
-				value: ( viewElement: ViewElement ) => {
+				value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
+					let localDefaultValue = defaultValue;
+
+					// Adjust default for layout tables.
+					if ( data.modelRange ) {
+						const modelElement = first( data.modelRange.getItems( { shallow: true } ) );
+						const tableElement = modelElement && modelElement.is( 'element' ) &&
+							modelElement.findAncestor( 'table', { includeSelf: true } );
+
+						if ( tableElement && tableElement.getAttribute( 'tableType' ) == 'layout' ) {
+							localDefaultValue = 'left';
+						}
+					}
+
 					const align = viewElement.getStyle( 'text-align' );
 
-					return align === defaultValue ? null : align;
+					return align === localDefaultValue ? null : align;
 				}
 			}
 		} )
@@ -224,10 +240,23 @@ function enableHorizontalAlignmentProperty( schema: Schema, conversion: Conversi
 			},
 			model: {
 				key: 'tableCellHorizontalAlignment',
-				value: ( viewElement: ViewElement ) => {
+				value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
+					let localDefaultValue = defaultValue;
+
+					// Adjust default for layout tables.
+					if ( data.modelRange ) {
+						const modelElement = first( data.modelRange.getItems( { shallow: true } ) );
+						const tableElement = modelElement && modelElement.is( 'element' ) &&
+							modelElement.findAncestor( 'table', { includeSelf: true } );
+
+						if ( tableElement && tableElement.getAttribute( 'tableType' ) == 'layout' ) {
+							localDefaultValue = 'left';
+						}
+					}
+
 					const align = viewElement.getAttribute( 'align' );
 
-					return align === defaultValue ? null : align;
+					return align === localDefaultValue ? null : align;
 				}
 			}
 		} );
@@ -268,10 +297,23 @@ function enableVerticalAlignmentProperty( schema: Schema, conversion: Conversion
 			},
 			model: {
 				key: 'tableCellVerticalAlignment',
-				value: ( viewElement: ViewElement ) => {
+				value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
+					let localDefaultValue = defaultValue;
+
+					// Adjust default for layout tables.
+					if ( data.modelRange ) {
+						const modelElement = first( data.modelRange.getItems( { shallow: true } ) );
+						const tableElement = modelElement && modelElement.is( 'element' ) &&
+							modelElement.findAncestor( 'table', { includeSelf: true } );
+
+						if ( tableElement && tableElement.getAttribute( 'tableType' ) == 'layout' ) {
+							localDefaultValue = 'middle';
+						}
+					}
+
 					const align = viewElement.getStyle( 'vertical-align' );
 
-					return align === defaultValue ? null : align;
+					return align === localDefaultValue ? null : align;
 				}
 			}
 		} )
@@ -285,10 +327,23 @@ function enableVerticalAlignmentProperty( schema: Schema, conversion: Conversion
 			},
 			model: {
 				key: 'tableCellVerticalAlignment',
-				value: ( viewElement: ViewElement ) => {
+				value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
+					let localDefaultValue = defaultValue;
+
+					// Adjust default for layout tables.
+					if ( data.modelRange ) {
+						const modelElement = first( data.modelRange.getItems( { shallow: true } ) );
+						const tableElement = modelElement && modelElement.is( 'element' ) &&
+							modelElement.findAncestor( 'table', { includeSelf: true } );
+
+						if ( tableElement && tableElement.getAttribute( 'tableType' ) == 'layout' ) {
+							localDefaultValue = 'middle';
+						}
+					}
+
 					const valign = viewElement.getAttribute( 'valign' );
 
-					return valign === defaultValue ? null : valign;
+					return valign === localDefaultValue ? null : valign;
 				}
 			}
 		} );

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesui.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesui.ts
@@ -153,7 +153,11 @@ export default class TableCellPropertiesUI extends Plugin {
 				isRightToLeftContent: editor.locale.contentLanguageDirection === 'rtl'
 			}
 		);
-		this._defaultLayoutTableCellProperties = getNormalizedDefaultProperties();
+		this._defaultLayoutTableCellProperties = getNormalizedDefaultProperties( undefined, {
+			includeVerticalAlignmentProperty: true,
+			includeHorizontalAlignmentProperty: true,
+			isRightToLeftContent: editor.locale.contentLanguageDirection === 'rtl'
+		} );
 
 		this._balloon = editor.plugins.get( ContextualBalloon );
 		this.view = null;

--- a/packages/ckeditor5-table/src/tableproperties/commands/tablepropertycommand.ts
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tablepropertycommand.ts
@@ -32,8 +32,20 @@ export default class TablePropertyCommand extends Command {
 
 	/**
 	 * The default value for the attribute.
+	 *
+	 * @readonly
 	 */
-	protected readonly _defaultValue: string | undefined;
+	protected _defaultValue: string | undefined;
+
+	/**
+	 * The default value for the attribute for the content table.
+	 */
+	private readonly _defaultContentTableValue: string | undefined;
+
+	/**
+	 * The default value for the attribute for the layout table.
+	 */
+	private readonly _defaultLayoutTableValue: string | undefined;
 
 	/**
 	 * Creates a new `TablePropertyCommand` instance.
@@ -46,7 +58,8 @@ export default class TablePropertyCommand extends Command {
 		super( editor );
 
 		this.attributeName = attributeName;
-		this._defaultValue = defaultValue;
+		this._defaultContentTableValue = defaultValue;
+		this._defaultLayoutTableValue = attributeName === 'tableBorderStyle' ? 'none' : undefined;
 	}
 
 	/**
@@ -57,6 +70,10 @@ export default class TablePropertyCommand extends Command {
 		const selection = editor.model.document.selection;
 
 		const table = getSelectionAffectedTable( selection );
+
+		this._defaultValue = !table || table.getAttribute( 'tableType' ) !== 'layout' ?
+			this._defaultContentTableValue :
+			this._defaultLayoutTableValue;
 
 		this.isEnabled = !!table;
 		this.value = this._getValue( table );

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
@@ -8,12 +8,15 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core.js';
+import { first } from 'ckeditor5/src/utils.js';
 import {
 	addBackgroundRules,
 	addBorderRules,
 	type ViewElement,
 	type Conversion,
-	type Schema
+	type Schema,
+	type UpcastConversionApi,
+	type UpcastConversionData
 } from 'ckeditor5/src/engine.js';
 
 import TableEditing from '../tableediting.js';
@@ -217,7 +220,18 @@ function enableAlignmentProperty( schema: Schema, conversion: Conversion, defaul
 			},
 			model: {
 				key: 'tableAlignment',
-				value: ( viewElement: ViewElement ) => {
+				value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
+					let localDefaultValue = defaultValue;
+
+					// Adjust default for layout tables.
+					if ( data.modelRange ) {
+						const modelElement = first( data.modelRange.getItems( { shallow: true } ) );
+
+						if ( modelElement && modelElement.is( 'element' ) && modelElement.getAttribute( 'tableType' ) == 'layout' ) {
+							localDefaultValue = '';
+						}
+					}
+
 					let align = viewElement.getStyle( 'float' );
 
 					// CSS: `float:none` => Model: `alignment:center`.
@@ -225,7 +239,7 @@ function enableAlignmentProperty( schema: Schema, conversion: Conversion, defaul
 						align = 'center';
 					}
 
-					return align === defaultValue ? null : align;
+					return align === localDefaultValue ? null : align;
 				}
 			}
 		} )
@@ -239,10 +253,21 @@ function enableAlignmentProperty( schema: Schema, conversion: Conversion, defaul
 			model: {
 				name: 'table',
 				key: 'tableAlignment',
-				value: ( viewElement: ViewElement ) => {
+				value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
+					let localDefaultValue = defaultValue;
+
+					// Adjust default for layout tables.
+					if ( data.modelRange ) {
+						const modelElement = first( data.modelRange.getItems( { shallow: true } ) );
+
+						if ( modelElement && modelElement.is( 'element' ) && modelElement.getAttribute( 'tableType' ) == 'layout' ) {
+							localDefaultValue = '';
+						}
+					}
+
 					const align = viewElement.getAttribute( 'align' );
 
-					return align === defaultValue ? null : align;
+					return align === localDefaultValue ? null : align;
 				}
 			}
 		} );

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
@@ -8,7 +8,13 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core.js';
-import { addBackgroundRules, addBorderRules, type ViewElement, type Conversion, type Schema } from 'ckeditor5/src/engine.js';
+import {
+	addBackgroundRules,
+	addBorderRules,
+	type ViewElement,
+	type Conversion,
+	type Schema
+} from 'ckeditor5/src/engine.js';
 
 import TableEditing from '../tableediting.js';
 import {
@@ -166,15 +172,37 @@ function enableAlignmentProperty( schema: Schema, conversion: Conversion, defaul
 		.attributeToAttribute( {
 			model: {
 				name: 'table',
-				key: 'tableAlignment'
+				key: 'tableAlignment',
+				values: [ 'left', 'center', 'right' ]
 			},
-			view: alignment => ( {
-				key: 'style',
-				value: {
-					// Model: `alignment:center` => CSS: `float:none`.
-					float: alignment === 'center' ? 'none' : alignment
+			view: {
+				left: {
+					key: 'style',
+					value: {
+						float: 'left'
+					}
+				},
+				right: {
+					key: 'style',
+					value: {
+						float: 'right'
+					}
+				},
+				center: ( alignment, conversionApi, data ) => {
+					const value: Record<string, string> = data.item.getAttribute( 'tableType' ) !== 'layout' ? {
+						// Model: `alignment:center` => CSS: `float:none`.
+						float: 'none'
+					} : {
+						'margin-left': 'auto',
+						'margin-right': 'auto'
+					};
+
+					return {
+						key: 'style',
+						value
+					};
 				}
-			} ),
+			},
 			converterPriority: 'high'
 		} );
 

--- a/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.ts
+++ b/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.ts
@@ -43,13 +43,14 @@ import {
 	getLabeledColorInputCreator
 } from '../../utils/ui/table-properties.js';
 
+import type ColorInputView from '../../ui/colorinputview.js';
+import type { TablePropertiesOptions } from '../../tableconfig.js';
+
 // eslint-disable-next-line ckeditor5-rules/ckeditor-imports
 import '@ckeditor/ckeditor5-ui/theme/components/form/form.css';
 import '../../../theme/formrow.css';
 import '../../../theme/tableform.css';
 import '../../../theme/tableproperties.css';
-import type ColorInputView from '../../ui/colorinputview.js';
-import type { TablePropertiesOptions } from '../../tableconfig.js';
 
 /**
  * Additional configuration of the view.

--- a/packages/ckeditor5-table/src/utils/table-properties.ts
+++ b/packages/ckeditor5-table/src/utils/table-properties.ts
@@ -116,7 +116,7 @@ export type NormalizeTableDefaultPropertiesOptions = {
  * @param options Options used to determine which properties should be added.
  */
 export function getNormalizedDefaultProperties(
-	config: Partial<NormalizedDefaultProperties> | undefined,
+	config?: Partial<NormalizedDefaultProperties>,
 	options: NormalizeTableDefaultPropertiesOptions = {}
 ): NormalizedDefaultProperties {
 	const normalizedConfig: NormalizedDefaultProperties = {
@@ -155,7 +155,7 @@ export function getNormalizedDefaultProperties(
  * @param options Options used to determine which properties should be added.
  */
 export function getNormalizedDefaultTableProperties(
-	config: Partial<NormalizedDefaultProperties> | undefined,
+	config?: Partial<NormalizedDefaultProperties>,
 	options?: NormalizeTableDefaultPropertiesOptions
 ): NormalizedDefaultProperties {
 	return getNormalizedDefaultProperties( {
@@ -175,7 +175,7 @@ export function getNormalizedDefaultTableProperties(
  * @param options Options used to determine which properties should be added.
  */
 export function getNormalizedDefaultCellProperties(
-	config: Partial<NormalizedDefaultProperties> | undefined,
+	config?: Partial<NormalizedDefaultProperties>,
 	options?: NormalizeTableDefaultPropertiesOptions
 ): NormalizedDefaultProperties {
 	return getNormalizedDefaultProperties( {

--- a/packages/ckeditor5-table/src/utils/ui/table-properties.ts
+++ b/packages/ckeditor5-table/src/utils/ui/table-properties.ts
@@ -198,7 +198,12 @@ export function fillToolbar<TView extends View, TPropertyName extends keyof TVie
 		} );
 
 		button.on( 'execute', () => {
-			view[ propertyName ] = buttonValue as any;
+			// Allow toggling alignment if there is no default value specified (especially for layout tables).
+			if ( !defaultValue && buttonValue && view[ propertyName ] === buttonValue ) {
+				view[ propertyName ] = undefined as any;
+			} else {
+				view[ propertyName ] = buttonValue as any;
+			}
 		} );
 
 		toolbar.items.add( button );

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -7,6 +7,7 @@ import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtest
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
 
 import TableEditing from '../../src/tableediting.js';
+import TableLayoutEditing from '../../src/tablelayout/tablelayoutediting.js';
 import TableCellPropertiesEditing from '../../src/tablecellproperties/tablecellpropertiesediting.js';
 
 import TableCellBorderColorCommand from '../../src/tablecellproperties/commands/tablecellbordercolorcommand.js';
@@ -1237,6 +1238,111 @@ describe( 'table cell properties', () => {
 					model.change( writer => writer.setAttribute( 'tableCellHeight', '1410em', tableCell ) );
 
 					assertTableCellStyle( editor, 'height:1410em;' );
+				} );
+			} );
+		} );
+
+		describe( 'table layout', () => {
+			beforeEach( async () => {
+				await editor.destroy();
+
+				editor = await VirtualTestEditor.create( {
+					plugins: [ TableCellPropertiesEditing, Paragraph, TableEditing, TableLayoutEditing ]
+				} );
+
+				model = editor.model;
+			} );
+
+			describe( 'upcast', () => {
+				describe( 'horizontal alignment', () => {
+					it( 'should not upcast text-align:left style (due to the default value of the property)', () => {
+						editor.setData( '<table class="layout-table"><tr><td style="text-align:left">foo</td></tr></table>' );
+						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+						expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.be.undefined;
+					} );
+
+					it( 'should upcast text-align:right style', () => {
+						editor.setData( '<table class="layout-table"><tr><td style="text-align:right">foo</td></tr></table>' );
+						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+						expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'right' );
+					} );
+
+					describe( 'the [align] attribute', () => {
+						it( 'should not upcast the align=left attribute (due to the default value of the property)', () => {
+							editor.setData( '<table class="layout-table"><tr><td align="left">foo</td></tr></table>' );
+							const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+							expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.be.undefined;
+						} );
+
+						it( 'should upcast the align=right attribute ', () => {
+							editor.setData( '<table class="layout-table"><tr><td align="right">foo</td></tr></table>' );
+							const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+							expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.be.equal( 'right' );
+						} );
+
+						it( 'should upcast the align=center attribute', () => {
+							editor.setData( '<table class="layout-table"><tr><td align="center">foo</td></tr></table>' );
+							const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+							expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'center' );
+						} );
+
+						it( 'should upcast the align=justify attribute', () => {
+							editor.setData( '<table class="layout-table"><tr><td align="justify">foo</td></tr></table>' );
+							const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+							expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'justify' );
+						} );
+					} );
+				} );
+
+				describe( 'upcast conversion', () => {
+					it( 'should upcast "top" vertical-align', () => {
+						editor.setData( '<table class="layout-table"><tr><td style="vertical-align:top">foo</td></tr></table>' );
+
+						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+						expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.equal( 'top' );
+					} );
+
+					it( 'should upcast "bottom" vertical-align', () => {
+						editor.setData( '<table class="layout-table"><tr><td style="vertical-align:bottom">foo</td></tr></table>' );
+						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+						expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.equal( 'bottom' );
+					} );
+
+					it( 'should not upcast "middle" vertical-align (due to the default value of the property)', () => {
+						editor.setData( '<table class="layout-table"><tr><td style="vertical-align:middle">foo</td></tr></table>' );
+						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+						expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.be.undefined;
+					} );
+
+					it( 'should upcast "top" valign attribute', () => {
+						editor.setData( '<table class="layout-table"><tr><td valign="top">foo</td></tr></table>' );
+						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+						expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.equal( 'top' );
+					} );
+
+					it( 'should upcast "bottom" valign attribute', () => {
+						editor.setData( '<table class="layout-table"><tr><td valign="bottom">foo</td></tr></table>' );
+						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+						expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.equal( 'bottom' );
+					} );
+
+					it( 'should not upcast "middle" valign attribute (due to the default value of the property)', () => {
+						editor.setData( '<table class="layout-table"><tr><td valign="middle">foo</td></tr></table>' );
+						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+						expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.be.undefined;
+					} );
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -1244,13 +1244,15 @@ describe( 'table cell properties', () => {
 
 		describe( 'table layout', () => {
 			beforeEach( async () => {
-				await editor.destroy();
-
 				editor = await VirtualTestEditor.create( {
 					plugins: [ TableCellPropertiesEditing, Paragraph, TableEditing, TableLayoutEditing ]
 				} );
 
 				model = editor.model;
+			} );
+
+			afterEach( async () => {
+				await editor.destroy();
 			} );
 
 			describe( 'upcast', () => {
@@ -1269,29 +1271,43 @@ describe( 'table cell properties', () => {
 						expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'right' );
 					} );
 
-					describe( 'the [align] attribute', () => {
-						it( 'should not upcast the align=left attribute (due to the default value of the property)', () => {
+					it( 'should upcast text-align:center style', () => {
+						editor.setData( '<table class="layout-table"><tr><td style="text-align:center">foo</td></tr></table>' );
+						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+						expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'center' );
+					} );
+
+					it( 'should upcast text-align:justify style', () => {
+						editor.setData( '<table class="layout-table"><tr><td style="text-align:justify">foo</td></tr></table>' );
+						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+						expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'justify' );
+					} );
+
+					describe( 'the `align` attribute', () => {
+						it( 'should not upcast the align="left" attribute (due to the default value of the property)', () => {
 							editor.setData( '<table class="layout-table"><tr><td align="left">foo</td></tr></table>' );
 							const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
 							expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.be.undefined;
 						} );
 
-						it( 'should upcast the align=right attribute ', () => {
+						it( 'should upcast the align="right" attribute ', () => {
 							editor.setData( '<table class="layout-table"><tr><td align="right">foo</td></tr></table>' );
 							const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
 							expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.be.equal( 'right' );
 						} );
 
-						it( 'should upcast the align=center attribute', () => {
+						it( 'should upcast the align="center" attribute', () => {
 							editor.setData( '<table class="layout-table"><tr><td align="center">foo</td></tr></table>' );
 							const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
 							expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'center' );
 						} );
 
-						it( 'should upcast the align=justify attribute', () => {
+						it( 'should upcast the align="justify" attribute', () => {
 							editor.setData( '<table class="layout-table"><tr><td align="justify">foo</td></tr></table>' );
 							const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
@@ -1300,7 +1316,7 @@ describe( 'table cell properties', () => {
 					} );
 				} );
 
-				describe( 'upcast conversion', () => {
+				describe( 'vertical alignment', () => {
 					it( 'should upcast "top" vertical-align', () => {
 						editor.setData( '<table class="layout-table"><tr><td style="vertical-align:top">foo</td></tr></table>' );
 
@@ -1323,25 +1339,27 @@ describe( 'table cell properties', () => {
 						expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.be.undefined;
 					} );
 
-					it( 'should upcast "top" valign attribute', () => {
-						editor.setData( '<table class="layout-table"><tr><td valign="top">foo</td></tr></table>' );
-						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+					describe( 'the `valign` attribute', () => {
+						it( 'should upcast "top" valign attribute', () => {
+							editor.setData( '<table class="layout-table"><tr><td valign="top">foo</td></tr></table>' );
+							const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-						expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.equal( 'top' );
-					} );
+							expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.equal( 'top' );
+						} );
 
-					it( 'should upcast "bottom" valign attribute', () => {
-						editor.setData( '<table class="layout-table"><tr><td valign="bottom">foo</td></tr></table>' );
-						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+						it( 'should upcast "bottom" valign attribute', () => {
+							editor.setData( '<table class="layout-table"><tr><td valign="bottom">foo</td></tr></table>' );
+							const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-						expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.equal( 'bottom' );
-					} );
+							expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.equal( 'bottom' );
+						} );
 
-					it( 'should not upcast "middle" valign attribute (due to the default value of the property)', () => {
-						editor.setData( '<table class="layout-table"><tr><td valign="middle">foo</td></tr></table>' );
-						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+						it( 'should not upcast "middle" valign attribute (due to the default value of the property)', () => {
+							editor.setData( '<table class="layout-table"><tr><td valign="middle">foo</td></tr></table>' );
+							const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-						expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.be.undefined;
+							expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.be.undefined;
+						} );
 					} );
 				} );
 			} );

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesui.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesui.js
@@ -850,7 +850,7 @@ describe( 'table cell properties', () => {
 				} );
 			} );
 
-			describe( 'Showing the #view', () => {
+			describe( 'Showing the #view (content table)', () => {
 				beforeEach( () => {
 					editor.model.change( writer => {
 						writer.setSelection( editor.model.document.getRoot().getChild( 0 ).getChild( 0 ).getChild( 0 ), 0 );

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesui.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesui.js
@@ -18,6 +18,7 @@ import ContextualBalloon from '@ckeditor/ckeditor5-ui/src/panel/balloon/contextu
 import ClipboardPipeline from '@ckeditor/ckeditor5-clipboard/src/clipboardpipeline.js';
 
 import Table from '../../src/table.js';
+import TableLayout from '../../src/tablelayout.js';
 import TableCellPropertiesEditing from '../../src/tablecellproperties/tablecellpropertiesediting.js';
 import TableCellWidthEditing from '../../src/tablecellwidth/tablecellwidthediting.js';
 import TableCellPropertiesUI from '../../src/tablecellproperties/tablecellpropertiesui.js';
@@ -777,9 +778,12 @@ describe( 'table cell properties', () => {
 					.create( editorElement, {
 						plugins: [
 							Table, TableCellPropertiesEditing, TableCellPropertiesUI, TableCellWidthEditing,
-							ClipboardPipeline, Paragraph, Undo
+							ClipboardPipeline, Paragraph, Undo, TableLayout
 						],
-						initialData: '<table><tr><td>foo</td></tr></table><p>bar</p>',
+						initialData:
+							'<table class="content-table"><tr><td>foo</td></tr></table>' +
+							'<p>bar</p>' +
+							'<table class="layout-table"><tr><td>foo</td></tr></table>',
 						table: {
 							tableCellProperties: {
 								defaultProperties: {
@@ -902,6 +906,49 @@ describe( 'table cell properties', () => {
 							padding: '10px',
 							horizontalAlignment: 'center',
 							verticalAlignment: 'bottom'
+						} );
+					} );
+				} );
+			} );
+
+			describe( 'Showing the #view (layout table)', () => {
+				beforeEach( () => {
+					editor.model.change( writer => {
+						writer.setSelection( editor.model.document.getRoot().getChild( 2 ).getChild( 0 ).getChild( 0 ), 0 );
+					} );
+
+					// Trigger lazy init.
+					tableCellPropertiesUI._showView();
+					tableCellPropertiesUI._hideView();
+
+					tableCellPropertiesView = tableCellPropertiesUI.view;
+				} );
+
+				describe( 'initial data', () => {
+					it( 'should use hardcoded defaults for layout table instead of configuration', () => {
+						editor.commands.get( 'tableCellBorderStyle' ).value = null;
+						editor.commands.get( 'tableCellBorderColor' ).value = null;
+						editor.commands.get( 'tableCellBorderWidth' ).value = null;
+						editor.commands.get( 'tableCellBackgroundColor' ).value = null;
+						editor.commands.get( 'tableCellWidth' ).value = null;
+						editor.commands.get( 'tableCellHeight' ).value = null;
+						editor.commands.get( 'tableCellPadding' ).value = null;
+						editor.commands.get( 'tableCellHorizontalAlignment' ).value = null;
+						editor.commands.get( 'tableCellVerticalAlignment' ).value = null;
+
+						tableCellPropertiesButton.fire( 'execute' );
+
+						expect( contextualBalloon.visibleView ).to.equal( tableCellPropertiesView );
+						expect( tableCellPropertiesView ).to.include( {
+							borderStyle: 'none',
+							borderColor: '',
+							borderWidth: '',
+							backgroundColor: '',
+							width: '',
+							height: '',
+							padding: '',
+							horizontalAlignment: 'left',
+							verticalAlignment: 'middle'
 						} );
 					} );
 				} );

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -7,6 +7,7 @@ import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtest
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
 
 import TableEditing from '../../src/tableediting.js';
+import TableLayoutEditing from '../../src/tablelayout/tablelayoutediting.js';
 import TablePropertiesEditing from '../../src/tableproperties/tablepropertiesediting.js';
 
 import TableBorderColorCommand from '../../src/tableproperties/commands/tablebordercolorcommand.js';
@@ -394,7 +395,7 @@ describe( 'table properties', () => {
 										'<paragraph>parent:00</paragraph>' +
 									'</tableCell>' +
 									'<tableCell>' +
-										'<table tableBorderColor="green" tableBorderStyle="solid">' +
+											'<table tableBorderColor="green" tableBorderStyle="solid">' +
 											'<tableRow>' +
 												'<tableCell>' +
 													'<paragraph>child:00</paragraph>' +
@@ -1253,6 +1254,65 @@ describe( 'table properties', () => {
 					assertTableStyle( editor, null, 'float:none;' );
 				} );
 
+				describe( 'with TableLayoutEditing', () => {
+					let editor, model;
+
+					beforeEach( async () => {
+						editor = await VirtualTestEditor.create( {
+							plugins: [ TablePropertiesEditing, Paragraph, TableEditing, TableLayoutEditing ]
+						} );
+
+						model = editor.model;
+					} );
+
+					afterEach( async () => {
+						await editor.destroy();
+					} );
+
+					it( 'should downcast "center" alignment for regular table using float:none', () => {
+						setModelData( model,
+							'<table headingRows="0" headingColumns="0">' +
+								'<tableRow><tableCell><paragraph>regular table</paragraph></tableCell></tableRow>' +
+							'</table>'
+						);
+
+						const regularTable = model.document.getRoot().getNodeByPath( [ 0 ] );
+						model.change( writer => writer.setAttribute( 'tableAlignment', 'center', regularTable ) );
+
+						expect( editor.getData() ).to.be.equal(
+							'<figure class="table content-table" style="float:none;">' +
+								'<table>' +
+									'<tbody>' +
+										'<tr><td>regular table</td></tr>' +
+									'</tbody>' +
+								'</table>' +
+							'</figure>'
+						);
+					} );
+
+					it( 'should downcast "center" alignment for layout table using auto margins', () => {
+						setModelData( model,
+							'<table tableType="layout" headingRows="0" headingColumns="0">' +
+								'<tableRow><tableCell><paragraph>layout table</paragraph></tableCell></tableRow>' +
+							'</table>'
+						);
+
+						const layoutTable = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+						model.change( writer => writer.setAttribute( 'tableAlignment', 'center', layoutTable ) );
+
+						expect( editor.getData() ).to.be.equal(
+							'<figure class="table layout-table" style="margin-left:auto;margin-right:auto;" role="presentation">' +
+								'<table>' +
+									'<tbody>' +
+										'<tr><td>layout table</td></tr>' +
+									'</tbody>' +
+								'</table>' +
+							'</figure>'
+						);
+					} );
+				} );
+
 				it( 'should downcast changed tableAlignment (left -> right)', () => {
 					model.change( writer => writer.setAttribute( 'tableAlignment', 'left', table ) );
 
@@ -1443,15 +1503,233 @@ describe( 'table properties', () => {
 			} );
 		} );
 
+		describe( 'default layout tables properties', () => {
+			let editor, model;
+
+			beforeEach( () => {
+				return VirtualTestEditor
+					.create( {
+						plugins: [ TablePropertiesEditing, Paragraph, TableEditing, TableLayoutEditing ],
+						table: {
+							tableProperties: {
+								defaultProperties: {
+									borderStyle: 'none',
+									borderColor: '',
+									borderWidth: ''
+								}
+							}
+						}
+					} )
+					.then( newEditor => {
+						editor = newEditor;
+
+						model = editor.model;
+					} );
+			} );
+
+			afterEach( async () => {
+				await editor.destroy();
+			} );
+
+			describe( 'border', () => {
+				it( 'should not upcast the default border values', () => {
+					editor.setData(
+						'<table class="layout-table" style="border-style: none">' +
+							'<tr>' +
+								'<td>foo</td>' +
+							'</tr>' +
+						'</table>'
+					);
+
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableBorderColor' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableBorderStyle' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableBorderWidth' ) ).to.be.undefined;
+				} );
+
+				it( 'should upcast non-default `border-color` value', () => {
+					editor.setData(
+						'<table class="layout-table" style="border-color:#ff0">' +
+							'<tr>' +
+								'<td>foo</td>' +
+							'</tr>' +
+						'</table>'
+					);
+
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableBorderColor' ) ).to.be.equal( '#ff0' );
+				} );
+
+				it( 'should upcast non-default `border-style` value', () => {
+					editor.setData(
+						'<table class="layout-table" style="border-style:dashed">' +
+							'<tr>' +
+								'<td>foo</td>' +
+							'</tr>' +
+						'</table>'
+					);
+
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableBorderStyle' ) ).to.be.equal( 'dashed' );
+				} );
+
+				it( 'should upcast non-default `border-width` value', () => {
+					editor.setData(
+						'<table class="layout-table" style="border-width:2px">' +
+							'<tr>' +
+								'<td>foo</td>' +
+							'</tr>' +
+						'</table>'
+					);
+
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableBorderWidth' ) ).to.be.equal( '2px' );
+				} );
+			} );
+
+			describe( 'background color', () => {
+				it( 'should not upcast the default `background-color` value', () => {
+					editor.setData(
+						'<table class="layout-table" style="background-color:#00f">' +
+							'<tr>' +
+								'<td>foo</td>' +
+							'</tr>' +
+						'</table>'
+					);
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'backgroundColor' ) ).to.be.undefined;
+				} );
+
+				it( 'should not upcast the default `background` value', () => {
+					editor.setData(
+						'<table class="layout-table" style="background:#00f">' +
+							'<tr>' +
+								'<td>foo</td>' +
+							'</tr>' +
+						'</table>'
+					);
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'backgroundColor' ) ).to.be.undefined;
+				} );
+			} );
+
+			describe( 'width', () => {
+				it( 'should not upcast the default `width` value from <table>', () => {
+					editor.setData(
+						'<table class="layout-table" style="width:250px">' +
+							'<tr>' +
+								'<td>foo</td>' +
+							'</tr>' +
+						'</table>'
+					);
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'width' ) ).to.be.undefined;
+				} );
+
+				it( 'should not upcast the default `width` value from <figure>', () => {
+					editor.setData(
+						'<figure class="table layout-table" style="width:250px">' +
+						'<table>' +
+							'<tr>' +
+								'<td>foo</td>' +
+							'</tr>' +
+						'</table>' +
+						'</figure>'
+					);
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'width' ) ).to.be.undefined;
+				} );
+			} );
+
+			describe( 'height', () => {
+				it( 'should not upcast the default `height` value from <table>', () => {
+					editor.setData(
+						'<table class="layout-table" style="height:150px">' +
+							'<tr>' +
+								'<td>foo</td>' +
+							'</tr>' +
+						'</table>'
+					);
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'height' ) ).to.be.undefined;
+				} );
+
+				it( 'should not upcast the default `height` value from <figure>', () => {
+					editor.setData(
+						'<figure class="table layout-table" style="height:150px">' +
+							'<table>' +
+								'<tr>' +
+									'<td>foo</td>' +
+								'</tr>' +
+							'</table>' +
+						'</figure>'
+					);
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'height' ) ).to.be.undefined;
+				} );
+			} );
+
+			describe( 'alignment', () => {
+				it( 'should not upcast the default value from the align attribute (none)', () => {
+					editor.setData(
+						'<table class="layout-table" align="none">' +
+							'<tr>' +
+								'<td>foo</td>' +
+							'</tr>' +
+						'</table>'
+					);
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableAlignment' ) ).to.be.undefined;
+				} );
+
+				it( 'should upcast the non-default value from the style attribute (float:left)', () => {
+					editor.setData(
+						'<table class="layout-table" style="float:left">' +
+							'<tr>' +
+								'<td>foo</td>' +
+							'</tr>' +
+						'</table>'
+					);
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableAlignment' ) ).to.be.equal( 'left' );
+				} );
+
+				it( 'should upcast align=left attribute', () => {
+					editor.setData(
+						'<table class="layout-table" align="left">' +
+							'<tr>' +
+								'<td>foo</td>' +
+							'</tr>' +
+						'</table>'
+					);
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableAlignment' ) ).to.equal( 'left' );
+				} );
+			} );
+		} );
+
 		function createEmptyTable() {
 			setModelData(
 				model,
 				'<table headingRows="0" headingColumns="0">' +
-				'<tableRow>' +
-				'<tableCell>' +
-				'<paragraph>foo</paragraph>' +
-				'</tableCell>' +
-				'</tableRow>' +
+					'<tableRow>' +
+						'<tableCell>' +
+							'<paragraph>foo</paragraph>' +
+						'</tableCell>' +
+					'</tableRow>' +
 				'</table>'
 			);
 

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -1269,21 +1269,21 @@ describe( 'table properties', () => {
 						await editor.destroy();
 					} );
 
-					it( 'should downcast "center" alignment for regular table using float:none', () => {
+					it( 'should downcast "center" alignment for content table using float:none', () => {
 						setModelData( model,
 							'<table headingRows="0" headingColumns="0">' +
-								'<tableRow><tableCell><paragraph>regular table</paragraph></tableCell></tableRow>' +
+								'<tableRow><tableCell><paragraph>content table</paragraph></tableCell></tableRow>' +
 							'</table>'
 						);
 
-						const regularTable = model.document.getRoot().getNodeByPath( [ 0 ] );
-						model.change( writer => writer.setAttribute( 'tableAlignment', 'center', regularTable ) );
+						const contentTable = model.document.getRoot().getNodeByPath( [ 0 ] );
+						model.change( writer => writer.setAttribute( 'tableAlignment', 'center', contentTable ) );
 
 						expect( editor.getData() ).to.be.equal(
 							'<figure class="table content-table" style="float:none;">' +
 								'<table>' +
 									'<tbody>' +
-										'<tr><td>regular table</td></tr>' +
+										'<tr><td>content table</td></tr>' +
 									'</tbody>' +
 								'</table>' +
 							'</figure>'
@@ -1298,7 +1298,6 @@ describe( 'table properties', () => {
 						);
 
 						const layoutTable = model.document.getRoot().getNodeByPath( [ 0 ] );
-
 						model.change( writer => writer.setAttribute( 'tableAlignment', 'center', layoutTable ) );
 
 						expect( editor.getData() ).to.be.equal(
@@ -1429,14 +1428,14 @@ describe( 'table properties', () => {
 					editor.setData( '<table style="background-color:#00f"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'backgroundColor' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableBackgroundColor' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default `background` value', () => {
 					editor.setData( '<table style="background:#00f"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'backgroundColor' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableBackgroundColor' ) ).to.be.undefined;
 				} );
 			} );
 
@@ -1445,14 +1444,14 @@ describe( 'table properties', () => {
 					editor.setData( '<table style="width:250px"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'width' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableWidth' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default `width` value from <figure>', () => {
 					editor.setData( '<figure class="table" style="width:250px"><table><tr><td>foo</td></tr></table></figure>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'width' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableWidth' ) ).to.be.undefined;
 				} );
 			} );
 
@@ -1461,14 +1460,14 @@ describe( 'table properties', () => {
 					editor.setData( '<table style="height:150px"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'height' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableHeight' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default `height` value from <figure>', () => {
 					editor.setData( '<figure class="table" style="height:150px"><table><tr><td>foo</td></tr></table></figure>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'height' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableHeight' ) ).to.be.undefined;
 				} );
 			} );
 
@@ -1513,9 +1512,13 @@ describe( 'table properties', () => {
 						table: {
 							tableProperties: {
 								defaultProperties: {
+									alignment: 'left',
 									borderStyle: 'none',
 									borderColor: '',
-									borderWidth: ''
+									borderWidth: '',
+									backgroundColor: '#00f',
+									width: '250px',
+									height: '150px'
 								}
 							}
 						}
@@ -1532,7 +1535,7 @@ describe( 'table properties', () => {
 			} );
 
 			describe( 'border', () => {
-				it( 'should not upcast the default border values', () => {
+				it( 'should not upcast the default `border` values', () => {
 					editor.setData(
 						'<table class="layout-table" style="border-style: none">' +
 							'<tr>' +
@@ -1548,20 +1551,6 @@ describe( 'table properties', () => {
 					expect( table.getAttribute( 'tableBorderWidth' ) ).to.be.undefined;
 				} );
 
-				it( 'should upcast non-default `border-color` value', () => {
-					editor.setData(
-						'<table class="layout-table" style="border-color:#ff0">' +
-							'<tr>' +
-								'<td>foo</td>' +
-							'</tr>' +
-						'</table>'
-					);
-
-					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
-
-					expect( table.getAttribute( 'tableBorderColor' ) ).to.be.equal( '#ff0' );
-				} );
-
 				it( 'should upcast non-default `border-style` value', () => {
 					editor.setData(
 						'<table class="layout-table" style="border-style:dashed">' +
@@ -1574,6 +1563,20 @@ describe( 'table properties', () => {
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
 					expect( table.getAttribute( 'tableBorderStyle' ) ).to.be.equal( 'dashed' );
+				} );
+
+				it( 'should upcast non-default `border-color` value', () => {
+					editor.setData(
+						'<table class="layout-table" style="border-color:#ff0">' +
+							'<tr>' +
+								'<td>foo</td>' +
+							'</tr>' +
+						'</table>'
+					);
+
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableBorderColor' ) ).to.be.equal( '#ff0' );
 				} );
 
 				it( 'should upcast non-default `border-width` value', () => {
@@ -1592,7 +1595,7 @@ describe( 'table properties', () => {
 			} );
 
 			describe( 'background color', () => {
-				it( 'should not upcast the default `background-color` value', () => {
+				it( 'should upcast non-default `background-color` value', () => {
 					editor.setData(
 						'<table class="layout-table" style="background-color:#00f">' +
 							'<tr>' +
@@ -1602,10 +1605,10 @@ describe( 'table properties', () => {
 					);
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'backgroundColor' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableBackgroundColor' ) ).to.be.equal( '#00f' );
 				} );
 
-				it( 'should not upcast the default `background` value', () => {
+				it( 'should upcast non-default `background` value', () => {
 					editor.setData(
 						'<table class="layout-table" style="background:#00f">' +
 							'<tr>' +
@@ -1615,12 +1618,12 @@ describe( 'table properties', () => {
 					);
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'backgroundColor' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableBackgroundColor' ) ).to.be.equal( '#00f' );
 				} );
 			} );
 
 			describe( 'width', () => {
-				it( 'should not upcast the default `width` value from <table>', () => {
+				it( 'should upcast non-default `width` value from <table>', () => {
 					editor.setData(
 						'<table class="layout-table" style="width:250px">' +
 							'<tr>' +
@@ -1630,27 +1633,12 @@ describe( 'table properties', () => {
 					);
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'width' ) ).to.be.undefined;
-				} );
-
-				it( 'should not upcast the default `width` value from <figure>', () => {
-					editor.setData(
-						'<figure class="table layout-table" style="width:250px">' +
-						'<table>' +
-							'<tr>' +
-								'<td>foo</td>' +
-							'</tr>' +
-						'</table>' +
-						'</figure>'
-					);
-					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
-
-					expect( table.getAttribute( 'width' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableWidth' ) ).to.be.equal( '250px' );
 				} );
 			} );
 
 			describe( 'height', () => {
-				it( 'should not upcast the default `height` value from <table>', () => {
+				it( 'should upcast non-default `height` value from <table>', () => {
 					editor.setData(
 						'<table class="layout-table" style="height:150px">' +
 							'<tr>' +
@@ -1660,22 +1648,7 @@ describe( 'table properties', () => {
 					);
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'height' ) ).to.be.undefined;
-				} );
-
-				it( 'should not upcast the default `height` value from <figure>', () => {
-					editor.setData(
-						'<figure class="table layout-table" style="height:150px">' +
-							'<table>' +
-								'<tr>' +
-									'<td>foo</td>' +
-								'</tr>' +
-							'</table>' +
-						'</figure>'
-					);
-					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
-
-					expect( table.getAttribute( 'height' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableHeight' ) ).to.be.equal( '150px' );
 				} );
 			} );
 

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
@@ -914,8 +914,6 @@ describe( 'table properties', () => {
 
 			describe( 'Showing the #view (layout table)', () => {
 				beforeEach( async () => {
-					await editor.destroy();
-
 					editor = await ClassicTestEditor.create( editorElement, {
 						plugins: [ Table, TablePropertiesEditing, TablePropertiesUI, Paragraph, Undo, ClipboardPipeline, TableLayout ],
 						initialData: '<table><tr><td>foo</td></tr></table><p>bar</p>',
@@ -947,6 +945,10 @@ describe( 'table properties', () => {
 					tablePropertiesUI._hideView();
 
 					tablePropertiesView = tablePropertiesUI.view;
+				} );
+
+				afterEach( async () => {
+					await editor.destroy();
 				} );
 
 				it( 'should use hardcoded defaults for layout table instead of configuration', () => {

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
@@ -913,7 +913,12 @@ describe( 'table properties', () => {
 			} );
 
 			describe( 'Showing the #view (layout table)', () => {
+				let editor, editorElement, tablePropertiesUI, tablePropertiesView, tablePropertiesButton;
+
 				beforeEach( async () => {
+					editorElement = document.createElement( 'div' );
+					document.body.appendChild( editorElement );
+
 					editor = await ClassicTestEditor.create( editorElement, {
 						plugins: [ Table, TablePropertiesEditing, TablePropertiesUI, Paragraph, Undo, ClipboardPipeline, TableLayout ],
 						initialData: '<table><tr><td>foo</td></tr></table><p>bar</p>',
@@ -934,7 +939,6 @@ describe( 'table properties', () => {
 
 					tablePropertiesUI = editor.plugins.get( TablePropertiesUI );
 					tablePropertiesButton = editor.ui.componentFactory.create( 'tableProperties' );
-					contextualBalloon = editor.plugins.get( ContextualBalloon );
 
 					editor.model.change( writer => {
 						writer.setSelection( editor.model.document.getRoot().getChild( 0 ).getChild( 0 ).getChild( 0 ), 0 );
@@ -948,7 +952,9 @@ describe( 'table properties', () => {
 				} );
 
 				afterEach( async () => {
-					await editor.destroy();
+					editorElement.remove();
+
+					return editor.destroy();
 				} );
 
 				it( 'should use hardcoded defaults for layout table instead of configuration', () => {

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
@@ -18,6 +18,7 @@ import ContextualBalloon from '@ckeditor/ckeditor5-ui/src/panel/balloon/contextu
 import ClipboardPipeline from '@ckeditor/ckeditor5-clipboard/src/clipboardpipeline.js';
 
 import Table from '../../src/table.js';
+import TableLayout from '../../src/tablelayout.js';
 import TablePropertiesEditing from '../../src/tableproperties/tablepropertiesediting.js';
 import TablePropertiesUI from '../../src/tableproperties/tablepropertiesui.js';
 import TablePropertiesUIView from '../../src/tableproperties/ui/tablepropertiesview.js';
@@ -882,7 +883,6 @@ describe( 'table properties', () => {
 
 						tablePropertiesButton.fire( 'execute' );
 
-						expect( contextualBalloon.visibleView ).to.equal( tablePropertiesView );
 						expect( tablePropertiesView ).to.include( {
 							borderStyle: 'dashed',
 							borderColor: '#ff0',
@@ -899,7 +899,6 @@ describe( 'table properties', () => {
 
 						tablePropertiesButton.fire( 'execute' );
 
-						expect( contextualBalloon.visibleView ).to.equal( tablePropertiesView );
 						expect( tablePropertiesView ).to.include( {
 							borderStyle: 'none',
 							borderColor: '',
@@ -909,6 +908,66 @@ describe( 'table properties', () => {
 							height: '150px',
 							alignment: 'left'
 						} );
+					} );
+				} );
+			} );
+
+			describe( 'Showing the #view (layout table)', () => {
+				beforeEach( async () => {
+					await editor.destroy();
+
+					editor = await ClassicTestEditor.create( editorElement, {
+						plugins: [ Table, TablePropertiesEditing, TablePropertiesUI, Paragraph, Undo, ClipboardPipeline, TableLayout ],
+						initialData: '<table><tr><td>foo</td></tr></table><p>bar</p>',
+						table: {
+							tableProperties: {
+								defaultProperties: {
+									alignment: 'left',
+									borderStyle: 'dashed',
+									borderColor: '#ff0',
+									borderWidth: '2px',
+									backgroundColor: '#00f',
+									width: '250px',
+									height: '150px'
+								}
+							}
+						}
+					} );
+
+					tablePropertiesUI = editor.plugins.get( TablePropertiesUI );
+					tablePropertiesButton = editor.ui.componentFactory.create( 'tableProperties' );
+					contextualBalloon = editor.plugins.get( ContextualBalloon );
+
+					editor.model.change( writer => {
+						writer.setSelection( editor.model.document.getRoot().getChild( 0 ).getChild( 0 ).getChild( 0 ), 0 );
+					} );
+
+					// Trigger lazy init.
+					tablePropertiesUI._showView();
+					tablePropertiesUI._hideView();
+
+					tablePropertiesView = tablePropertiesUI.view;
+				} );
+
+				it( 'should use hardcoded defaults for layout table instead of configuration', () => {
+					editor.commands.get( 'tableBorderStyle' ).value = null;
+					editor.commands.get( 'tableBorderColor' ).value = null;
+					editor.commands.get( 'tableBorderWidth' ).value = null;
+					editor.commands.get( 'tableBackgroundColor' ).value = null;
+					editor.commands.get( 'tableWidth' ).value = null;
+					editor.commands.get( 'tableHeight' ).value = null;
+					editor.commands.get( 'tableAlignment' ).value = null;
+
+					tablePropertiesButton.fire( 'execute' );
+
+					expect( tablePropertiesView ).to.include( {
+						borderStyle: 'none',
+						borderColor: '',
+						borderWidth: '',
+						backgroundColor: '',
+						width: '',
+						height: '',
+						alignment: ''
 					} );
 				} );
 			} );

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
@@ -95,7 +95,7 @@ describe( 'table properties', () => {
 			} );
 
 			it( 'should set normalized default table properties', () => {
-				expect( tablePropertiesUI._defaultTableProperties ).to.be.an( 'object' );
+				expect( tablePropertiesUI._defaultContentTableProperties ).to.be.an( 'object' );
 			} );
 
 			describe( '#view', () => {

--- a/packages/ckeditor5-table/tests/utils/ui/table-properties.js
+++ b/packages/ckeditor5-table/tests/utils/ui/table-properties.js
@@ -348,6 +348,22 @@ describe( 'table utils', () => {
 				expect( view.someProperty ).to.equal( '' );
 			} );
 
+			it( 'should toggle the property value when an active button is clicked', () => {
+				// Set the property to match one of the button values.
+				view.someProperty = 'first';
+				expect( toolbar.items.first.isOn ).to.be.true;
+
+				// Click the active button.
+				toolbar.items.first.fire( 'execute' );
+
+				// The property should be reset to undefined.
+				expect( view.someProperty ).to.be.undefined;
+
+				// Clicking the button again should set the value back.
+				toolbar.items.first.fire( 'execute' );
+				expect( view.someProperty ).to.equal( 'first' );
+			} );
+
 			describe( 'skipping "nameToValue" callback', () => {
 				let view, locale, toolbar;
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
@@ -16,6 +16,8 @@
 	& .table.layout-table {
 		& > table {
 			width: 100%;
+			height: 100%;
+
 			/* Styles to make the layout table outline visible when the layout table is inside another layout table inside edge cells.
 			Currently, this solution works on every browser except Safari. */
 			overflow: clip;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (table): Separate table and table cell properties view instances for separate defaults. Closes https://github.com/ckeditor/ckeditor5/issues/18219

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
