### PR TITLE
Fix snippets and manual tests using snippet styles

### DIFF
--- a/packages/ckeditor5-html-embed/docs/_snippets/features/html-embed.js
+++ b/packages/ckeditor5-html-embed/docs/_snippets/features/html-embed.js
@@ -132,7 +132,7 @@ ClassicEditor
 					'<meta charset="utf-8">' +
 					`<base href="${ location.href }">` +
 					`<title>${ document.title }</title>` +
-					links.map( link => `<link rel="stylesheet" href="${ link.href }" type="text/css">` ).join( '' ) +
+					links.map( link => `<link rel="stylesheet" href="${ link.href }">` ).join( '' ) +
 					`<style>
 						body {
 							padding: 20px;

--- a/packages/ckeditor5-html-embed/docs/_snippets/features/html-embed.js
+++ b/packages/ckeditor5-html-embed/docs/_snippets/features/html-embed.js
@@ -113,10 +113,15 @@ ClassicEditor
 
 		// The "Preview editor data" button logic.
 		document.querySelector( '#preview-data-action' ).addEventListener( 'click', () => {
-			const mainCSSElement = [ ...document.querySelectorAll( 'link' ) ]
-				.find( linkElement => linkElement.href.endsWith( 'css/styles.css' ) );
-			const snippetCSSElement = [ ...document.querySelectorAll( 'link' ) ]
-				.find( linkElement => linkElement.href.endsWith( 'snippet.css' ) );
+			const stylesheets = [
+				'css/styles.css',
+				'ckeditor5.css',
+				'ckeditor5-premium-features.css'
+			];
+
+			const links = Array
+				.from( document.querySelectorAll( 'link' ) )
+				.filter( element => stylesheets.some( name => element.href.endsWith( name ) ) );
 
 			const iframeElement = document.querySelector( '#preview-data-container' );
 
@@ -127,8 +132,7 @@ ClassicEditor
 					'<meta charset="utf-8">' +
 					`<base href="${ location.href }">` +
 					`<title>${ document.title }</title>` +
-					`<link rel="stylesheet" href="${ mainCSSElement.href }" type="text/css">` +
-					`<link rel="stylesheet" href="${ snippetCSSElement.href }" type="text/css">` +
+					links.map( link => `<link rel="stylesheet" href="${ link.href }" type="text/css">` ).join( '' ) +
 					`<style>
 						body {
 							padding: 20px;

--- a/packages/ckeditor5-page-break/docs/_snippets/features/page-break.js
+++ b/packages/ckeditor5-page-break/docs/_snippets/features/page-break.js
@@ -80,7 +80,7 @@ ClassicEditor
 			iframeElement.srcdoc = '<html>' +
 				'<head>' +
 					`<title>${ document.title }</title>` +
-					links.map( link => `<link rel="stylesheet" href="${ link.href }" type="text/css">` ).join( '' ) +
+					links.map( link => `<link rel="stylesheet" href="${ link.href }">` ).join( '' ) +
 				'</head>' +
 				'<body class="ck-content">' +
 					editor.getData() +

--- a/packages/ckeditor5-page-break/docs/_snippets/features/page-break.js
+++ b/packages/ckeditor5-page-break/docs/_snippets/features/page-break.js
@@ -66,15 +66,21 @@ ClassicEditor
 
 		// The "Print editor data" button logic.
 		document.querySelector( '#print-data-action' ).addEventListener( 'click', () => {
-			const snippetCSSElement = [ ...document.querySelectorAll( 'link' ) ]
-				.find( linkElement => linkElement.href.endsWith( 'snippet.css' ) );
+			const stylesheets = [
+				'ckeditor5.css',
+				'ckeditor5-premium-features.css'
+			];
+
+			const links = Array
+				.from( document.querySelectorAll( 'link' ) )
+				.filter( element => stylesheets.some( name => element.href.endsWith( name ) ) );
 
 			const iframeElement = document.querySelector( '#print-data-container' );
 
 			iframeElement.srcdoc = '<html>' +
 				'<head>' +
 					`<title>${ document.title }</title>` +
-					`<link rel="stylesheet" href="${ snippetCSSElement.href }" type="text/css">` +
+					links.map( link => `<link rel="stylesheet" href="${ link.href }" type="text/css">` ).join( '' ) +
 				'</head>' +
 				'<body class="ck-content">' +
 					editor.getData() +

--- a/tests/manual/all-features.js
+++ b/tests/manual/all-features.js
@@ -248,7 +248,8 @@ ClassicEditor
 			iframeElement.srcdoc = '<html>' +
 				'<head>' +
 					`<title>${ document.title }</title>` +
-					'<link rel="stylesheet" href="https://ckeditor.com/docs/ckeditor5/latest/snippets/features/page-break/snippet.css" type="text/css">' +
+					'<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ckeditor5/dist/browser/ckeditor5.css" type="text/css">' +
+					'<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ckeditor5-premium-features/dist/browser/ckeditor5-premium-features.css" type="text/css">' +
 				'</head>' +
 				'<body class="ck-content">' +
 					editor.getData() +

--- a/tests/manual/all-features.js
+++ b/tests/manual/all-features.js
@@ -248,8 +248,8 @@ ClassicEditor
 			iframeElement.srcdoc = '<html>' +
 				'<head>' +
 					`<title>${ document.title }</title>` +
-					'<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ckeditor5/dist/browser/ckeditor5.css" type="text/css">' +
-					'<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ckeditor5-premium-features/dist/browser/ckeditor5-premium-features.css" type="text/css">' +
+					'<link rel="stylesheet" href="https://cdn.ckeditor.com/ckeditor5/nightly/ckeditor5.css">' +
+					'<link rel="stylesheet" href="https://cdn.ckeditor.com/ckeditor5-premium-features/nightly/ckeditor5-premium-features.css">' +
 				'</head>' +
 				'<body class="ck-content">' +
 					editor.getData() +

--- a/tests/manual/memory/memory.js
+++ b/tests/manual/memory/memory.js
@@ -146,8 +146,8 @@ function initEditor() {
 				iframeElement.srcdoc = '<html>' +
 					'<head>' +
 					`<title>${ document.title }</title>` +
-					'<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ckeditor5/dist/browser/ckeditor5.css" type="text/css">' +
-					'<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ckeditor5-premium-features/dist/browser/ckeditor5-premium-features.css" type="text/css">' +
+					'<link rel="stylesheet" href="https://cdn.ckeditor.com/ckeditor5/nightly/ckeditor5.css">' +
+					'<link rel="stylesheet" href="https://cdn.ckeditor.com/ckeditor5-premium-features/nightly/ckeditor5-premium-features.css">' +
 					'</head>' +
 					'<body class="ck-content">' +
 					editor.getData() +

--- a/tests/manual/memory/memory.js
+++ b/tests/manual/memory/memory.js
@@ -146,7 +146,8 @@ function initEditor() {
 				iframeElement.srcdoc = '<html>' +
 					'<head>' +
 					`<title>${ document.title }</title>` +
-					'<link rel="stylesheet" href="https://ckeditor.com/docs/ckeditor5/latest/snippets/features/page-break/snippet.css" type="text/css">' +
+					'<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ckeditor5/dist/browser/ckeditor5.css" type="text/css">' +
+					'<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ckeditor5-premium-features/dist/browser/ckeditor5-premium-features.css" type="text/css">' +
 					'</head>' +
 					'<body class="ck-content">' +
 					editor.getData() +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Fix snippets that assume styles come from the `snippet.css` file. Closes #18285.

Internal: Fix manual tests that assume styles come from the `snippet.css` file. Closes #18285.
