### PR TITLE
Remove Commercial-related tasks from CI

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -100,21 +100,6 @@ commands:
             echo export CKE5_COMMIT_SHA1=$CIRCLE_SHA1 >> $BASH_ENV
 
 jobs:
-  cke5_manual:
-    machine: true
-    resource_class: xlarge
-    steps:
-      - checkout_command
-      - halt_if_short_flow
-      - bootstrap_repository_command
-      - prepare_environment_command
-      - run:
-          name: Prepare DLL builds in CKEditor 5
-          command: yarn run dll:build
-      - run:
-          name: Verify CKEditor 5 manual tests
-          command: bash scripts/check-manual-tests.sh -r ckeditor5 -f ckeditor5
-
   cke5_validators:
     machine: true
     resource_class: large
@@ -218,26 +203,6 @@ jobs:
           name: Trigger the Uber CI
           command: yarn ckeditor5-dev-ci-trigger-circle-build
 
-  release_prepare:
-    machine: true
-    resource_class: xlarge
-    steps:
-      - checkout_command
-      - halt_if_short_flow
-      - bootstrap_repository_command
-      - prepare_environment_command
-      - run:
-          name: Check if packages are ready to be released
-          command: npm run release:prepare-packages -- --compile-only --verbose
-
-      - run:
-          name: Lint generated packages
-          command: yarn run release:lint-packages
-
-      - run:
-          name: Check dependencies
-          command: yarn run check-dependencies
-
   notify_ci_failure:
     machine: true
     resource_class: medium
@@ -297,24 +262,12 @@ workflows:
               ignore:
                 - stable
       - cke5_validators
-      - cke5_manual:
-          filters:
-            branches:
-              ignore:
-                - stable
-      - release_prepare:
-          filters:
-            branches:
-              ignore:
-                - stable
       - cke5_trigger_uber_ci:
           requires:
             - cke5_tests_framework
             - cke5_tests_features_batch_n
             - cke5_coverage
             - cke5_validators
-            - cke5_manual
-            - release_prepare
           filters:
             branches:
               only:
@@ -324,8 +277,6 @@ workflows:
             - cke5_tests_framework
             - cke5_tests_features_batch_n
             - cke5_validators
-            - cke5_manual
-            - release_prepare
           filters:
             branches:
               only:
@@ -344,8 +295,6 @@ workflows:
       - cke5_tests_framework
       - cke5_tests_features_batch_n
       - cke5_validators
-      - cke5_manual
-      - release_prepare
       - notify_ci_failure:
           hideAuthor: "true"
           filters:

--- a/scripts/ci/generate-circleci-configuration.mjs
+++ b/scripts/ci/generate-circleci-configuration.mjs
@@ -32,7 +32,8 @@ const FEATURE_COVERAGE_BATCH_FILENAME_PLACEHOLDER = '.out/combined_features_batc
  * one batch will be automatically added to cover remaining tests.
  */
 const FEATURE_BATCH_SIZES = [
-	30
+	20,
+	15
 ];
 
 const NON_FULL_COVERAGE_PACKAGES = [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Moved the Commercial-related tasks from the CKEditor 5 repository to CC.

---

### Additional information

* See: https://github.com/cksource/ckeditor5-commercial/issues/7274.
