### PR TITLE
Fix for wrapping toolbar items in `Link` and `Bookmark` UI.

### DIFF
--- a/packages/ckeditor5-bookmark/src/bookmarkui.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkui.ts
@@ -136,6 +136,7 @@ export default class BookmarkUI extends Plugin {
 			items: editor.config.get( 'bookmark.toolbar' )!,
 
 			getRelatedElement: getSelectedBookmarkWidget,
+			balloonClassName: 'ck-bookmark-balloon',
 
 			// Override positions to the same list as for balloon panel default
 			// so widget toolbar will try to use same position as form view.

--- a/packages/ckeditor5-bookmark/tests/bookmarkui.js
+++ b/packages/ckeditor5-bookmark/tests/bookmarkui.js
@@ -321,7 +321,7 @@ describe( 'BookmarkUI', () => {
 			setModelData( editor.model, '<paragraph>[<bookmark bookmarkId="foo"></bookmark>]</paragraph>' );
 
 			sinon.assert.calledWithMatch( spy, sinon.match( ( { balloonClassName, view } ) => {
-				return view === toolbarView && balloonClassName === 'ck-toolbar-container';
+				return view === toolbarView && balloonClassName === 'ck-bookmark-balloon';
 			} ) );
 		} );
 
@@ -362,7 +362,7 @@ describe( 'BookmarkUI', () => {
 						defaultPositions.viewportStickyNorth
 					]
 				},
-				balloonClassName: 'ck-toolbar-container'
+				balloonClassName: 'ck-bookmark-balloon'
 			} );
 		} );
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-bookmark/bookmarktoolbar.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-bookmark/bookmarktoolbar.css
@@ -5,6 +5,14 @@
 
 @import "@ckeditor/ckeditor5-ui/theme/mixins/_unselectable.css";
 
+.ck.ck-bookmark-balloon {
+	& .ck.ck-toolbar {
+		& > .ck-toolbar__items {
+			flex-wrap: nowrap;
+		}
+	}
+}
+
 .ck.ck-bookmark-toolbar__preview {
 	padding: 0 var(--ck-spacing-medium);
 	max-width: var(--ck-input-width);

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linktoolbar.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linktoolbar.css
@@ -9,6 +9,12 @@
 	--ck-link-bookmark-icon-size: calc( var(--ck-icon-size) * 0.7); /* 0.7 = 14/20 cause default the icon size is 20px */
 }
 
+.ck.ck-toolbar.ck-link-toolbar {
+	& > .ck-toolbar__items {
+		flex-wrap: nowrap;
+	}
+}
+
 a.ck.ck-button.ck-link-toolbar__preview {
 	padding: 0 var(--ck-spacing-medium);
 	color: var(--ck-color-link-default);


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix(link): Should not wrap toolbar items in `Link` UI. Closes #18200.

Fix(bookmark): Should not wrap toolbar items in `Bookmark` UI. Closes #18200.

---

### Additional information

⚠️ Target branch: `release`.
