### PR TITLE
Add disclaimer to multi-root lazy loading with information about its limitations

### DIFF
--- a/packages/ckeditor5-editor-multi-root/src/augmentation.ts
+++ b/packages/ckeditor5-editor-multi-root/src/augmentation.ts
@@ -83,6 +83,18 @@ declare module '@ckeditor/ckeditor5-core' {
 		/**
 		 * A list of names of all the roots that exist in the document but are not initially loaded by the editor.
 		 *
+		 * **Important! Lazy roots loading is an experimental feature, and may become deprecated. Be advised of the following limitations:**
+		 *
+		 * * **Real-time collaboration integrations that use
+		 * [uploaded editor bundles](https://ckeditor.com/docs/cs/latest/guides/collaboration/editor-bundle.html) are not supported.**
+		 * * **Revision history feature will read and process the whole document on editor initialization, possibly defeating the purpose
+		 * of using the lazy roots loading.**
+		 * * **Multiple features, that require all document data to be loaded, may also produce incorrect or confusing results if not all
+		 * roots are loaded. These include: bookmarks, find and replace, word count, pagination, document exports, document outline,
+		 * and table of contents.**
+		 *
+		 * **It is not recommended to use lazy loading unless you experience severe performance problems.**
+		 *
 		 * These roots can be loaded at any time after the editor has been initialized, using
 		 * {@link module:editor-multi-root/multirooteditor~MultiRootEditor#loadRoot `MultiRootEditor#lazyRoot()`}.
 		 *

--- a/packages/ckeditor5-editor-multi-root/src/augmentation.ts
+++ b/packages/ckeditor5-editor-multi-root/src/augmentation.ts
@@ -83,7 +83,8 @@ declare module '@ckeditor/ckeditor5-core' {
 		/**
 		 * A list of names of all the roots that exist in the document but are not initially loaded by the editor.
 		 *
-		 * **Important! Lazy roots loading is an experimental feature, and may become deprecated. Be advised of the following limitations:**
+		 * **Important! Lazy roots loading is an experimental feature, and may become deprecated. Be advised of the following
+		 * known limitations:**
 		 *
 		 * * **Real-time collaboration integrations that use
 		 * [uploaded editor bundles](https://ckeditor.com/docs/cs/latest/guides/collaboration/editor-bundle.html) are not supported. Using
@@ -91,11 +92,9 @@ declare module '@ckeditor/ckeditor5-core' {
 		 * * **Revision history feature will read and process the whole document on editor initialization, possibly defeating the purpose
 		 * of using the lazy roots loading. Additionally, when the document is loaded for the first time, all roots need to be loaded,
 		 * to make sure that the initial revision data includes all roots. Otherwise, you may experience data loss.**
-		 * * **Multiple features, that require all document data to be loaded, may also produce incorrect or confusing results if not all
+		 * * **Multiple features, that require full document data to be loaded, will produce incorrect or confusing results if not all
 		 * roots are loaded. These include: bookmarks, find and replace, word count, pagination, document exports, document outline,
 		 * and table of contents.**
-		 *
-		 * **It is not recommended to use lazy loading unless you experience severe performance problems.**
 		 *
 		 * These roots can be loaded at any time after the editor has been initialized, using
 		 * {@link module:editor-multi-root/multirooteditor~MultiRootEditor#loadRoot `MultiRootEditor#lazyRoot()`}.

--- a/packages/ckeditor5-editor-multi-root/src/augmentation.ts
+++ b/packages/ckeditor5-editor-multi-root/src/augmentation.ts
@@ -86,9 +86,11 @@ declare module '@ckeditor/ckeditor5-core' {
 		 * **Important! Lazy roots loading is an experimental feature, and may become deprecated. Be advised of the following limitations:**
 		 *
 		 * * **Real-time collaboration integrations that use
-		 * [uploaded editor bundles](https://ckeditor.com/docs/cs/latest/guides/collaboration/editor-bundle.html) are not supported.**
+		 * [uploaded editor bundles](https://ckeditor.com/docs/cs/latest/guides/collaboration/editor-bundle.html) are not supported. Using
+		 * lazy roots will lead to unexpected behavior and data loss.**
 		 * * **Revision history feature will read and process the whole document on editor initialization, possibly defeating the purpose
-		 * of using the lazy roots loading.**
+		 * of using the lazy roots loading. Additionally, when the document is loaded for the first time, all roots need to be loaded,
+		 * to make sure that the initial revision data includes all roots. Otherwise, you may experience data loss.**
 		 * * **Multiple features, that require all document data to be loaded, may also produce incorrect or confusing results if not all
 		 * roots are loaded. These include: bookmarks, find and replace, word count, pagination, document exports, document outline,
 		 * and table of contents.**

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -529,9 +529,11 @@ export default class MultiRootEditor extends Editor {
 	 * **Important! Lazy roots loading is an experimental feature, and may become deprecated. Be advised of the following limitations:**
 	 *
 	 * * **Real-time collaboration integrations that use
-	 * [uploaded editor bundles](https://ckeditor.com/docs/cs/latest/guides/collaboration/editor-bundle.html) are not supported.**
+	 * [uploaded editor bundles](https://ckeditor.com/docs/cs/latest/guides/collaboration/editor-bundle.html) are not supported. Using
+	 * lazy roots will lead to unexpected behavior and data loss.**
 	 * * **Revision history feature will read and process the whole document on editor initialization, possibly defeating the purpose
-	 * of using the lazy roots loading.**
+	 * of using the lazy roots loading. Additionally, when the document is loaded for the first time, all roots need to be loaded,
+	 * to make sure that the initial revision data includes all roots. Otherwise, you may experience data loss.**
 	 * * **Multiple features, that require all document data to be loaded, may also produce incorrect or confusing results if not all
 	 * roots are loaded. These include: bookmarks, find and replace, word count, pagination, document exports, document outline,
 	 * and table of contents.**

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -526,6 +526,18 @@ export default class MultiRootEditor extends Editor {
 	 * Loads a root that has previously been declared in {@link module:core/editor/editorconfig~EditorConfig#lazyRoots `lazyRoots`}
 	 * configuration option.
 	 *
+	 * **Important! Lazy roots loading is an experimental feature, and may become deprecated. Be advised of the following limitations:**
+	 *
+	 * * **Real-time collaboration integrations that use
+	 * [uploaded editor bundles](https://ckeditor.com/docs/cs/latest/guides/collaboration/editor-bundle.html) are not supported.**
+	 * * **Revision history feature will read and process the whole document on editor initialization, possibly defeating the purpose
+	 * of using the lazy roots loading.**
+	 * * **Multiple features, that require all document data to be loaded, may also produce incorrect or confusing results if not all
+	 * roots are loaded. These include: bookmarks, find and replace, word count, pagination, document exports, document outline,
+	 * and table of contents.**
+	 *
+	 * **It is not recommended to use lazy loading unless you experience severe performance problems.**
+	 *
 	 * Only roots specified in the editor config can be loaded. A root cannot be loaded multiple times. A root cannot be unloaded and
 	 * loading a root cannot be reverted using the undo feature.
 	 *

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -526,7 +526,8 @@ export default class MultiRootEditor extends Editor {
 	 * Loads a root that has previously been declared in {@link module:core/editor/editorconfig~EditorConfig#lazyRoots `lazyRoots`}
 	 * configuration option.
 	 *
-	 * **Important! Lazy roots loading is an experimental feature, and may become deprecated. Be advised of the following limitations:**
+	 * **Important! Lazy roots loading is an experimental feature, and may become deprecated. Be advised of the following
+	 * known limitations:**
 	 *
 	 * * **Real-time collaboration integrations that use
 	 * [uploaded editor bundles](https://ckeditor.com/docs/cs/latest/guides/collaboration/editor-bundle.html) are not supported. Using
@@ -534,11 +535,9 @@ export default class MultiRootEditor extends Editor {
 	 * * **Revision history feature will read and process the whole document on editor initialization, possibly defeating the purpose
 	 * of using the lazy roots loading. Additionally, when the document is loaded for the first time, all roots need to be loaded,
 	 * to make sure that the initial revision data includes all roots. Otherwise, you may experience data loss.**
-	 * * **Multiple features, that require all document data to be loaded, may also produce incorrect or confusing results if not all
+	 * * **Multiple features, that require full document data to be loaded, will produce incorrect or confusing results if not all
 	 * roots are loaded. These include: bookmarks, find and replace, word count, pagination, document exports, document outline,
 	 * and table of contents.**
-	 *
-	 * **It is not recommended to use lazy loading unless you experience severe performance problems.**
 	 *
 	 * Only roots specified in the editor config can be loaded. A root cannot be loaded multiple times. A root cannot be unloaded and
 	 * loading a root cannot be reverted using the undo feature.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs (editor-multi-root): Updated documentation related to multi-root roots lazy loading, informing about limitations of this functionality. Closes #18197.
