### PR TITLE
Fix for nesting widgets while hovering to prevent cut of the parent UI elements.

### DIFF
--- a/packages/ckeditor5-table/theme/tablelayout.css
+++ b/packages/ckeditor5-table/theme/tablelayout.css
@@ -45,9 +45,15 @@
 			/* Because of setting the opacity to 0.75 to the selection handle for the layout table,
 			it overrides the similar selector in widget (specificity is higher),
 			thats why we must override it here also. */
-			&:has( .ck-widget:hover ) > .ck-widget__selection-handle {
+			&:has( .ck-widget.table:hover ) > .ck-widget__selection-handle {
 				opacity: 0;
 				visibility: hidden;
+			}
+
+			&.ck-widget_selected {
+				/* To prevent the widget outline from being cut off at the bottom
+				when the next cell or table has a background color, for example. */
+				z-index: var(--ck-z-default);
 			}
 		}
 	}

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tablelayout.css
@@ -95,6 +95,8 @@
 					&.ck-widget__type-around__button_before,
 					&.ck-widget__type-around__button_after {
 						transform: translateY(0);
+						/* Same value as inline-image widget because it is after the inline-image in HTML structure */
+						z-index: 2;
 					}
 
 					&.ck-widget__type-around__button_before {
@@ -127,7 +129,9 @@
 					--ck-widget-handler-icon-size: var(--ck-table-layout-widget-handler-icon-size);
 
 					transform: translateY(calc(0px - var(--ck-widget-outline-thickness)));
-					z-index: var(--ck-z-default);
+					/* Value increased by 1 as in selected inline-image widget
+					because it is before the inline-image in HTML structure. */
+					z-index: 3;
 				}
 			}
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widget.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widget.css
@@ -37,13 +37,6 @@
 	&:hover {
 		outline-color: var(--ck-color-widget-hover-border);
 	}
-
-	/*
-	 * Hide the outline of all widget parents when the widget is being hovered.
-	 */
-	&:has( .ck-widget:hover ) {
-		outline-color: transparent;
-	}
 }
 
 .ck .ck-editor__nested-editable {
@@ -143,12 +136,6 @@
 			}
 		}
 	}
-
-	/* Hide the selection handle on mouse hover over the widget of all the widget parents. */
-	&:has( .ck-widget:hover ) > .ck-widget__selection-handle {
-		opacity: 0;
-		visibility: hidden;
-	}
 }
 
 /* In a RTL environment, align the selection handler to the right side of the widget */
@@ -179,6 +166,19 @@
 			background: var(--ck-color-widget-blurred-border);
 		}
 	}
+}
+
+/*
+* Hide the outline of all widget parents when the widget is being hovered.
+*/
+.ck .ck-widget:has( .ck-widget.table:hover ) {
+	outline-color: transparent;
+}
+
+/* Hide the selection handle on mouse hover over the widget of all the widget parents. */
+.ck .ck-widget.ck-widget_with-selection-handle:has( .ck-widget.table:hover ) > .ck-widget__selection-handle {
+	opacity: 0;
+	visibility: hidden;
 }
 
 /* Style the widget when it's selected but the editable it belongs to lost focus. */

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
@@ -219,15 +219,6 @@
 			opacity: 0
 		}
 	}
-
-	/*
-	 * Hide type around buttons of all widget parents when the widget is being hovered.
-	 */
-	&:has( .ck-widget:hover ) {
-		& > .ck-widget__type-around > .ck-widget__type-around__button {
-			@mixin ck-widget-type-around-button-hidden;
-		}
-	}
 }
 
 /*
@@ -255,6 +246,15 @@
 				@mixin ck-widget-type-around-button-hidden;
 			}
 		}
+	}
+}
+
+/*
+ * Hide type around buttons of all widget parents when the widget is being hovered.
+ */
+.ck .ck-widget:has( .ck-widget.table:hover ) {
+	& > .ck-widget__type-around > .ck-widget__type-around__button {
+		@mixin ck-widget-type-around-button-hidden;
 	}
 }
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (table): Selected or hovered widget should not hide the parent's table ui widgets. See #18245.

Internal (theme-lark): Selected or hovered widget should not hide the parent's table ui widgets. See #18245.

---

### Additional information

#### Before:

<img width="382" alt="Screenshot 2025-04-02 at 11 11 42" src="https://github.com/user-attachments/assets/37cca770-8afa-4cc9-a4a2-89c101d20dfe" />

#### After:

<img width="408" alt="Screenshot 2025-04-02 at 11 11 58" src="https://github.com/user-attachments/assets/99c8e3ba-efff-4207-8b9b-c5cbc641cfe1" />

---

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
