### PR TITLE
Fix not working removal manual decorators from image with links.

### DIFF
--- a/packages/ckeditor5-link/src/linkimageediting.ts
+++ b/packages/ckeditor5-link/src/linkimageediting.ts
@@ -253,16 +253,32 @@ function downcastImageLinkManualDecorator( decorator: ManualDecorator ): ( dispa
 				return;
 			}
 
-			for ( const [ key, val ] of toMap( decorator.attributes ) ) {
-				conversionApi.writer.setAttribute( key, val, linkInImage );
-			}
+			if ( decorator.value ) {
+				// Handle activated manual decorator.
+				for ( const [ key, val ] of toMap( decorator.attributes ) ) {
+					conversionApi.writer.setAttribute( key, val, linkInImage );
+				}
 
-			if ( decorator.classes ) {
-				conversionApi.writer.addClass( decorator.classes, linkInImage );
-			}
+				if ( decorator.classes ) {
+					conversionApi.writer.addClass( decorator.classes, linkInImage );
+				}
 
-			for ( const key in decorator.styles ) {
-				conversionApi.writer.setStyle( key, decorator.styles[ key ], linkInImage );
+				for ( const key in decorator.styles ) {
+					conversionApi.writer.setStyle( key, decorator.styles[ key ], linkInImage );
+				}
+			} else if ( decorator.value === undefined ) {
+				// Handle deactivated manual decorator.
+				for ( const key in decorator.attributes ) {
+					conversionApi.writer.removeAttribute( key, linkInImage );
+				}
+
+				if ( decorator.classes ) {
+					conversionApi.writer.removeClass( decorator.classes, linkInImage );
+				}
+
+				for ( const key in decorator.styles ) {
+					conversionApi.writer.removeStyle( key, linkInImage );
+				}
 			}
 		} );
 	};

--- a/packages/ckeditor5-link/src/linkimageediting.ts
+++ b/packages/ckeditor5-link/src/linkimageediting.ts
@@ -253,21 +253,8 @@ function downcastImageLinkManualDecorator( decorator: ManualDecorator ): ( dispa
 				return;
 			}
 
-			if ( decorator.value ) {
-				// Handle activated manual decorator.
-				for ( const [ key, val ] of toMap( decorator.attributes ) ) {
-					conversionApi.writer.setAttribute( key, val, linkInImage );
-				}
-
-				if ( decorator.classes ) {
-					conversionApi.writer.addClass( decorator.classes, linkInImage );
-				}
-
-				for ( const key in decorator.styles ) {
-					conversionApi.writer.setStyle( key, decorator.styles[ key ], linkInImage );
-				}
-			} else if ( decorator.value === undefined ) {
-				// Handle deactivated manual decorator.
+			// Handle deactivated manual decorator.
+			if ( decorator.value === undefined ) {
 				for ( const key in decorator.attributes ) {
 					conversionApi.writer.removeAttribute( key, linkInImage );
 				}
@@ -279,6 +266,21 @@ function downcastImageLinkManualDecorator( decorator: ManualDecorator ): ( dispa
 				for ( const key in decorator.styles ) {
 					conversionApi.writer.removeStyle( key, linkInImage );
 				}
+
+				return;
+			}
+
+			// Handle activated manual decorator.
+			for ( const [ key, val ] of toMap( decorator.attributes ) ) {
+				conversionApi.writer.setAttribute( key, val, linkInImage );
+			}
+
+			if ( decorator.classes ) {
+				conversionApi.writer.addClass( decorator.classes, linkInImage );
+			}
+
+			for ( const key in decorator.styles ) {
+				conversionApi.writer.setStyle( key, decorator.styles[ key ], linkInImage );
 			}
 		} );
 	};

--- a/packages/ckeditor5-link/tests/linkimageediting.js
+++ b/packages/ckeditor5-link/tests/linkimageediting.js
@@ -1117,6 +1117,76 @@ describe( 'LinkImageEditing', () => {
 				);
 			} );
 
+			it( 'should remove decorator attributes, classes and styles when manual decorator is deactivated', () => {
+				setModelData( model,
+					'<imageBlock alt="bar" linkHref="https://cksource.com" ' +
+					'linkIsDownloadable="true" linkIsExternal="true" ' +
+					'linkIsGallery="true" linkIsHighlighted="true" src="sample.jpg"></imageBlock>'
+				);
+
+				// Verify if decorators are present in the view
+				expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal(
+					'<figure class="ck-widget image" contenteditable="false">' +
+						'<a class="gallery highlighted" download="download" href="https://cksource.com" ' +
+						'rel="noopener noreferrer" style="text-decoration:underline" target="_blank">' +
+							'<img alt="bar" src="sample.jpg"></img>' +
+						'</a>' +
+					'</figure>'
+				);
+
+				// Remove each decorator one by one and verify if they are removed from the view.
+				const image = model.document.getRoot().getChild( 0 );
+
+				model.change( writer => {
+					writer.setAttribute( 'linkIsDownloadable', undefined, image );
+				} );
+
+				expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal(
+					'<figure class="ck-widget image" contenteditable="false">' +
+						'<a class="gallery highlighted" href="https://cksource.com" ' +
+						'rel="noopener noreferrer" style="text-decoration:underline" target="_blank">' +
+							'<img alt="bar" src="sample.jpg"></img>' +
+						'</a>' +
+					'</figure>'
+				);
+
+				model.change( writer => {
+					writer.setAttribute( 'linkIsExternal', undefined, image );
+				} );
+
+				expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal(
+					'<figure class="ck-widget image" contenteditable="false">' +
+						'<a class="gallery highlighted" href="https://cksource.com" style="text-decoration:underline">' +
+							'<img alt="bar" src="sample.jpg"></img>' +
+						'</a>' +
+					'</figure>'
+				);
+
+				model.change( writer => {
+					writer.setAttribute( 'linkIsGallery', undefined, image );
+				} );
+
+				expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal(
+					'<figure class="ck-widget image" contenteditable="false">' +
+						'<a class="highlighted" href="https://cksource.com" style="text-decoration:underline">' +
+							'<img alt="bar" src="sample.jpg"></img>' +
+						'</a>' +
+					'</figure>'
+				);
+
+				model.change( writer => {
+					writer.setAttribute( 'linkIsHighlighted', undefined, image );
+				} );
+
+				expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal(
+					'<figure class="ck-widget image" contenteditable="false">' +
+						'<a href="https://cksource.com">' +
+							'<img alt="bar" src="sample.jpg"></img>' +
+						'</a>' +
+					'</figure>'
+				);
+			} );
+
 			// See #8401.
 			it( 'should downcast without error if the image already has no link', () => {
 				setModelData( model,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (link): Fix not working toggling decorators on images with links. Closes #18265 

---

### Additional information

It looks like we do not remove manual decorators set on image with links in editing mode.