### PR TITLE
Make fullscreen scroll to the selection upon entering and leaving

### DIFF
--- a/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-default.html
+++ b/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-default.html
@@ -255,6 +255,10 @@
 		word-break: break-word;
 	}
 
+	.editor-content.ck.ck-content table {
+		margin: 0;
+	}
+
 	.editor-content.ck.ck-content,
 	.editor-content.ck.ck-content.ck-focused {
 		border: 1px solid hsl(0, 0%, 88%);

--- a/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-default.js
+++ b/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-default.js
@@ -709,7 +709,7 @@ generateComments( csConfig, channelId, initialCommentsData )
 				document.querySelector( '#default_toolbar-container' ).appendChild( editor.ui.view.toolbar.element );
 				editor.plugins.get( 'AnnotationsUIs' ).switchTo( 'narrowSidebar' );
 
-				window.editor = editor;
+				window.editorDefault = editor;
 
 				// Prevent showing a warning notification when user is pasting a content from MS Word or Google Docs.
 				window.preventPasteFromOfficeNotification = true;

--- a/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-pageless.html
+++ b/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-pageless.html
@@ -47,5 +47,6 @@
 	.pageless_demo-container .editor-content.ck.ck-content {
 		margin: 0;
 		border: 0;
+		padding: 2em;
 	}
 </style>

--- a/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-pageless.js
+++ b/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-pageless.js
@@ -392,7 +392,7 @@ FullscreenEditor
 	.then( editor => {
 		document.querySelector( '#pageless_toolbar-container' ).appendChild( editor.ui.view.toolbar.element );
 
-		window.editor = editor;
+		window.editorPageless = editor;
 
 		// Prevent showing a warning notification when user is pasting a content from MS Word or Google Docs.
 		window.preventPasteFromOfficeNotification = true;

--- a/packages/ckeditor5-fullscreen/src/fullscreenediting.ts
+++ b/packages/ckeditor5-fullscreen/src/fullscreenediting.ts
@@ -62,7 +62,26 @@ export default class FullscreenEditing extends Plugin {
 				this.editor.editing.view.document.isFocused = false;
 			}
 
+			let viewportOffset: number | { top: number; bottom: number; left: number; right: number };
+
+			if ( this.editor.config.get( 'ui.viewportOffset' ) ) {
+				viewportOffset = {
+					top: this.editor.config.get( 'ui.viewportOffset' )!.top || 0,
+					bottom: this.editor.config.get( 'ui.viewportOffset' )!.bottom || 0,
+					left: this.editor.config.get( 'ui.viewportOffset' )!.left || 0,
+					right: this.editor.config.get( 'ui.viewportOffset' )!.right || 0
+				};
+			} else {
+				viewportOffset = 0;
+			}
+
 			this.editor.editing.view.focus();
+			this.editor.editing.view.scrollToTheSelection( {
+				alignToTop: true,
+				forceScroll: true,
+				ancestorOffset: 50,
+				viewportOffset
+			} );
 
 			cancel();
 		} );

--- a/packages/ckeditor5-fullscreen/src/fullscreenui.ts
+++ b/packages/ckeditor5-fullscreen/src/fullscreenui.ts
@@ -83,6 +83,26 @@ export default class FullscreenUI extends Plugin {
 		this.listenTo( view, 'execute', () => {
 			editor.execute( COMMAND_NAME );
 			editor.editing.view.focus();
+
+			let viewportOffset: number | { top: number; bottom: number; left: number; right: number };
+
+			if ( editor.config.get( 'ui.viewportOffset' ) ) {
+				viewportOffset = {
+					top: editor.config.get( 'ui.viewportOffset' )!.top || 0,
+					bottom: editor.config.get( 'ui.viewportOffset' )!.bottom || 0,
+					left: editor.config.get( 'ui.viewportOffset' )!.left || 0,
+					right: editor.config.get( 'ui.viewportOffset' )!.right || 0
+				};
+			} else {
+				viewportOffset = 0;
+			}
+
+			editor.editing.view.scrollToTheSelection( {
+				alignToTop: true,
+				forceScroll: true,
+				ancestorOffset: 50,
+				viewportOffset
+			} );
 		} );
 
 		return view;

--- a/packages/ckeditor5-fullscreen/tests/fullscreenui.js
+++ b/packages/ckeditor5-fullscreen/tests/fullscreenui.js
@@ -84,14 +84,76 @@ describe( 'FullscreenUI', () => {
 			expect( button.label ).to.equal( 'Enter fullscreen mode' );
 		} );
 
-		it( 'on #execute should call the `fullscreen` command', () => {
-			const spy = sinon.spy( editor.commands.get( 'toggleFullscreen' ), 'execute' );
+		describe( 'on #execute', () => {
+			it( 'should call the `fullscreen` command', () => {
+				const spy = sinon.spy( editor.commands.get( 'toggleFullscreen' ), 'execute' );
 
-			button.fire( 'execute' );
+				button.fire( 'execute' );
 
-			sinon.assert.calledOnce( spy );
+				sinon.assert.calledOnce( spy );
+			} );
 
-			button.fire( 'execute' );
+			describe( 'should scroll', () => {
+				it( 'to the selection', () => {
+					const spy = sinon.spy( editor.editing.view, 'scrollToTheSelection' );
+
+					button.fire( 'execute' );
+
+					expect( spy.calledOnce ).to.be.true;
+				} );
+
+				it( 'and set viewportOffset to 0 if not configured', () => {
+					const spy = sinon.spy( editor.editing.view, 'scrollToTheSelection' );
+
+					button.fire( 'execute' );
+
+					expect( spy.calledOnce ).to.be.true;
+
+					sinon.assert.calledOnceWithExactly( spy, {
+						alignToTop: true,
+						forceScroll: true,
+						ancestorOffset: 50,
+						viewportOffset: 0
+					} );
+				} );
+
+				it( 'and use `config.ui.viewportOffset` if configured', () => {
+					const spy = sinon.spy( editor.editing.view, 'scrollToTheSelection' );
+					editor.config.set( 'ui.viewportOffset', {
+						top: 100,
+						bottom: 200,
+						left: 300,
+						right: 400
+					} );
+
+					button.fire( 'execute' );
+
+					expect( spy.calledOnce ).to.be.true;
+
+					sinon.assert.calledOnceWithExactly( spy, {
+						alignToTop: true,
+						forceScroll: true,
+						ancestorOffset: 50,
+						viewportOffset: { top: 100, bottom: 200, left: 300, right: 400 }
+					} );
+				} );
+
+				it( 'and substitute missing values in `config.ui.viewportOffset`', () => {
+					const spy = sinon.spy( editor.editing.view, 'scrollToTheSelection' );
+					editor.config.set( 'ui.viewportOffset', {} );
+
+					button.fire( 'execute' );
+
+					expect( spy.calledOnce ).to.be.true;
+
+					sinon.assert.calledOnceWithExactly( spy, {
+						alignToTop: true,
+						forceScroll: true,
+						ancestorOffset: 50,
+						viewportOffset: { top: 0, bottom: 0, left: 0, right: 0 }
+					} );
+				} );
+			} );
 		} );
 	} );
 
@@ -129,14 +191,76 @@ describe( 'FullscreenUI', () => {
 			expect( button.isOn ).to.be.false;
 		} );
 
-		it( 'on #execute should call the `toggleFullscreen` command', () => {
-			const spy = sinon.spy( editor.commands.get( 'toggleFullscreen' ), 'execute' );
+		describe( 'on #execute', () => {
+			it( 'should call the `fullscreen` command', () => {
+				const spy = sinon.spy( editor.commands.get( 'toggleFullscreen' ), 'execute' );
 
-			button.fire( 'execute' );
+				button.fire( 'execute' );
 
-			sinon.assert.calledOnce( spy );
+				sinon.assert.calledOnce( spy );
+			} );
 
-			button.fire( 'execute' );
+			describe( 'should scroll', () => {
+				it( 'to the selection', () => {
+					const spy = sinon.spy( editor.editing.view, 'scrollToTheSelection' );
+
+					button.fire( 'execute' );
+
+					expect( spy.calledOnce ).to.be.true;
+				} );
+
+				it( 'and set viewportOffset to 0 if not configured', () => {
+					const spy = sinon.spy( editor.editing.view, 'scrollToTheSelection' );
+
+					button.fire( 'execute' );
+
+					expect( spy.calledOnce ).to.be.true;
+
+					sinon.assert.calledOnceWithExactly( spy, {
+						alignToTop: true,
+						forceScroll: true,
+						ancestorOffset: 50,
+						viewportOffset: 0
+					} );
+				} );
+
+				it( 'and use `config.ui.viewportOffset` if configured', () => {
+					const spy = sinon.spy( editor.editing.view, 'scrollToTheSelection' );
+					editor.config.set( 'ui.viewportOffset', {
+						top: 100,
+						bottom: 200,
+						left: 300,
+						right: 400
+					} );
+
+					button.fire( 'execute' );
+
+					expect( spy.calledOnce ).to.be.true;
+
+					sinon.assert.calledOnceWithExactly( spy, {
+						alignToTop: true,
+						forceScroll: true,
+						ancestorOffset: 50,
+						viewportOffset: { top: 100, bottom: 200, left: 300, right: 400 }
+					} );
+				} );
+
+				it( 'and substitute missing values in `config.ui.viewportOffset`', () => {
+					const spy = sinon.spy( editor.editing.view, 'scrollToTheSelection' );
+					editor.config.set( 'ui.viewportOffset', {} );
+
+					button.fire( 'execute' );
+
+					expect( spy.calledOnce ).to.be.true;
+
+					sinon.assert.calledOnceWithExactly( spy, {
+						alignToTop: true,
+						forceScroll: true,
+						ancestorOffset: 50,
+						viewportOffset: { top: 0, bottom: 0, left: 0, right: 0 }
+					} );
+				} );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (fullscreen): Fullscreen will scroll to the selection upon entering and leaving. Closes https://github.com/ckeditor/ckeditor5/issues/18246.

---

### Additional information

* Fullscreen will scroll to the selection upon entering and leaving using toolbar button, menu bar button or keystrokes.
* It will try to align the editor at the top of the page.
* It uses the `config.ui.viewportOffset` if used to take into account the navbars etc (see our docs where it's set to 100px).
* `ancestorOffset` is used to scroll the view enough to display at least the editor toolbar (in classic editor at least, see manual test).
* Small CSS fixes: for table margin in fullscreen mode and smaller padding for pageless demo.

