### PR TITLE
Nested tables outline visibility.

### DIFF
--- a/packages/ckeditor5-table/theme/tablelayout.css
+++ b/packages/ckeditor5-table/theme/tablelayout.css
@@ -28,8 +28,8 @@
 		/* Widget type around overrides. */
 		&.ck-widget {
 			&:hover {
-				/* To prevent cut off of the widget outline at the bottom,
-				when next cell or table has, for example, background color. */
+				/* To prevent the widget outline from being cut off at the bottom
+				when the next cell or table has a background color, for example. */
 				z-index: var(--ck-z-default);
 			}
 

--- a/packages/ckeditor5-table/theme/tablelayout.css
+++ b/packages/ckeditor5-table/theme/tablelayout.css
@@ -27,6 +27,12 @@
 
 		/* Widget type around overrides. */
 		&.ck-widget {
+			&:hover {
+				/* To prevent cut off of the widget outline at the bottom,
+				when next cell or table has, for example, background color. */
+				z-index: var(--ck-z-default);
+			}
+
 			&:hover > .ck-widget__selection-handle {
 				opacity: 0.75;
 				visibility: visible;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (table): Nested tables outline should not been cut of at the bottom during hovering. Closes #18262.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
