### PR TITLE
Fix rounded corners on UI components in fullscreen mode

### DIFF
--- a/packages/ckeditor5-fullscreen/src/handlers/classiceditorhandler.ts
+++ b/packages/ckeditor5-fullscreen/src/handlers/classiceditorhandler.ts
@@ -56,8 +56,14 @@ export default class ClassicEditorHandler extends AbstractEditorHandler {
 		// in both menu bar and toolbar (adding the side padding to the elements).
 		// Since we don't move the whole container but only parts, we need to reapply the attribute value manually.
 		// Decupled editor doesn't have this issue because there is no top-level container,
-		// so `dir` is set on each component separately.
+		// so `dir` attribute is set on each component separately.
 		this.getWrapper().setAttribute( 'dir', editorUIView.element!.getAttribute( 'dir' )! );
+
+		// The `ck-rounded-corners` class is added to the wrapper element to ensure that the corners in menu bar, toolbar etc are rounded
+		// when the editor is in fullscreen mode.
+		// Decupled editor doesn't have this issue because there is no top-level container,
+		// so `ck-rounded-corners` class is set on each component separately.
+		this.getWrapper().classList.add( 'ck-rounded-corners' );
 
 		if ( this._editor.config.get( 'fullscreen.menuBar.isVisible' ) ) {
 			if ( !editorUIView.menuBarView ) {

--- a/packages/ckeditor5-fullscreen/tests/handlers/classiceditorhandler.js
+++ b/packages/ckeditor5-fullscreen/tests/handlers/classiceditorhandler.js
@@ -57,6 +57,12 @@ describe( 'ClassicEditorHandler', () => {
 			expect( classicEditorHandler.getWrapper().getAttribute( 'dir' ) ).to.equal( editor.ui.view.element.getAttribute( 'dir' ) );
 		} );
 
+		it( 'should set `.ck-rounded-corners` class on the fullscreen container', () => {
+			classicEditorHandler.enable();
+
+			expect( classicEditorHandler.getWrapper().classList.contains( 'ck-rounded-corners' ) ).to.be.true;
+		} );
+
 		it( 'should move menu bar if it is present', async () => {
 			const tempDomElement = global.document.createElement( 'div' );
 			global.document.body.appendChild( tempDomElement );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (fullscreen): Fix rounded corners on UI components in fullscreen mode. Closes https://github.com/ckeditor/ckeditor5/issues/18276.

---

### Additional information

Fix is only necessary in classic editor. Decoupled editor applies `.ck-rounded-corners` on each component that needs it separately.
