### PR TITLE
Improve fullscreen scrolling

### DIFF
--- a/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-default.js
+++ b/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-default.js
@@ -702,14 +702,14 @@ generateComments( csConfig, channelId, initialCommentsData )
 					container: document.querySelector( '#default_presence' )
 				},
 				fullscreen: {
-					onEnterCallback: container => container.classList.add( 'formatted' )
+					onEnterCallback: container => container.classList.add( 'formatted', 'live-snippet' )
 				}
 			} )
 			.then( editor => {
 				document.querySelector( '#default_toolbar-container' ).appendChild( editor.ui.view.toolbar.element );
 				editor.plugins.get( 'AnnotationsUIs' ).switchTo( 'narrowSidebar' );
 
-				window.editor = editor;
+				window.editorDefault = editor;
 
 				// Prevent showing a warning notification when user is pasting a content from MS Word or Google Docs.
 				window.preventPasteFromOfficeNotification = true;

--- a/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-pageless.html
+++ b/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-pageless.html
@@ -42,10 +42,12 @@
 		max-width: 100%;
 		margin: 0;
 		border: 0;
+		padding: 2em;
 	}
 
 	.pageless_demo-container .editor-content.ck.ck-content {
 		margin: 0;
 		border: 0;
+		padding: 2em;
 	}
 </style>

--- a/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-pageless.js
+++ b/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-pageless.js
@@ -382,7 +382,7 @@ FullscreenEditor
 		},
 		cloudServices: csConfig,
 		fullscreen: {
-			onEnterCallback: container => container.classList.add( 'formatted' ),
+			onEnterCallback: container => container.classList.add( 'formatted', 'live-snippet' ),
 			container: document.querySelector( '.main__content' ),
 			menuBar: {
 				isVisible: false
@@ -392,7 +392,7 @@ FullscreenEditor
 	.then( editor => {
 		document.querySelector( '#pageless_toolbar-container' ).appendChild( editor.ui.view.toolbar.element );
 
-		window.editor = editor;
+		window.editorPageless = editor;
 
 		// Prevent showing a warning notification when user is pasting a content from MS Word or Google Docs.
 		window.preventPasteFromOfficeNotification = true;

--- a/packages/ckeditor5-fullscreen/src/fullscreenediting.ts
+++ b/packages/ckeditor5-fullscreen/src/fullscreenediting.ts
@@ -63,6 +63,7 @@ export default class FullscreenEditing extends Plugin {
 			}
 
 			this.editor.editing.view.focus();
+			this.editor.editing.view.scrollToTheSelection();
 
 			cancel();
 		} );

--- a/packages/ckeditor5-fullscreen/src/fullscreenui.ts
+++ b/packages/ckeditor5-fullscreen/src/fullscreenui.ts
@@ -83,6 +83,7 @@ export default class FullscreenUI extends Plugin {
 		this.listenTo( view, 'execute', () => {
 			editor.execute( COMMAND_NAME );
 			editor.editing.view.focus();
+			editor.editing.view.scrollToTheSelection();
 		} );
 
 		return view;

--- a/packages/ckeditor5-fullscreen/src/handlers/abstracteditorhandler.ts
+++ b/packages/ckeditor5-fullscreen/src/handlers/abstracteditorhandler.ts
@@ -677,9 +677,16 @@ export default class AbstractEditorHandler {
 		}
 
 		while ( element ) {
-			const overflow = element.style.overflowY || global.window.getComputedStyle( element ).overflowY;
+			const overflowY = element.style.overflowY || global.window.getComputedStyle( element ).overflowY;
+			const overflowX = element.style.overflowX || global.window.getComputedStyle( element ).overflowX;
 
-			if ( overflow === 'auto' || overflow === 'scroll' ) {
+			// Out of 5 possible keyword values: visible, hidden, clip, scroll and auto - only the last two allow for scrolling.
+			if (
+				overflowY === 'auto' ||
+				overflowY === 'scroll' ||
+				overflowX === 'auto' ||
+				overflowX === 'scroll'
+			) {
 				this._savedAncestorsScrollPositions.set( element, {
 					scrollLeft: element.scrollLeft,
 					scrollTop: element.scrollTop

--- a/packages/ckeditor5-fullscreen/tests/fullscreenediting.js
+++ b/packages/ckeditor5-fullscreen/tests/fullscreenediting.js
@@ -73,15 +73,14 @@ describe( 'FullscreenEditing', () => {
 		return tempEditor.destroy();
 	} );
 
-	it( 'should register keystrokes on init ', () => {
+	it( 'should register keystrokes on init', () => {
 		const spy = sinon.spy( editor.keystrokes, 'set' );
 		editor.plugins.get( 'FullscreenEditing' ).init();
 
 		expect( spy ).to.have.been.calledOnce;
 	} );
 
-	it( 'should toggle fullscreen mode on keystroke combination', () => {
-		const spy = sinon.spy( editor, 'execute' );
+	describe( 'on Ctrl+Shift+F keystroke combination', () => {
 		const keyEventData = {
 			keyCode: keyCodes.f,
 			ctrlKey: !env.isMac,
@@ -91,34 +90,45 @@ describe( 'FullscreenEditing', () => {
 			stopPropagation: sinon.spy()
 		};
 
-		editor.keystrokes.press( keyEventData );
+		it( 'should toggle fullscreen mode', () => {
+			const spy = sinon.spy( editor, 'execute' );
 
-		expect( spy.calledOnce ).to.be.true;
-		expect( spy.calledWithExactly( 'toggleFullscreen' ) ).to.be.true;
+			editor.keystrokes.press( keyEventData );
 
-		editor.keystrokes.press( keyEventData );
+			expect( spy.calledOnce ).to.be.true;
+			expect( spy.calledWithExactly( 'toggleFullscreen' ) ).to.be.true;
 
-		expect( spy.calledTwice ).to.be.true;
-	} );
+			editor.keystrokes.press( keyEventData );
 
-	it( 'should force editable blur on keystroke combination on non-Chromium browsers', () => {
-		const keyEventData = {
-			keyCode: keyCodes.f,
-			ctrlKey: !env.isMac,
-			metaKey: env.isMac,
-			shiftKey: true,
-			preventDefault: sinon.spy(),
-			stopPropagation: sinon.spy()
-		};
+			expect( spy.calledTwice ).to.be.true;
+		} );
 
-		sinon.stub( env, 'isBlink' ).value( false );
+		it( 'should force editable blur on non-Chromium browsers', () => {
+			sinon.stub( env, 'isBlink' ).value( false );
 
-		editor.keystrokes.press( keyEventData );
+			editor.keystrokes.press( keyEventData );
 
-		expect( global.document.activeElement ).to.equal( editor.ui.getEditableElement() );
+			expect( global.document.activeElement ).to.equal( editor.ui.getEditableElement() );
 
-		editor.keystrokes.press( keyEventData );
+			editor.keystrokes.press( keyEventData );
 
-		expect( global.document.activeElement ).to.equal( editor.ui.getEditableElement() );
+			expect( global.document.activeElement ).to.equal( editor.ui.getEditableElement() );
+		} );
+
+		it( 'should focus the editable element', () => {
+			const spy = sinon.spy( editor.editing.view, 'focus' );
+
+			editor.keystrokes.press( keyEventData );
+
+			expect( spy.calledOnce ).to.be.true;
+		} );
+
+		it( 'should scroll to the selection', () => {
+			const spy = sinon.spy( editor.editing.view, 'scrollToTheSelection' );
+
+			editor.keystrokes.press( keyEventData );
+
+			expect( spy.calledOnce ).to.be.true;
+		} );
 	} );
 } );

--- a/packages/ckeditor5-fullscreen/tests/fullscreenui.js
+++ b/packages/ckeditor5-fullscreen/tests/fullscreenui.js
@@ -84,14 +84,30 @@ describe( 'FullscreenUI', () => {
 			expect( button.label ).to.equal( 'Enter fullscreen mode' );
 		} );
 
-		it( 'on #execute should call the `fullscreen` command', () => {
-			const spy = sinon.spy( editor.commands.get( 'toggleFullscreen' ), 'execute' );
+		describe( 'on #execute', () => {
+			it( 'should call the `fullscreen` command', () => {
+				const spy = sinon.spy( editor.commands.get( 'toggleFullscreen' ), 'execute' );
 
-			button.fire( 'execute' );
+				button.fire( 'execute' );
 
-			sinon.assert.calledOnce( spy );
+				sinon.assert.calledOnce( spy );
+			} );
 
-			button.fire( 'execute' );
+			it( 'should focus the editable element', () => {
+				const spy = sinon.spy( editor.editing.view, 'focus' );
+
+				button.fire( 'execute' );
+
+				expect( spy.calledOnce ).to.be.true;
+			} );
+
+			it( 'should scroll to the selection', () => {
+				const spy = sinon.spy( editor.editing.view, 'scrollToTheSelection' );
+
+				button.fire( 'execute' );
+
+				expect( spy.calledOnce ).to.be.true;
+			} );
 		} );
 	} );
 
@@ -129,14 +145,30 @@ describe( 'FullscreenUI', () => {
 			expect( button.isOn ).to.be.false;
 		} );
 
-		it( 'on #execute should call the `toggleFullscreen` command', () => {
-			const spy = sinon.spy( editor.commands.get( 'toggleFullscreen' ), 'execute' );
+		describe( 'on #execute', () => {
+			it( 'should call the `fullscreen` command', () => {
+				const spy = sinon.spy( editor.commands.get( 'toggleFullscreen' ), 'execute' );
 
-			button.fire( 'execute' );
+				button.fire( 'execute' );
 
-			sinon.assert.calledOnce( spy );
+				sinon.assert.calledOnce( spy );
+			} );
 
-			button.fire( 'execute' );
+			it( 'should focus the editable element', () => {
+				const spy = sinon.spy( editor.editing.view, 'focus' );
+
+				button.fire( 'execute' );
+
+				expect( spy.calledOnce ).to.be.true;
+			} );
+
+			it( 'should scroll to the selection', () => {
+				const spy = sinon.spy( editor.editing.view, 'scrollToTheSelection' );
+
+				button.fire( 'execute' );
+
+				expect( spy.calledOnce ).to.be.true;
+			} );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-word-count/tests/wordcount.js
+++ b/packages/ckeditor5-word-count/tests/wordcount.js
@@ -23,7 +23,7 @@ import ImageCaptionEditing from '@ckeditor/ckeditor5-image/src/imagecaption/imag
 import ImageBlockEditing from '@ckeditor/ckeditor5-image/src/image/imageblockediting.js';
 
 // Delay related to word-count throttling.
-const DELAY = 255;
+const DELAY = 300;
 
 describe( 'WordCount', () => {
 	testUtils.createSinonSandbox();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (fullscreen): Fullscreen will restore the window and container scroll position while closing. Closes https://github.com/ckeditor/ckeditor5/issues/18246.

Internal (fullscreen): Fullscreen will preserve the scroll to the current selection in the editable when toggling fullscreen. Closes https://github.com/ckeditor/ckeditor5/issues/18259.

---

### Additional information

* On entering fullscreen mode, it will save the scroll position of all (scrollable) ancestors and restore them after leaving.
* Fullscreen will scroll the editor contents to the selection upon entering and leaving. 
* Small CSS fixes: for table margin in fullscreen mode and smaller padding for pageless demo.
