### PR TITLE
Remove `overflow: hidden` from table while using TableColumnResize.

### DIFF
--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
@@ -486,26 +486,26 @@ export default class TableColumnResizeEditing extends Plugin {
 	 */
 	private _recalculateResizerElement( viewResizer: ViewElement ): void {
 		const editor = this.editor;
+		const domConverter = editor.editing.view.domConverter;
 
 		// Get DOM target figure ancestor element.
-		const domTable = editor.editing.view.domConverter.mapViewToDom( viewResizer.findAncestor( 'table' )! )!;
+		const domTable = domConverter.mapViewToDom( viewResizer.findAncestor( 'table' )! )!;
 
-		// Get DOM target element.
-		const domCell = editor.editing.view.domConverter.mapViewToDom(
+		// Get DOM table cell element.
+		const domCell = domConverter.mapViewToDom(
 			viewResizer.findAncestor( item => [ 'td', 'th' ].includes( item.name ) )!
 		)!;
 
-		const rectFigure = new Rect( domTable );
+		const rectTable = new Rect( domTable );
 		const rectCell = new Rect( domCell );
 
-		if ( rectFigure.height == rectCell.height ) {
+		if ( rectTable.height == rectCell.height ) {
 			return;
 		}
 
-		// Calculate the top position of the column resizer element.
-		const targetTopPosition = toPx( Number( ( rectFigure.top - rectCell.top ).toFixed( 4 ) ) );
-		// Calculate the bottom position of the column resizer element.
-		const targetBottomPosition = toPx( Number( ( rectCell.bottom - rectFigure.bottom ).toFixed( 4 ) ) );
+		// Calculate the top, and bottom positions of the column resizer element.
+		const targetTopPosition = toPx( Number( ( rectTable.top - rectCell.top ).toFixed( 4 ) ) );
+		const targetBottomPosition = toPx( Number( ( rectCell.bottom - rectTable.bottom ).toFixed( 4 ) ) );
 
 		// Set `top` and `bottom` styles to the column resizer element.
 		editor.editing.view.change( viewWriter => {
@@ -879,7 +879,7 @@ export default class TableColumnResizeEditing extends Plugin {
 			writer.removeClass( 'ck-table-column-resizer__active', viewResizer );
 		} );
 
-		const element = this.editor.editing.view.domConverter.mapViewToDom( viewResizer )!;
+		const element = editingView.domConverter.mapViewToDom( viewResizer )!;
 
 		if ( !element.matches( ':hover' ) ) {
 			this._resetResizerStyles( viewResizer );

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
@@ -489,23 +489,26 @@ export default class TableColumnResizeEditing extends Plugin {
 		const editor = this.editor;
 
 		// Get DOM target figure ancestor element.
-		const domFigureAncestor = editor.editing.view.domConverter.mapViewToDom( target.findAncestor( 'figure' )! )!;
+		const domTable = editor.editing.view.domConverter.mapViewToDom( target.findAncestor( 'table' )! )!;
 
 		// Get DOM target element.
-		const domTarget = editor.editing.view.domConverter.mapViewToDom( target )!;
+		const domCell = editor.editing.view.domConverter.mapViewToDom(
+			target.findAncestor( item => [ 'td', 'th' ].includes( item.name ) )!
+		)!;
 
-		const rectFigure = new Rect( domFigureAncestor );
-		const rectTarget = new Rect( domTarget );
+		const rectFigure = new Rect( domTable );
+		const rectCell = new Rect( domCell );
 
-		if ( rectFigure.height == rectTarget.height ) {
+		if ( rectFigure.height == rectCell.height ) {
 			return;
 		}
 
 		// Calculate the top position of the column resizer element.
-		const targetTopPosition = `${ rectFigure.top - rectTarget.top }px`;
+		const targetTopPosition = `${ rectFigure.top - rectCell.top }px`;
 		// Calculate the bottom position of the column resizer element.
-		const targetBottomPosition = `${ rectTarget.bottom - rectFigure.bottom }px`;
+		const targetBottomPosition = `${ rectCell.bottom - rectFigure.bottom }px`;
 
+		// TODO update also on mousemove (while dragging) and reset on end/mouseout.
 		// Set `top` and `bottom` styles to the column resizer element.
 		editor.editing.view.change( viewWriter => {
 			viewWriter.setStyle( 'top', targetTopPosition, target );

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
@@ -499,10 +499,6 @@ export default class TableColumnResizeEditing extends Plugin {
 		const rectTable = new Rect( domTable );
 		const rectCell = new Rect( domCell );
 
-		if ( rectTable.height == rectCell.height ) {
-			return;
-		}
-
 		// Calculate the top, and bottom positions of the column resizer element.
 		const targetTopPosition = toPx( Number( ( rectTable.top - rectCell.top ).toFixed( 4 ) ) );
 		const targetBottomPosition = toPx( Number( ( rectCell.bottom - rectTable.bottom ).toFixed( 4 ) ) );

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
@@ -480,7 +480,9 @@ export default class TableColumnResizeEditing extends Plugin {
 	}
 
 	/**
-	 * TODO: description
+	 * Calculate and set `top` and `bottom` styles to the column resizer element to fit the height of the table.
+	 *
+	 * @param viewResizer The column resizer element.
 	 */
 	private _recalculateResizerElement( viewResizer: ViewElement ): void {
 		const editor = this.editor;
@@ -513,7 +515,9 @@ export default class TableColumnResizeEditing extends Plugin {
 	}
 
 	/**
-	 * TODO: description
+	 * Remove `top` and `bottom` styles of the column resizer element.
+	 *
+	 * @param viewResizer The column resizer element.
 	 */
 	private _resetResizerStyles( viewResizer: ViewElement ): void {
 		this.editor.editing.view.change( viewWriter => {
@@ -523,7 +527,11 @@ export default class TableColumnResizeEditing extends Plugin {
 	}
 
 	/**
-	 * TODO: description
+	 * Handles the `mouseover` event on column resizer element.
+	 * Recalculates the `top` and `bottom` styles of the column resizer element to fit the height of the table.
+	 *
+	 * @param eventInfo An object containing information about the fired event.
+	 * @param domEventData The data related to the DOM event.
 	 */
 	private _onMouseOverHandler( eventInfo: EventInfo, domEventData: DomEventData ) {
 		const target = domEventData.target;
@@ -540,7 +548,11 @@ export default class TableColumnResizeEditing extends Plugin {
 	}
 
 	/**
-	 * TODO: description
+	 * Handles the `mouseout` event on column resizer element.
+	 * When resizing is not active, it resets the `top` and `bottom` styles of the column resizer element.
+	 *
+	 * @param eventInfo An object containing information about the fired event.
+	 * @param domEventData The data related to the DOM event.
 	 */
 	private _onMouseOutHandler( eventInfo: EventInfo, domEventData: DomEventData ) {
 		const target = domEventData.target;

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
@@ -97,11 +97,6 @@ export default class TableColumnResizeEditing extends Plugin {
 	private _isResizingActive: boolean;
 
 	/**
-	 * A flag indicating if the column resizer element is hovered.
-	 */
-	private _isResizerElementHovered: boolean;
-
-	/**
 	 * A flag indicating if the column resizing is allowed. It is not allowed if the editor is in read-only
 	 * or comments-only mode or the `TableColumnResize` plugin is disabled.
 	 *
@@ -159,7 +154,6 @@ export default class TableColumnResizeEditing extends Plugin {
 		super( editor );
 
 		this._isResizingActive = false;
-		this._isResizerElementHovered = false;
 		this.set( '_isResizingAllowed', true );
 		this._resizingData = null;
 		this._domEmitter = new ( DomEmitterMixin() )();
@@ -542,7 +536,6 @@ export default class TableColumnResizeEditing extends Plugin {
 			return;
 		}
 
-		this._isResizerElementHovered = true;
 		this._recalculateResizerElement( target );
 	}
 
@@ -564,7 +557,6 @@ export default class TableColumnResizeEditing extends Plugin {
 			return;
 		}
 
-		this._isResizerElementHovered = false;
 		this._resetResizerStyles( target );
 	}
 
@@ -875,12 +867,14 @@ export default class TableColumnResizeEditing extends Plugin {
 			writer.removeClass( 'ck-table-column-resizer__active', viewResizer );
 		} );
 
-		this._isResizingActive = false;
-		this._resizingData = null;
+		const element = this.editor.editing.view.domConverter.mapViewToDom( viewResizer )!;
 
-		if ( !this._isResizerElementHovered ) {
+		if ( !element.matches( ':hover' ) ) {
 			this._resetResizerStyles( viewResizer );
 		}
+
+		this._isResizingActive = false;
+		this._resizingData = null;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
@@ -503,9 +503,9 @@ export default class TableColumnResizeEditing extends Plugin {
 		}
 
 		// Calculate the top position of the column resizer element.
-		const targetTopPosition = toPx( rectFigure.top - rectCell.top );
+		const targetTopPosition = toPx( Number( ( rectFigure.top - rectCell.top ).toFixed( 4 ) ) );
 		// Calculate the bottom position of the column resizer element.
-		const targetBottomPosition = toPx( rectCell.bottom - rectFigure.bottom );
+		const targetBottomPosition = toPx( Number( ( rectCell.bottom - rectFigure.bottom ).toFixed( 4 ) ) );
 
 		// Set `top` and `bottom` styles to the column resizer element.
 		editor.editing.view.change( viewWriter => {

--- a/packages/ckeditor5-table/tests/manual/tablelayout.js
+++ b/packages/ckeditor5-table/tests/manual/tablelayout.js
@@ -13,7 +13,7 @@ import { Autoformat } from '@ckeditor/ckeditor5-autoformat';
 import { BlockQuote } from '@ckeditor/ckeditor5-block-quote';
 import { Bold, Italic } from '@ckeditor/ckeditor5-basic-styles';
 import { Heading } from '@ckeditor/ckeditor5-heading';
-import { ImageInline, ImageCaption, ImageToolbar } from '@ckeditor/ckeditor5-image';
+import { ImageInline, ImageCaption, ImageToolbar, ImageResize } from '@ckeditor/ckeditor5-image';
 import { Indent } from '@ckeditor/ckeditor5-indent';
 import { Link } from '@ckeditor/ckeditor5-link';
 import { List } from '@ckeditor/ckeditor5-list';
@@ -42,6 +42,7 @@ const config = {
 		ImageCaption,
 		ImageInline,
 		ImageToolbar,
+		ImageResize,
 		Indent,
 		Italic,
 		Link,

--- a/packages/ckeditor5-table/tests/tablecolumnresize/_utils/utils.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/_utils/utils.js
@@ -51,6 +51,40 @@ export const tableColumnResizeMouseSimulator = {
 		this._getPlugin( editor )._onMouseUpHandler();
 	},
 
+	over( editor, domTarget, options = {} ) {
+		const preventDefault = options.preventDefault || sinon.spy().named( 'preventDefault' );
+		const stop = options.stop || sinon.spy().named( 'stop' );
+
+		const clientX = getColumnResizerRect( domTarget ).x;
+
+		const eventInfo = { stop };
+
+		const domEventData = {
+			target: editor.editing.view.domConverter.domToView( domTarget ),
+			domEvent: { clientX, clientY: 0 },
+			preventDefault
+		};
+
+		this._getPlugin( editor )._onMouseOverHandler( eventInfo, domEventData );
+	},
+
+	out( editor, domTarget, options = {} ) {
+		const preventDefault = options.preventDefault || sinon.spy().named( 'preventDefault' );
+		const stop = options.stop || sinon.spy().named( 'stop' );
+
+		const clientX = getColumnResizerRect( domTarget ).x;
+
+		const eventInfo = { stop };
+
+		const domEventData = {
+			target: editor.editing.view.domConverter.domToView( domTarget ),
+			domEvent: { clientX, clientY: 0 },
+			preventDefault
+		};
+
+		this._getPlugin( editor )._onMouseOutHandler( eventInfo, domEventData );
+	},
+
 	resize( editor, domTable, columnIndex, vector, rowIndex, options ) {
 		const domResizer = getDomResizer( domTable, columnIndex, rowIndex );
 
@@ -122,4 +156,8 @@ export function getColumnResizerRect( resizerElement ) {
 	const resizerPosition = new Point( cellRect.right, cellRect.top + cellRect.height / 2 );
 
 	return resizerPosition;
+}
+
+export function getComputedStyle( element, property ) {
+	return global.window.getComputedStyle( element )[ property ];
 }

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -1198,6 +1198,43 @@ describe( 'TableColumnResizeEditing', () => {
 			expect( getTableColumnsWidths( model.document.getRoot().getChild( 0 ) ) ).to.deep.equal( [ '20%', '25%', '55%' ] );
 		} );
 
+		it( 'does not clean the resizer styles on mouseover if resizing was not finished', () => {
+			setModelData( model, modelTable( [
+				[ '00', '01', '02' ],
+				[ '10', '11', '12' ]
+			], { columnWidths: '20%,25%,55%', tableWidth: '500px' } ) );
+
+			const tableRect = getDomTableRects( getDomTable( view ) );
+
+			tableColumnResizeMouseSimulator.over( editor, getDomResizer( getDomTable( view ), 0, 0 ) );
+			tableColumnResizeMouseSimulator.down( editor, getDomResizer( getDomTable( view ), 0, 0 ) );
+			tableColumnResizeMouseSimulator.move( editor, getDomResizer( getDomTable( view ), 0, 0 ), { x: 10, y: 0 } );
+
+			const resizerAfterMouseOver = getDomResizer( getDomTable( view ), 0, 0 );
+			const resizerRect = new Rect( resizerAfterMouseOver.parentElement );
+
+			const top = Number( ( tableRect.top - resizerRect.top ).toFixed( 4 ) );
+			const bottom = Number( ( resizerRect.bottom - tableRect.bottom ).toFixed( 4 ) );
+
+			expect( getComputedStyle( resizerAfterMouseOver, 'top' ) ).to.equal( top + 'px' );
+			expect( getComputedStyle( resizerAfterMouseOver, 'bottom' ) ).to.equal( bottom + 'px' );
+
+			expect( resizerAfterMouseOver.outerHTML ).to.equal(
+				`<div class="ck-table-column-resizer ck-table-column-resizer__active" style="bottom:${ bottom }px;top:${ top }px;"></div>`
+			);
+
+			const resizerAfterMouseOut = getDomResizer( getDomTable( view ), 0, 0 );
+
+			tableColumnResizeMouseSimulator.out( editor, getDomResizer( getDomTable( view ), 0, 0 ), { x: 10, y: 0 } );
+
+			expect( getComputedStyle( resizerAfterMouseOut, 'top' ) ).to.equal( top + 'px' );
+			expect( getComputedStyle( resizerAfterMouseOut, 'bottom' ) ).to.equal( bottom + 'px' );
+
+			expect( resizerAfterMouseOut.outerHTML ).to.equal(
+				`<div class="ck-table-column-resizer ck-table-column-resizer__active" style="bottom:${ bottom }px;top:${ top }px;"></div>`
+			);
+		} );
+
 		it( 'does not change the widths if the movement vector was {0,0}', () => {
 			// Test-specific.
 			const columnToResizeIndex = 0;

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -25,6 +25,7 @@ import ClipboardPipeline from '@ckeditor/ckeditor5-clipboard/src/clipboardpipeli
 import { focusEditor } from '@ckeditor/ckeditor5-widget/tests/widgetresize/_utils/utils.js';
 import { modelTable } from '../_utils/utils.js';
 import {
+	getComputedStyle,
 	getDomTable,
 	getModelTable,
 	getViewTable,
@@ -1004,6 +1005,16 @@ describe( 'TableColumnResizeEditing', () => {
 
 			expect( resizePlugin._isResizingActive ).to.be.false;
 			expect( getTableColumnsWidths( model.document.getRoot().getChild( 0 ) ) ).to.deep.equal( [ '20%', '25%', '55%' ] );
+
+			tableColumnResizeMouseSimulator.over( editor, view.getDomRoot() );
+
+			expect( resizePlugin._isResizingActive ).to.be.false;
+			expect( getTableColumnsWidths( model.document.getRoot().getChild( 0 ) ) ).to.deep.equal( [ '20%', '25%', '55%' ] );
+
+			tableColumnResizeMouseSimulator.out( editor, view.getDomRoot() );
+
+			expect( resizePlugin._isResizingActive ).to.be.false;
+			expect( getTableColumnsWidths( model.document.getRoot().getChild( 0 ) ) ).to.deep.equal( [ '20%', '25%', '55%' ] );
 		} );
 
 		it( 'if resizing is not allowed', () => {
@@ -1015,6 +1026,16 @@ describe( 'TableColumnResizeEditing', () => {
 			resizePlugin._isResizingAllowed = false;
 
 			tableColumnResizeMouseSimulator.down( editor, getDomResizer( getDomTable( view ), 0, 0 ) );
+
+			expect( resizePlugin._isResizingActive ).to.be.false;
+			expect( getTableColumnsWidths( model.document.getRoot().getChild( 0 ) ) ).to.deep.equal( [ '20%', '25%', '55%' ] );
+
+			tableColumnResizeMouseSimulator.over( editor, getDomResizer( getDomTable( view ), 0, 0 ) );
+
+			expect( resizePlugin._isResizingActive ).to.be.false;
+			expect( getTableColumnsWidths( model.document.getRoot().getChild( 0 ) ) ).to.deep.equal( [ '20%', '25%', '55%' ] );
+
+			tableColumnResizeMouseSimulator.out( editor, getDomResizer( getDomTable( view ), 0, 0 ) );
 
 			expect( resizePlugin._isResizingActive ).to.be.false;
 			expect( getTableColumnsWidths( model.document.getRoot().getChild( 0 ) ) ).to.deep.equal( [ '20%', '25%', '55%' ] );
@@ -1066,6 +1087,46 @@ describe( 'TableColumnResizeEditing', () => {
 			tableColumnResizeMouseSimulator.move( editor, getDomResizer( getDomTable( view ), 0, 0 ), { x: 10, y: 0 } );
 
 			const finalViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( view ) );
+
+			expect( finalViewColumnWidthsPx ).to.deep.equal( initialViewColumnWidthsPx );
+			expect( getTableColumnsWidths( model.document.getRoot().getChild( 0 ) ) ).to.deep.equal( [ '20%', '25%', '55%' ] );
+		} );
+
+		it( 'after mouseover sets resizer sizes, after mouseout removes them', () => {
+			setModelData( model, modelTable( [
+				[ '00', '01', '02' ],
+				[ '10', '11', '12' ]
+			], { columnWidths: '20%,25%,55%', tableWidth: '500px' } ) );
+
+			const initialViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( view ) );
+			const resizerBeforeMouseOver = getDomResizer( getDomTable( view ), 0, 0 );
+
+			expect( resizerBeforeMouseOver.outerHTML ).to.equal( '<div class="ck-table-column-resizer"></div>' );
+			expect( getComputedStyle( resizerBeforeMouseOver, 'top' ) ).to.equal( '0px' );
+			expect( getComputedStyle( resizerBeforeMouseOver, 'bottom' ) ).to.equal( '0px' );
+
+			tableColumnResizeMouseSimulator.over( editor, getDomResizer( getDomTable( view ), 0, 0 ) );
+
+			const finalViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( view ) );
+			const resizerAfterMouseOver = getDomResizer( getDomTable( view ), 0, 0 );
+
+			expect( getComputedStyle( resizerAfterMouseOver, 'top' ) ).to.equal( '-0.5px' );
+			expect( getComputedStyle( resizerAfterMouseOver, 'bottom' ) ).to.equal( '-32.7969px' );
+
+			expect( resizerAfterMouseOver.outerHTML ).to.equal(
+				'<div class="ck-table-column-resizer" style="bottom:-32.7969px;top:-0.5px;"></div>'
+			);
+
+			const resizerAfterMouseOut = getDomResizer( getDomTable( view ), 0, 0 );
+
+			tableColumnResizeMouseSimulator.out( editor, getDomResizer( getDomTable( view ), 0, 0 ), { x: 10, y: 0 } );
+
+			expect( getComputedStyle( resizerAfterMouseOut, 'top' ) ).to.equal( '0px' );
+			expect( getComputedStyle( resizerAfterMouseOut, 'bottom' ) ).to.equal( '0px' );
+
+			expect( resizerAfterMouseOut.outerHTML ).to.equal(
+				'<div class="ck-table-column-resizer"></div>'
+			);
 
 			expect( finalViewColumnWidthsPx ).to.deep.equal( initialViewColumnWidthsPx );
 			expect( getTableColumnsWidths( model.document.getRoot().getChild( 0 ) ) ).to.deep.equal( [ '20%', '25%', '55%' ] );

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -53,6 +53,7 @@ import WidgetResize from '@ckeditor/ckeditor5-widget/src/widgetresize.js';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
 import { Undo } from '@ckeditor/ckeditor5-undo';
 import { MultiRootEditor } from '@ckeditor/ckeditor5-editor-multi-root';
+import Rect from '@ckeditor/ckeditor5-utils/src/dom/rect.js';
 
 describe( 'TableColumnResizeEditing', () => {
 	let model, editor, view, editorElement, contentDirection, resizePlugin;
@@ -1098,6 +1099,8 @@ describe( 'TableColumnResizeEditing', () => {
 				[ '10', '11', '12' ]
 			], { columnWidths: '20%,25%,55%', tableWidth: '500px' } ) );
 
+			const tableRect = getDomTableRects( getDomTable( view ) );
+
 			const initialViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( view ) );
 			const resizerBeforeMouseOver = getDomResizer( getDomTable( view ), 0, 0 );
 
@@ -1110,11 +1113,16 @@ describe( 'TableColumnResizeEditing', () => {
 			const finalViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( view ) );
 			const resizerAfterMouseOver = getDomResizer( getDomTable( view ), 0, 0 );
 
-			expect( getComputedStyle( resizerAfterMouseOver, 'top' ) ).to.equal( '-0.5px' );
-			expect( getComputedStyle( resizerAfterMouseOver, 'bottom' ) ).to.equal( '-32.7969px' );
+			const resizerRect = new Rect( resizerAfterMouseOver.parentElement );
+
+			const top = Number( ( tableRect.top - resizerRect.top ).toFixed( 4 ) );
+			const bottom = Number( ( resizerRect.bottom - tableRect.bottom ).toFixed( 4 ) );
+
+			expect( getComputedStyle( resizerAfterMouseOver, 'top' ) ).to.equal( top + 'px' );
+			expect( getComputedStyle( resizerAfterMouseOver, 'bottom' ) ).to.equal( bottom + 'px' );
 
 			expect( resizerAfterMouseOver.outerHTML ).to.equal(
-				'<div class="ck-table-column-resizer" style="bottom:-32.7969px;top:-0.5px;"></div>'
+				`<div class="ck-table-column-resizer" style="bottom:${ bottom }px;top:${ top }px;"></div>`
 			);
 
 			const resizerAfterMouseOut = getDomResizer( getDomTable( view ), 0, 0 );

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -16,10 +16,6 @@
 	table-layout: fixed;
 }
 
-.ck-content .table table {
-	overflow: hidden;
-}
-
 .ck-content .table td,
 .ck-content .table th {
 	/* To prevent text overflowing beyond its cell when columns are resized by resize handler
@@ -62,8 +58,8 @@
 	   it is extended to an extremely high height. Even for screens with a very high pixel density, the resizer will fulfill its role as
 	   it should, i.e. for a screen of 476 ppi the total height of the resizer will take over 350 sheets of A4 format, which is totally
 	   unrealistic height for a single table. */
-	top: -999999px;
-	bottom: -999999px;
+	/* top: -999999px;
+	bottom: -999999px; */
 }
 
 .ck.ck-editor__editable[dir=rtl] .table .ck-table-column-resizer {

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -54,12 +54,6 @@
 .ck.ck-editor__editable .table .ck-table-column-resizer__active {
 	background-color: var(--ck-color-selector-column-resizer-hover);
 	opacity: 0.25;
-	/* The resizer element resides in each cell so to occupy the entire height of the table, which is unknown from a CSS point of view,
-	   it is extended to an extremely high height. Even for screens with a very high pixel density, the resizer will fulfill its role as
-	   it should, i.e. for a screen of 476 ppi the total height of the resizer will take over 350 sheets of A4 format, which is totally
-	   unrealistic height for a single table. */
-	/* top: -999999px;
-	bottom: -999999px; */
 }
 
 .ck.ck-editor__editable[dir=rtl] .table .ck-table-column-resizer {

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
@@ -18,11 +18,6 @@
 			width: 100%;
 			height: 100%;
 
-			/* Styles to make the layout table outline visible when the layout table is inside another layout table inside edge cells.
-			Currently, this solution works on every browser except Safari. */
-			overflow: clip;
-			overflow-clip-margin: var(--ck-widget-outline-thickness);
-
 			/* Resetting `border-collapse` property to the user agent styles. */
 			border-collapse: revert;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (table): Widgets UI elements should be visible when are inside tables. Closes #18268.

---

### Additional information

⚠️ `release` branch is the target.

ℹ️  To prevent cut off any element that lies inside a layout table (or content table) we decided to calculate the table resizer on demand instead of using `overflow: hidden` hack with huge value of top and bottom to make sure that resizer element will be streched to the top and bottom of the table.
