### PR TITLE
Restore the default class for bookmark toolbar.

### DIFF
--- a/packages/ckeditor5-bookmark/src/bookmarkui.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkui.ts
@@ -136,7 +136,7 @@ export default class BookmarkUI extends Plugin {
 			items: editor.config.get( 'bookmark.toolbar' )!,
 
 			getRelatedElement: getSelectedBookmarkWidget,
-			balloonClassName: 'ck-bookmark-balloon',
+			balloonClassName: 'ck-bookmark-balloon ck-toolbar-container',
 
 			// Override positions to the same list as for balloon panel default
 			// so widget toolbar will try to use same position as form view.

--- a/packages/ckeditor5-bookmark/tests/bookmarkui.js
+++ b/packages/ckeditor5-bookmark/tests/bookmarkui.js
@@ -321,7 +321,7 @@ describe( 'BookmarkUI', () => {
 			setModelData( editor.model, '<paragraph>[<bookmark bookmarkId="foo"></bookmark>]</paragraph>' );
 
 			sinon.assert.calledWithMatch( spy, sinon.match( ( { balloonClassName, view } ) => {
-				return view === toolbarView && balloonClassName === 'ck-bookmark-balloon';
+				return view === toolbarView && balloonClassName === 'ck-bookmark-balloon ck-toolbar-container';
 			} ) );
 		} );
 
@@ -362,7 +362,7 @@ describe( 'BookmarkUI', () => {
 						defaultPositions.viewportStickyNorth
 					]
 				},
-				balloonClassName: 'ck-bookmark-balloon'
+				balloonClassName: 'ck-bookmark-balloon ck-toolbar-container'
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (bookmark): Restore the default CSS class for bookmark toolbar.

---

### Additional information

:warning: target branch: `release`.