### PR TITLE
Resetting `border-collapse` property on layout table to the user agent styles in editing view.

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
@@ -23,6 +23,9 @@
 			overflow: clip;
 			overflow-clip-margin: var(--ck-widget-outline-thickness);
 
+			/* Resetting `border-collapse` property to the user agent styles. */
+			border-collapse: revert;
+
 			/* The default table layout style in the editing view when the border is unset. */
 			&:not(
 			[style*="border:"],


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix(table): Selected widget inside layout table cell should not have cropped border. Closes #18245.

---

### Additional information

⚠️ `release` branch is the target.
