### PR TITLE
Third click on "Add bookmark"/ "Link" no longer opens the balloon at the top of the editor.

### DIFF
--- a/packages/ckeditor5-bookmark/src/bookmarkui.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkui.ts
@@ -430,7 +430,7 @@ export default class BookmarkUI extends Plugin {
 			emitter: this.formView!,
 			activator: () => this._isFormInPanel,
 			contextElements: () => [ this._balloon.view.element! ],
-			callback: () => this._hideFormView()
+			callback: () => this._hideFormView( false )
 		} );
 	}
 
@@ -470,7 +470,7 @@ export default class BookmarkUI extends Plugin {
 	/**
 	 * Removes the {@link #formView} from the {@link #_balloon}.
 	 */
-	private _removeFormView(): void {
+	private _removeFormView( updateFocus: boolean = true ): void {
 		// Blur the input element before removing it from DOM to prevent issues in some browsers.
 		// See https://github.com/ckeditor/ckeditor5/issues/1501.
 		this.formView!.saveButtonView.focus();
@@ -482,7 +482,9 @@ export default class BookmarkUI extends Plugin {
 
 		// Because the form has an input which has focus, the focus must be brought back
 		// to the editor. Otherwise, it would be lost.
-		this.editor.editing.view.focus();
+		if ( updateFocus ) {
+			this.editor.editing.view.focus();
+		}
 
 		this._hideFakeVisualSelection();
 	}
@@ -511,7 +513,7 @@ export default class BookmarkUI extends Plugin {
 	/**
 	 * Removes the {@link #formView} from the {@link #_balloon}.
 	 */
-	private _hideFormView(): void {
+	private _hideFormView( updateFocus: boolean = true ): void {
 		if ( !this._isFormInPanel ) {
 			return;
 		}
@@ -523,10 +525,12 @@ export default class BookmarkUI extends Plugin {
 
 		// Make sure the focus always gets back to the editable _before_ removing the focused form view.
 		// Doing otherwise causes issues in some browsers. See https://github.com/ckeditor/ckeditor5-link/issues/193.
-		editor.editing.view.focus();
+		if ( updateFocus ) {
+			editor.editing.view.focus();
+		}
 
 		// Remove form first because it's on top of the stack.
-		this._removeFormView();
+		this._removeFormView( updateFocus );
 
 		this._hideFakeVisualSelection();
 	}

--- a/packages/ckeditor5-bookmark/src/bookmarkui.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkui.ts
@@ -431,9 +431,9 @@ export default class BookmarkUI extends Plugin {
 			activator: () => this._isFormInPanel,
 			contextElements: () => [ this._balloon.view.element! ],
 			callback: () => {
-				// Focusing editable during click outside the balloon panel might cause
-				// the selection to move to beginning of the editable. So, we avoid focusing
-				// the editable during this action.
+				// Focusing on the editable during a click outside the balloon panel might
+				// cause the selection to move to the beginning of the editable, so we avoid
+				// focusing on it during this action.
 				// See: https://github.com/ckeditor/ckeditor5/issues/18253
 				this._hideFormView( false );
 			}

--- a/packages/ckeditor5-bookmark/src/bookmarkui.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkui.ts
@@ -430,7 +430,13 @@ export default class BookmarkUI extends Plugin {
 			emitter: this.formView!,
 			activator: () => this._isFormInPanel,
 			contextElements: () => [ this._balloon.view.element! ],
-			callback: () => this._hideFormView( false )
+			callback: () => {
+				// Focusing editable during click outside the balloon panel might cause
+				// the selection to move to beginning of the editable. So, we avoid focusing
+				// the editable during this action.
+				// See: https://github.com/ckeditor/ckeditor5/issues/18253
+				this._hideFormView( false );
+			}
 		} );
 	}
 

--- a/packages/ckeditor5-bookmark/tests/bookmarkui.js
+++ b/packages/ckeditor5-bookmark/tests/bookmarkui.js
@@ -1525,7 +1525,7 @@ describe( 'BookmarkUI', () => {
 			bookmarkUIFeature._showFormView();
 			document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
 
-			sinon.assert.calledWithExactly( spy );
+			sinon.assert.calledWithExactly( spy, false );
 		} );
 
 		it( 'should not hide the UI upon clicking inside the the UI', () => {

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -761,7 +761,7 @@ export default class LinkUI extends Plugin {
 			emitter: this.formView!,
 			activator: () => this._isUIInPanel,
 			contextElements: () => [ this._balloon.view.element! ],
-			callback: () => this._hideUI()
+			callback: () => this._hideUI( false )
 		} );
 	}
 
@@ -920,7 +920,7 @@ export default class LinkUI extends Plugin {
 	/**
 	 * Removes the {@link #formView} from the {@link #_balloon}.
 	 */
-	private _removeFormView(): void {
+	private _removeFormView( updateFocus: boolean = true ): void {
 		if ( this._isFormInPanel ) {
 			// Blur the input element before removing it from DOM to prevent issues in some browsers.
 			// See https://github.com/ckeditor/ckeditor5/issues/1501.
@@ -934,7 +934,9 @@ export default class LinkUI extends Plugin {
 
 			// Because the form has an input which has focus, the focus must be brought back
 			// to the editor. Otherwise, it would be lost.
-			this.editor.editing.view.focus();
+			if ( updateFocus ) {
+				this.editor.editing.view.focus();
+			}
 
 			this._hideFakeVisualSelection();
 		}
@@ -1014,7 +1016,7 @@ export default class LinkUI extends Plugin {
 		this._removePropertiesView();
 
 		// Then remove the form view because it's beneath the properties form.
-		this._removeFormView();
+		this._removeFormView( updateFocus );
 
 		// Finally, remove the link toolbar view because it's last in the stack.
 		if ( this._isToolbarInPanel ) {

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -761,7 +761,13 @@ export default class LinkUI extends Plugin {
 			emitter: this.formView!,
 			activator: () => this._isUIInPanel,
 			contextElements: () => [ this._balloon.view.element! ],
-			callback: () => this._hideUI( false )
+			callback: () => {
+				// Focusing editable during click outside the balloon panel might cause
+				// the selection to move to beginning of the editable. So, we avoid focusing
+				// the editable during this action.
+				// See: https://github.com/ckeditor/ckeditor5/issues/18253
+				this._hideUI( false );
+			}
 		} );
 	}
 

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -762,9 +762,9 @@ export default class LinkUI extends Plugin {
 			activator: () => this._isUIInPanel,
 			contextElements: () => [ this._balloon.view.element! ],
 			callback: () => {
-				// Focusing editable during click outside the balloon panel might cause
-				// the selection to move to beginning of the editable. So, we avoid focusing
-				// the editable during this action.
+				// Focusing on the editable during a click outside the balloon panel might
+				// cause the selection to move to the beginning of the editable, so we avoid
+				// focusing on it during this action.
 				// See: https://github.com/ckeditor/ckeditor5/issues/18253
 				this._hideUI( false );
 			}

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -1599,7 +1599,7 @@ describe( 'LinkUI', () => {
 			linkUIFeature._showUI();
 			document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
 
-			sinon.assert.calledWithExactly( spy );
+			sinon.assert.calledWithExactly( spy, false );
 		} );
 
 		it( 'should hide the UI when link is in not currently visible stack', () => {
@@ -1618,7 +1618,7 @@ describe( 'LinkUI', () => {
 
 			document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
 
-			sinon.assert.calledWithExactly( spy );
+			sinon.assert.calledWithExactly( spy, false );
 		} );
 
 		it( 'should not hide the UI upon clicking inside the the UI', () => {
@@ -3357,7 +3357,7 @@ describe( 'LinkUI', () => {
 
 				document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
 
-				sinon.assert.calledWithExactly( spy );
+				sinon.assert.calledWithExactly( spy, false );
 				expect( linkUIFeature._balloon.visibleView ).to.be.null;
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (bookmark, link): Third click on "Add bookmark"/ "Link" no longer opens the balloon at the top of the editor. Closes #18253.

---

### Additional information

It looks like focusing editable during execution `callback` of click outside handler causes the issue. Most likely race condition in focus / selection management, or built-in browser heuristic that is executed during click event. 

#### Before

https://github.com/user-attachments/assets/289866e8-9905-4cd4-ab20-413bfb03d77e

#### After

https://github.com/user-attachments/assets/cbc3259f-22fc-4b0e-93e8-4795891fa461


