### PR TITLE
Do not focus the editable if user clicked outside of emoji balloon.

### DIFF
--- a/packages/ckeditor5-emoji/src/emojipicker.ts
+++ b/packages/ckeditor5-emoji/src/emojipicker.ts
@@ -247,7 +247,13 @@ export default class EmojiPicker extends Plugin {
 		clickOutsideHandler( {
 			emitter: emojiPickerFormView,
 			contextElements: [ this.balloonPlugin.view.element! ],
-			callback: () => this._hideUI(),
+			callback: () => {
+				// Focusing on the editable during a click outside the balloon panel might
+				// cause the selection to move to the beginning of the editable, so we avoid
+				// focusing on it during this action.
+				// See: https://github.com/ckeditor/ckeditor5/issues/18253
+				this._hideUI( false );
+			},
 			activator: () => this.balloonPlugin.visibleView === emojiPickerFormView
 		} );
 
@@ -256,11 +262,17 @@ export default class EmojiPicker extends Plugin {
 
 	/**
 	 * Hides the balloon with the emoji picker.
+	 *
+	 * @param updateFocus Whether to focus the editor after closing the emoji picker.
 	 */
-	private _hideUI(): void {
+	private _hideUI( updateFocus: boolean = true ): void {
 		this.balloonPlugin.remove( this.emojiPickerFormView! );
 		this.emojiPickerView!.searchView.setInputValue( '' );
-		this.editor.editing.view.focus();
+
+		if ( updateFocus ) {
+			this.editor.editing.view.focus();
+		}
+
 		this._hideFakeVisualSelection();
 	}
 

--- a/packages/ckeditor5-emoji/tests/emojipicker.js
+++ b/packages/ckeditor5-emoji/tests/emojipicker.js
@@ -391,9 +391,12 @@ describe( 'EmojiPicker', () => {
 		it( 'should close the picker when clicking outside of it', () => {
 			emojiPicker.showUI();
 
+			const focusSpy = sinon.spy( editor.editing.view, 'focus' );
+
 			document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
 
 			expect( emojiPicker.balloonPlugin.visibleView ).to.equal( null );
+			expect( focusSpy ).not.to.be.called;
 		} );
 
 		it( 'should close the picker when focus is on the picker and escape is clicked', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (emoji): Third click on emoji toolbar button no longer opens the balloon at the top of the editor. Closes https://github.com/ckeditor/ckeditor5/issues/18253

---

### Additional information

Missing part of this PR: https://github.com/ckeditor/ckeditor5/pull/18281
