### PR TITLE
Sticky toolbar with viewport top offset and visual viewport is now truly sticky

### DIFF
--- a/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.ts
@@ -376,7 +376,7 @@ export default class StickyPanelView extends View {
 	}
 
 	/**
-	 * TODO
+	 * Returns normalized visual viewport offsets (only for Safari and iOS).
 	 */
 	private _getVisualViewportOffset(): { left: number; top: number } {
 		const visualViewport = global.window.visualViewport;

--- a/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.ts
@@ -15,15 +15,11 @@ import type ViewCollection from '../../viewcollection.js';
 import {
 	type Locale,
 	type ObservableChangeEvent,
-	global,
+	Rect,
 	toUnit,
-	Rect
+	global,
+	env
 } from '@ckeditor/ckeditor5-utils';
-
-// @if CK_DEBUG_STICKYPANEL // const {
-// @if CK_DEBUG_STICKYPANEL // 	default: RectDrawer,
-// @if CK_DEBUG_STICKYPANEL // 	diagonalStylesBlack
-// @if CK_DEBUG_STICKYPANEL // } = require( '@ckeditor/ckeditor5-utils/tests/_utils/rectdrawer' );
 
 import '../../../theme/components/panel/stickypanel.css';
 
@@ -244,10 +240,14 @@ export default class StickyPanelView extends View {
 			this.checkIfShouldBeSticky();
 		} );
 
-		if ( global.window.visualViewport ) {
-			this.listenTo( global.window.visualViewport, 'scroll', () => this._updateVisualViewport() );
-			this.listenTo( global.window.visualViewport, 'resize', () => this._updateVisualViewport() );
-			this._updateVisualViewport();
+		if ( ( env.isiOS || env.isSafari ) && global.window.visualViewport ) {
+			this.listenTo( global.window.visualViewport, 'scroll', () => {
+				this.checkIfShouldBeSticky();
+			} );
+
+			this.listenTo( global.window.visualViewport, 'resize', () => {
+				this.checkIfShouldBeSticky();
+			} );
 		}
 	}
 
@@ -256,62 +256,50 @@ export default class StickyPanelView extends View {
 	 * Then handles the positioning of the panel.
 	 */
 	public checkIfShouldBeSticky(): void {
-		// @if CK_DEBUG_STICKYPANEL // RectDrawer.clear();
-
 		if ( !this.limiterElement || !this.isActive ) {
 			this._unstick();
 
 			return;
 		}
 
-		const limiterRect = new Rect( this.limiterElement );
+		const {
+			left: visualViewportOffsetLeft,
+			top: visualViewportOffsetTop
+		} = this._getVisualViewportOffset();
 
+		const limiterRect = new Rect( this.limiterElement );
 		let visibleLimiterRect = limiterRect.getVisible();
 
 		if ( visibleLimiterRect ) {
 			const windowRect = new Rect( global.window );
+			let viewportTopOffset = this.viewportTopOffset;
 
-			windowRect.top += this.viewportTopOffset;
-			windowRect.height -= this.viewportTopOffset;
+			if ( env.isiOS || env.isSafari ) {
+				// Adjust the viewport top offset to height visible in the visual viewport.
+				viewportTopOffset = visualViewportOffsetTop > this.viewportTopOffset ? 0 : this.viewportTopOffset - visualViewportOffsetTop;
+			}
+
+			windowRect.top += viewportTopOffset;
+			windowRect.height -= viewportTopOffset;
 
 			visibleLimiterRect = visibleLimiterRect.getIntersection( windowRect );
 		}
 
-		// @if CK_DEBUG_STICKYPANEL // if ( visibleLimiterRect ) {
-		// @if CK_DEBUG_STICKYPANEL // 	RectDrawer.draw( visibleLimiterRect,
-		// @if CK_DEBUG_STICKYPANEL // 		{ outlineWidth: '3px', opacity: '.8', outlineColor: 'red', outlineOffset: '-3px' },
-		// @if CK_DEBUG_STICKYPANEL // 		'Visible anc'
-		// @if CK_DEBUG_STICKYPANEL // 	);
-		// @if CK_DEBUG_STICKYPANEL // }
-		// @if CK_DEBUG_STICKYPANEL //
-		// @if CK_DEBUG_STICKYPANEL // RectDrawer.draw( limiterRect,
-		// @if CK_DEBUG_STICKYPANEL // 	{ outlineWidth: '3px', opacity: '.8', outlineColor: 'green', outlineOffset: '-3px' },
-		// @if CK_DEBUG_STICKYPANEL // 	'Limiter'
-		// @if CK_DEBUG_STICKYPANEL // );
+		limiterRect.moveBy( visualViewportOffsetLeft, visualViewportOffsetTop );
+
+		if ( visibleLimiterRect ) {
+			visibleLimiterRect.moveBy( visualViewportOffsetLeft, visualViewportOffsetTop );
+		}
 
 		// Stick the panel only if
 		// * the limiter's ancestors are intersecting with each other so that some of their rects are visible,
 		// * and the limiter's top edge is above the visible ancestors' top edge.
 		if ( visibleLimiterRect && limiterRect.top < visibleLimiterRect.top ) {
-			// @if CK_DEBUG_STICKYPANEL // RectDrawer.draw( visibleLimiterRect,
-			// @if CK_DEBUG_STICKYPANEL // 	{ outlineWidth: '3px', opacity: '.8', outlineColor: 'fuchsia', outlineOffset: '-3px',
-			// @if CK_DEBUG_STICKYPANEL // 		backgroundColor: 'rgba(255, 0, 255, .3)' },
-			// @if CK_DEBUG_STICKYPANEL // 	'Visible limiter'
-			// @if CK_DEBUG_STICKYPANEL // );
-
 			const visibleLimiterTop = visibleLimiterRect.top;
 
 			// Check if there's a change the panel can be sticky to the bottom of the limiter.
 			if ( visibleLimiterTop + this._contentPanelRect.height + this.limiterBottomOffset > visibleLimiterRect.bottom ) {
 				const stickyBottomOffset = Math.max( limiterRect.bottom - visibleLimiterRect.bottom, 0 ) + this.limiterBottomOffset;
-				// @if CK_DEBUG_STICKYPANEL // const stickyBottomOffsetRect = new Rect( {
-				// @if CK_DEBUG_STICKYPANEL // 	top: limiterRect.bottom - stickyBottomOffset, left: 0, right: 2000,
-				// @if CK_DEBUG_STICKYPANEL // 	bottom: limiterRect.bottom - stickyBottomOffset, width: 2000, height: 1
-				// @if CK_DEBUG_STICKYPANEL // } );
-				// @if CK_DEBUG_STICKYPANEL // RectDrawer.draw( stickyBottomOffsetRect,
-				// @if CK_DEBUG_STICKYPANEL // 	{ outlineWidth: '1px', opacity: '.8', outlineColor: 'black' },
-				// @if CK_DEBUG_STICKYPANEL // 	'Sticky bottom offset'
-				// @if CK_DEBUG_STICKYPANEL // );
 
 				// Check if sticking the panel to the bottom of the limiter does not cause it to suddenly
 				// move upwards if there's not enough space for it.
@@ -321,12 +309,10 @@ export default class StickyPanelView extends View {
 				} else {
 					this._unstick();
 				}
+			} else if ( this._contentPanelRect.height + this.limiterBottomOffset < limiterRect.height ) {
+				this._stickToTopOfAncestors( visibleLimiterTop );
 			} else {
-				if ( this._contentPanelRect.height + this.limiterBottomOffset < limiterRect.height ) {
-					this._stickToTopOfAncestors( visibleLimiterTop );
-				} else {
-					this._unstick();
-				}
+				this._unstick();
 			}
 		} else {
 			this._unstick();
@@ -337,14 +323,6 @@ export default class StickyPanelView extends View {
 		// @if CK_DEBUG_STICKYPANEL // console.log( '_isStickyToTheBottomOfLimiter', this._isStickyToTheBottomOfLimiter );
 		// @if CK_DEBUG_STICKYPANEL // console.log( '_stickyTopOffset', this._stickyTopOffset );
 		// @if CK_DEBUG_STICKYPANEL // console.log( '_stickyBottomOffset', this._stickyBottomOffset );
-		// @if CK_DEBUG_STICKYPANEL // if ( visibleLimiterRect ) {
-		// @if CK_DEBUG_STICKYPANEL // 	RectDrawer.draw( visibleLimiterRect,
-		// @if CK_DEBUG_STICKYPANEL // 		{ ...diagonalStylesBlack,
-		// @if CK_DEBUG_STICKYPANEL // 			outlineWidth: '3px', opacity: '.8', outlineColor: 'orange', outlineOffset: '-3px',
-		// @if CK_DEBUG_STICKYPANEL // 			backgroundColor: 'rgba(0, 0, 255, .2)' },
-		// @if CK_DEBUG_STICKYPANEL // 		'visibleLimiterRect'
-		// @if CK_DEBUG_STICKYPANEL // 	);
-		// @if CK_DEBUG_STICKYPANEL // }
 	}
 
 	/**
@@ -358,7 +336,7 @@ export default class StickyPanelView extends View {
 		this._isStickyToTheBottomOfLimiter = false;
 		this._stickyTopOffset = topOffset;
 		this._stickyBottomOffset = null;
-		this._marginLeft = toPx( -global.window.scrollX );
+		this._marginLeft = toPx( -global.window.scrollX + this._getVisualViewportOffset().left );
 	}
 
 	/**
@@ -372,7 +350,7 @@ export default class StickyPanelView extends View {
 		this._isStickyToTheBottomOfLimiter = true;
 		this._stickyTopOffset = null;
 		this._stickyBottomOffset = stickyBottomOffset;
-		this._marginLeft = toPx( -global.window.scrollX );
+		this._marginLeft = toPx( -global.window.scrollX + this._getVisualViewportOffset().left );
 	}
 
 	/**
@@ -398,10 +376,18 @@ export default class StickyPanelView extends View {
 	}
 
 	/**
-	 * Sets custom CSS properties to the panel element to make it aware of the visual viewport offset.
+	 * TODO
 	 */
-	private _updateVisualViewport(): void {
-		this.element!.style.setProperty( '--ck-visual-viewport-left', `${ global.window.visualViewport!.offsetLeft }px` );
-		this.element!.style.setProperty( '--ck-visual-viewport-top', `${ global.window.visualViewport!.offsetTop }px` );
+	private _getVisualViewportOffset(): { left: number; top: number } {
+		const visualViewport = global.window.visualViewport;
+
+		if ( !( env.isiOS || env.isSafari ) || !visualViewport ) {
+			return { left: 0, top: 0 };
+		}
+
+		const left = Math.max( Math.round( visualViewport.offsetLeft ), 0 );
+		const top = Math.max( Math.round( visualViewport.offsetTop ), 0 );
+
+		return { left, top };
 	}
 }

--- a/packages/ckeditor5-ui/tests/panel/sticky/stickypanelview.js
+++ b/packages/ckeditor5-ui/tests/panel/sticky/stickypanelview.js
@@ -11,6 +11,7 @@ import View from '../../../src/view.js';
 import LabelView from '../../../src/label/labelview.js';
 import ViewCollection from '../../../src/viewcollection.js';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
+import env from '@ckeditor/ckeditor5-utils/src/env.js';
 
 describe( 'StickyPanelView', () => {
 	let view, element, contentPanelElement, placeholderElement, limiterElement, locale;
@@ -230,94 +231,78 @@ describe( 'StickyPanelView', () => {
 			expect( spy.calledThrice ).to.be.true;
 		} );
 
-		it( 'sets up listeners for visualViewport events when available', () => {
-			const viewportStub = sinon.stub( visualViewport, 'addEventListener' );
-			const updateSpy = testUtils.sinon.spy( StickyPanelView.prototype, '_updateVisualViewport' );
+		it( 'does not set up listeners for visualViewport#scroll event when available (not iOS, not Safari)', () => {
+			const spy = testUtils.sinon.spy( view, 'checkIfShouldBeSticky' );
+			expect( spy.notCalled ).to.be.true;
 
 			view.render();
+			expect( spy.calledOnce ).to.be.true;
 
-			expect( updateSpy.calledOnce ).to.be.true;
-
-			expect( visualViewport.addEventListener.calledWith( 'scroll' ) ).to.be.true;
-			expect( visualViewport.addEventListener.calledWith( 'resize' ) ).to.be.true;
-
-			viewportStub.restore();
+			visualViewport.dispatchEvent( new Event( 'scroll' ) );
+			expect( spy.calledOnce ).to.be.true;
 		} );
-	} );
 
-	describe( '_updateVisualViewport()', () => {
-		let view, viewportStub, updateVisualViewportSpy;
+		it( 'sets up listeners for visualViewport#scroll event when available (iOS)', () => {
+			sinon.stub( env, 'isiOS' ).value( true );
 
-		beforeEach( () => {
-			view = new StickyPanelView();
-
-			viewportStub = sinon.stub( visualViewport, 'addEventListener' );
-			updateVisualViewportSpy = testUtils.sinon.spy( view, '_updateVisualViewport' );
+			const spy = testUtils.sinon.spy( view, 'checkIfShouldBeSticky' );
+			expect( spy.notCalled ).to.be.true;
 
 			view.render();
+			expect( spy.calledOnce ).to.be.true;
+
+			visualViewport.dispatchEvent( new Event( 'scroll' ) );
+			expect( spy.calledTwice ).to.be.true;
 		} );
 
-		afterEach( () => {
-			sinon.restore();
+		it( 'sets up listeners for visualViewport#scroll event when available (Safari)', () => {
+			sinon.stub( env, 'isSafari' ).value( true );
+
+			const spy = testUtils.sinon.spy( view, 'checkIfShouldBeSticky' );
+			expect( spy.notCalled ).to.be.true;
+
+			view.render();
+			expect( spy.calledOnce ).to.be.true;
+
+			visualViewport.dispatchEvent( new Event( 'scroll' ) );
+			expect( spy.calledTwice ).to.be.true;
 		} );
 
-		it( 'should call updateVisualViewport() on render()', () => {
-			expect( updateVisualViewportSpy.calledOnce ).to.be.true;
+		it( 'does not set up listeners for visualViewport#resize event when available (not iOS, not Safari)', () => {
+			const spy = testUtils.sinon.spy( view, 'checkIfShouldBeSticky' );
+			expect( spy.notCalled ).to.be.true;
+
+			view.render();
+			expect( spy.calledOnce ).to.be.true;
+
+			visualViewport.dispatchEvent( new Event( 'resize' ) );
+			expect( spy.calledOnce ).to.be.true;
 		} );
 
-		it( 'should set CSS custom properties based on visual viewport offsets', () => {
-			sinon.stub( visualViewport, 'offsetLeft' ).get( () => 15 );
-			sinon.stub( visualViewport, 'offsetTop' ).get( () => 25 );
+		it( 'sets up listeners for visualViewport#resize event when available (iOS)', () => {
+			sinon.stub( env, 'isiOS' ).value( true );
 
-			view._updateVisualViewport();
+			const spy = testUtils.sinon.spy( view, 'checkIfShouldBeSticky' );
+			expect( spy.notCalled ).to.be.true;
 
-			expect( view.element.style.getPropertyValue( '--ck-visual-viewport-left' ) ).to.equal( '15px' );
-			expect( view.element.style.getPropertyValue( '--ck-visual-viewport-top' ) ).to.equal( '25px' );
+			view.render();
+			expect( spy.calledOnce ).to.be.true;
+
+			visualViewport.dispatchEvent( new Event( 'resize' ) );
+			expect( spy.calledTwice ).to.be.true;
 		} );
 
-		it( 'should update CSS properties when offsetLeft and offsetTop changes', () => {
-			// Initial state.
-			view._updateVisualViewport();
+		it( 'sets up listeners for visualViewport#resize event when available (Safari)', () => {
+			sinon.stub( env, 'isSafari' ).value( true );
 
-			expect( view.element.style.getPropertyValue( '--ck-visual-viewport-left' ) ).to.equal( '0px' );
-			expect( view.element.style.getPropertyValue( '--ck-visual-viewport-top' ) ).to.equal( '0px' );
+			const spy = testUtils.sinon.spy( view, 'checkIfShouldBeSticky' );
+			expect( spy.notCalled ).to.be.true;
 
-			// Update viewport position.
-			sinon.stub( visualViewport, 'offsetLeft' ).get( () => 30 );
-			sinon.stub( visualViewport, 'offsetTop' ).get( () => 40 );
+			view.render();
+			expect( spy.calledOnce ).to.be.true;
 
-			view._updateVisualViewport();
-
-			expect( view.element.style.getPropertyValue( '--ck-visual-viewport-left' ) ).to.equal( '30px' );
-			expect( view.element.style.getPropertyValue( '--ck-visual-viewport-top' ) ).to.equal( '40px' );
-		} );
-
-		it( 'should react to visual viewport scroll events', () => {
-			// Check if correct event listener was added.
-			expect( viewportStub.calledWith( 'scroll' ) ).to.be.true;
-
-			// Get the callback function that was registered.
-			const scrollCallback = viewportStub.args.find( args => args[ 0 ] === 'scroll' )[ 1 ];
-
-			// Simulate the scroll event by calling the callback directly.
-			scrollCallback();
-
-			// Check if the method was called again.
-			expect( updateVisualViewportSpy.calledTwice ).to.be.true;
-		} );
-
-		it( 'should react to visual viewport resize events', () => {
-			// Check if correct event listener was added.
-			expect( viewportStub.calledWith( 'resize' ) ).to.be.true;
-
-			// Get the callback function that was registered.
-			const resizeCallback = viewportStub.args.find( args => args[ 0 ] === 'resize' )[ 1 ];
-
-			// Simulate the resize event by calling the callback directly.
-			resizeCallback();
-
-			// Check if the method was called again.
-			expect( updateVisualViewportSpy.calledTwice ).to.be.true;
+			visualViewport.dispatchEvent( new Event( 'resize' ) );
+			expect( spy.calledTwice ).to.be.true;
 		} );
 	} );
 
@@ -337,9 +322,13 @@ describe( 'StickyPanelView', () => {
 		} );
 	} );
 
-	describe( 'checkIfShouldBeSticky()', () => {
+	describe( 'checkIfShouldBeSticky() - (non-iOS and non Safari)', () => {
 		beforeEach( () => {
 			view.limiterElement = limiterElement;
+
+			// Set visual viewport offsets - those should be ignored on non iOS and non Safari.
+			sinon.stub( visualViewport, 'offsetLeft' ).get( () => 15 );
+			sinon.stub( visualViewport, 'offsetTop' ).get( () => 25 );
 		} );
 
 		it( 'should unstick the panel if limiter element is not set', () => {
@@ -1047,6 +1036,1368 @@ describe( 'StickyPanelView', () => {
 				expect( view.isSticky ).to.be.false;
 				expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
 				expect( view._marginLeft ).to.equal( null );
+			} );
+		} );
+	} );
+
+	describe( 'checkIfShouldBeSticky() - (iOS or Safari)', () => {
+		beforeEach( () => {
+			view.limiterElement = limiterElement;
+
+			sinon.stub( visualViewport, 'offsetLeft' ).get( () => 15 );
+			sinon.stub( visualViewport, 'offsetTop' ).get( () => 25 );
+
+			sinon.stub( env, 'isSafari' ).value( true );
+		} );
+
+		it( 'should unstick the panel if limiter element is not set', () => {
+			view.limiterElement = null;
+
+			assureStickiness( {
+				isSticky: false,
+				_isStickyToTheBottomOfLimiter: false,
+				_stickyTopOffset: null,
+				_stickyBottomOffset: null,
+				_marginLeft: null
+			} );
+		} );
+
+		it( 'should unstick the panel if it is not active', () => {
+			view.isActive = true;
+
+			const unstickSpy = testUtils.sinon.spy( view, '_unstick' );
+
+			view.isActive = false;
+
+			sinon.assert.calledOnce( unstickSpy );
+			assureStickiness( {
+				isSticky: false,
+				_isStickyToTheBottomOfLimiter: false,
+				_stickyTopOffset: null,
+				_stickyBottomOffset: null,
+				_marginLeft: null
+			} );
+		} );
+
+		describe( 'view.isSticky', () => {
+			beforeEach( () => {
+				testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+					height: 20
+				} );
+			} );
+
+			it( 'is true if beyond the top of the viewport (panel is active)', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( { top: -10, height: 100 } );
+
+				expect( view.isSticky ).to.be.false;
+
+				view.isActive = true;
+
+				expect( view.isSticky ).to.be.true;
+			} );
+
+			it( 'is false if beyond the top of the viewport (panel is inactive)', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( { top: -10, height: 100 } );
+
+				expect( view.isSticky ).to.be.false;
+
+				view.isActive = false;
+
+				expect( view.isSticky ).to.be.false;
+			} );
+
+			it( 'is false if in the viewport (panel is active)', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( { top: 10, height: 100 } );
+
+				expect( view.isSticky ).to.be.false;
+
+				view.isActive = true;
+
+				expect( view.isSticky ).to.be.false;
+			} );
+
+			it( 'is false if view.limiterElement is smaller than the panel and view.limiterBottomOffset (panel is active)', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( { top: -10, height: 60 } );
+
+				view.limiterBottomOffset = 50;
+
+				expect( view.isSticky ).to.be.false;
+
+				view.isActive = true;
+
+				expect( view.isSticky ).to.be.false;
+			} );
+		} );
+
+		describe( 'view._isStickyToTheBottomOfLimiter', () => {
+			it( 'is true if view.isSticky is true and reached the bottom edge of view.limiterElement', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+					top: -80,
+					bottom: 60,
+					height: 140,
+					width: 100,
+					left: 0,
+					right: 100
+				} );
+
+				testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+					height: 20
+				} );
+
+				expect( view.isSticky ).to.be.false;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
+
+				view.isActive = true;
+
+				expect( view.isSticky ).to.be.true;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.true;
+			} );
+
+			it( 'is false if view.isSticky is true and not reached the bottom edge of view.limiterElement', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+					top: -10,
+					bottom: 90,
+					height: 100,
+					width: 100,
+					left: 0,
+					right: 100
+				} );
+
+				testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+					height: 20
+				} );
+
+				expect( view.isSticky ).to.be.false;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
+
+				view.isActive = true;
+
+				expect( view.isSticky ).to.be.true;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
+			} );
+
+			it( 'is false if view.isSticky is false', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+					top: 10
+				} );
+
+				expect( view.isSticky ).to.be.false;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
+
+				view.isActive = true;
+
+				expect( view.isSticky ).to.be.false;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
+			} );
+		} );
+
+		describe( 'after scrolling', () => {
+			it( 'should do nothing if scrolled element does not contain the panel', () => {
+				view.isActive = true;
+
+				const separateElement = document.createElement( 'div' );
+
+				view.checkIfShouldBeSticky( separateElement );
+
+				expect( view.isSticky ).to.be.false;
+			} );
+
+			describe( 'if there is one scrollable non-window parent', () => {
+				let scrollableContainer;
+
+				beforeEach( () => {
+					scrollableContainer = document.createElement( 'div' );
+					scrollableContainer.className = 'scrollable';
+					scrollableContainer.style.overflow = 'scroll';
+					scrollableContainer.appendChild( limiterElement );
+					global.document.body.appendChild( scrollableContainer );
+
+					view.isActive = true;
+				} );
+
+				afterEach( () => {
+					scrollableContainer.remove();
+				} );
+
+				describe( 'scrolled the container', () => {
+					it( 'should make panel sticky to the top if the limiter top is not visible', () => {
+						const stickToTopSpy = testUtils.sinon.spy( view, '_stickToTopOfAncestors' );
+
+						testUtils.sinon.stub( scrollableContainer, 'getBoundingClientRect' ).returns( {
+							top: 40,
+							bottom: 140,
+							height: 100,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+							top: 20,
+							bottom: 200,
+							height: 180,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+							height: 20
+						} );
+
+						view.checkIfShouldBeSticky( scrollableContainer );
+
+						sinon.assert.calledOnce( stickToTopSpy );
+						assureStickiness( {
+							isSticky: true,
+							_isStickyToTheBottomOfLimiter: false,
+							_stickyTopOffset: 65, // The visual viewport top offset is 25 so original offset of 40 is adjusted.
+							_stickyBottomOffset: null,
+							_marginLeft: '15px' // The visual viewport left offset is 15 so original offset of 0 is adjusted.
+						} );
+					} );
+
+					it( 'should make panel sticky to the bottom if there is enough space left', () => {
+						const stickToBottomSpy = testUtils.sinon.spy( view, '_stickToBottomOfLimiter' );
+
+						testUtils.sinon.stub( scrollableContainer, 'getBoundingClientRect' ).returns( {
+							top: 40,
+							bottom: 140,
+							height: 100,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+							top: -80,
+							bottom: 60,
+							height: 140,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+							height: 20
+						} );
+
+						view.checkIfShouldBeSticky( scrollableContainer );
+
+						expect( view.isSticky ).to.be.true;
+						expect( view._isStickyToTheBottomOfLimiter ).to.be.true;
+
+						sinon.assert.calledOnce( stickToBottomSpy );
+						assureStickiness( {
+							isSticky: true,
+							_isStickyToTheBottomOfLimiter: true,
+							_stickyTopOffset: null,
+							_stickyBottomOffset: 50,
+							_marginLeft: '15px' // The visual viewport left offset is 15 so original offset of 0 is adjusted.
+						} );
+					} );
+
+					it( 'avoid flickering of the panel when sticking to the bottom and offset almost equals the height', () => {
+						const stickToBottomSpy = testUtils.sinon.spy( view, '_stickToBottomOfLimiter' );
+
+						testUtils.sinon.stub( scrollableContainer, 'getBoundingClientRect' ).returns( {
+							top: 40,
+							bottom: 140,
+							height: 100,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						const limiterStub = testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' );
+
+						limiterStub.returns( {
+							top: -12,
+							bottom: 60,
+							height: 140,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+							height: 20
+						} );
+
+						view.checkIfShouldBeSticky( scrollableContainer );
+
+						expect( view.isSticky ).to.be.true;
+						expect( view._isStickyToTheBottomOfLimiter ).to.be.true;
+
+						sinon.assert.calledOnce( stickToBottomSpy );
+						assureStickiness( {
+							isSticky: true,
+							_isStickyToTheBottomOfLimiter: true,
+							_stickyTopOffset: null,
+							_stickyBottomOffset: 50,
+							_marginLeft: '15px' // The visual viewport left offset is 15 so original offset of 0 is adjusted.
+						} );
+
+						// Check if extra `+ 1px` works properly. It should fail.
+						limiterStub.returns( {
+							top: -11,
+							bottom: 60,
+							height: 140,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						view.checkIfShouldBeSticky( scrollableContainer );
+
+						expect( view.isSticky ).to.be.false;
+						expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
+					} );
+
+					it( 'should unstick the panel if the limiter top is still visible', () => {
+						const stickToBottomSpy = testUtils.sinon.spy( view, '_stickToBottomOfLimiter' );
+						const stickToTopSpy = testUtils.sinon.spy( view, '_stickToTopOfAncestors' );
+						const unstickSpy = testUtils.sinon.spy( view, '_unstick' );
+
+						testUtils.sinon.stub( scrollableContainer, 'getBoundingClientRect' ).returns( {
+							top: 20,
+							bottom: 140,
+							height: 120,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+							top: 20,
+							bottom: 200,
+							height: 180,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+							height: 20
+						} );
+
+						view.checkIfShouldBeSticky( scrollableContainer );
+
+						sinon.assert.notCalled( stickToBottomSpy );
+						sinon.assert.notCalled( stickToTopSpy );
+						sinon.assert.calledOnce( unstickSpy );
+						assureStickiness( {
+							isSticky: false,
+							_isStickyToTheBottomOfLimiter: false,
+							_stickyTopOffset: null,
+							_stickyBottomOffset: null,
+							_marginLeft: null
+						} );
+					} );
+
+					it( 'should unstick the panel if there is not enough space left in the limiter', () => {
+						const spy = sinon.spy( view, '_unstick' );
+
+						testUtils.sinon.stub( scrollableContainer, 'getBoundingClientRect' ).returns( {
+							top: 40,
+							bottom: 140,
+							height: 100,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+							top: -80,
+							bottom: 60,
+							height: 140,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+							height: 100
+						} );
+
+						view.checkIfShouldBeSticky( scrollableContainer );
+
+						sinon.assert.calledOnce( spy );
+						assureStickiness( {
+							isSticky: false,
+							_isStickyToTheBottomOfLimiter: false,
+							_stickyTopOffset: null,
+							_stickyBottomOffset: null,
+							_marginLeft: null
+						} );
+					} );
+
+					it( 'should unstick the panel if panel limiter is not visible in the viewport', () => {
+						const spy = sinon.spy( view, '_unstick' );
+
+						testUtils.sinon.stub( scrollableContainer, 'getBoundingClientRect' ).returns( {
+							top: 120,
+							bottom: 140,
+							height: 100,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+							top: -80,
+							bottom: 60,
+							height: 140,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+							height: 20
+						} );
+
+						view.checkIfShouldBeSticky( scrollableContainer );
+
+						sinon.assert.calledOnce( spy );
+						assureStickiness( {
+							isSticky: false,
+							_isStickyToTheBottomOfLimiter: false,
+							_stickyTopOffset: null,
+							_stickyBottomOffset: null,
+							_marginLeft: null
+						} );
+					} );
+				} );
+			} );
+
+			describe( 'if there are multiple scrollable non-window parents', () => {
+				let scrollableOuterParent, scrollableInnerParent;
+
+				beforeEach( () => {
+					scrollableOuterParent = document.createElement( 'div' );
+					scrollableOuterParent.className = 'scrollable-outer';
+					scrollableOuterParent.style.overflow = 'scroll';
+
+					scrollableInnerParent = document.createElement( 'div' );
+					scrollableInnerParent.className = 'scrollable-inner';
+					scrollableInnerParent.style.overflow = 'scroll';
+
+					scrollableInnerParent.appendChild( limiterElement );
+					scrollableOuterParent.appendChild( scrollableInnerParent );
+					global.document.body.appendChild( scrollableOuterParent );
+
+					view.isActive = true;
+				} );
+
+				afterEach( () => {
+					scrollableInnerParent.remove();
+					scrollableOuterParent.remove();
+				} );
+
+				it( 'should unstick the panel if the limiter is still visible', () => {
+					const unstickSpy = testUtils.sinon.spy( view, '_unstick' );
+
+					testUtils.sinon.stub( scrollableOuterParent, 'getBoundingClientRect' ).returns( {
+						top: 10,
+						bottom: 160,
+						height: 150,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( scrollableInnerParent, 'getBoundingClientRect' ).returns( {
+						top: 20,
+						bottom: 140,
+						height: 120,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+						top: 40,
+						bottom: 100,
+						height: 60,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+						height: 20
+					} );
+
+					view.checkIfShouldBeSticky( scrollableOuterParent );
+
+					sinon.assert.calledOnce( unstickSpy );
+					assureStickiness( {
+						isSticky: false,
+						_isStickyToTheBottomOfLimiter: false,
+						_stickyTopOffset: null,
+						_stickyBottomOffset: null,
+						_marginLeft: null
+					} );
+				} );
+
+				it( 'should stick the panel to the top if the outer container was scrolled over the limiter top', () => {
+					const stickToTopSpy = testUtils.sinon.spy( view, '_stickToTopOfAncestors' );
+
+					testUtils.sinon.stub( scrollableOuterParent, 'getBoundingClientRect' ).returns( {
+						top: 50,
+						bottom: 160,
+						height: 150,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( scrollableInnerParent, 'getBoundingClientRect' ).returns( {
+						top: 20,
+						bottom: 140,
+						height: 120,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+						top: 40,
+						bottom: 140,
+						height: 100,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+						height: 20
+					} );
+
+					view.checkIfShouldBeSticky( scrollableOuterParent );
+
+					sinon.assert.calledOnce( stickToTopSpy );
+					assureStickiness( {
+						isSticky: true,
+						_isStickyToTheBottomOfLimiter: false,
+						_stickyTopOffset: 75, // The visual viewport top offset is 25 so original offset of 0 is adjusted.
+						_stickyBottomOffset: null,
+						_marginLeft: '15px' // The visual viewport left offset is 15 so original offset of 0 is adjusted.
+					} );
+				} );
+
+				it( 'should unstick the panel if the outer container was scrolled but there is no space below', () => {
+					const unstickSpy = testUtils.sinon.spy( view, '_unstick' );
+
+					testUtils.sinon.stub( scrollableOuterParent, 'getBoundingClientRect' ).returns( {
+						top: 50,
+						bottom: 160,
+						height: 150,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( scrollableInnerParent, 'getBoundingClientRect' ).returns( {
+						top: 20,
+						bottom: 140,
+						height: 120,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+						top: 40,
+						bottom: 110,
+						height: 60,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+						height: 20
+					} );
+
+					view.checkIfShouldBeSticky( scrollableOuterParent );
+
+					sinon.assert.calledOnce( unstickSpy );
+					assureStickiness( {
+						isSticky: false,
+						_isStickyToTheBottomOfLimiter: false,
+						_stickyTopOffset: null,
+						_stickyBottomOffset: null,
+						_marginLeft: null
+					} );
+				} );
+
+				it( 'should unstick the panel if the outer container was scrolled over the inner container top', () => {
+					const unstickSpy = testUtils.sinon.spy( view, '_unstick' );
+
+					testUtils.sinon.stub( scrollableOuterParent, 'getBoundingClientRect' ).returns( {
+						top: 50,
+						bottom: 160,
+						height: 150,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( scrollableInnerParent, 'getBoundingClientRect' ).returns( {
+						top: -20,
+						bottom: 50,
+						height: 70,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+						top: 0,
+						bottom: 40,
+						height: 40,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+						height: 20
+					} );
+
+					view.checkIfShouldBeSticky( scrollableOuterParent );
+
+					sinon.assert.calledOnce( unstickSpy );
+					assureStickiness( {
+						isSticky: false,
+						_isStickyToTheBottomOfLimiter: false,
+						_stickyTopOffset: null,
+						_stickyBottomOffset: null,
+						_marginLeft: null
+					} );
+				} );
+			} );
+		} );
+
+		describe( 'view._marginLeft', () => {
+			it( 'is set if view.isSticky is true view._stickyTopOffset is set', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+					top: -10,
+					bottom: 70,
+					height: 100,
+					width: 100,
+					left: 0,
+					right: 100
+				} );
+
+				testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+					height: 20
+				} );
+
+				sinon.stub( global.window, 'scrollX' ).value( 10 );
+				sinon.stub( global.window, 'scrollY' ).value( 0 );
+
+				expect( view.isSticky ).to.be.false;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
+				expect( view._marginLeft ).to.equal( null );
+
+				view.isActive = true;
+
+				expect( view.isSticky ).to.be.true;
+				expect( view._stickyTopOffset ).to.not.equal( null );
+				expect( view._marginLeft ).to.equal( '5px' ); // The visual viewport left offset is 15 so original offset of 0 is adjusted.
+			} );
+
+			it( 'is set if view._isStickyToTheBottomOfLimiter is true', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+					top: -30,
+					bottom: 50,
+					left: 60,
+					height: 80,
+					width: 100,
+					right: 160
+				} );
+
+				testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+					height: 20
+				} );
+
+				testUtils.sinon.stub( document.body, 'getBoundingClientRect' ).returns( {
+					left: 40
+				} );
+
+				sinon.stub( global.window, 'innerHeight' ).value( 100 );
+
+				expect( view.isSticky ).to.be.false;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
+				expect( view._marginLeft ).to.equal( null );
+
+				view.isActive = true;
+
+				expect( view.isSticky ).to.be.true;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.true;
+				expect( view._marginLeft ).to.equal( '15px' ); // The visual viewport left offset is 15 so original offset of 0 is adjusted.
+			} );
+
+			it( 'is null if view.isSticky is false', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+					top: 10
+				} );
+
+				expect( view.isSticky ).to.be.false;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
+				expect( view._marginLeft ).to.equal( null );
+
+				view.isActive = true;
+
+				expect( view.isSticky ).to.be.false;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
+				expect( view._marginLeft ).to.equal( null );
+			} );
+		} );
+	} );
+
+	describe( 'checkIfShouldBeSticky() - (iOS or Safari) - viewport top offset is set', () => {
+		beforeEach( () => {
+			view.limiterElement = limiterElement;
+			view.viewportTopOffset = 30;
+
+			sinon.stub( visualViewport, 'offsetLeft' ).get( () => 15 );
+			sinon.stub( visualViewport, 'offsetTop' ).get( () => 25 );
+
+			sinon.stub( env, 'isSafari' ).value( true );
+		} );
+
+		it( 'should unstick the panel if limiter element is not set', () => {
+			view.limiterElement = null;
+
+			assureStickiness( {
+				isSticky: false,
+				_isStickyToTheBottomOfLimiter: false,
+				_stickyTopOffset: null,
+				_stickyBottomOffset: null,
+				_marginLeft: null
+			} );
+		} );
+
+		it( 'should unstick the panel if it is not active', () => {
+			view.isActive = true;
+
+			const unstickSpy = testUtils.sinon.spy( view, '_unstick' );
+
+			view.isActive = false;
+
+			sinon.assert.calledOnce( unstickSpy );
+			assureStickiness( {
+				isSticky: false,
+				_isStickyToTheBottomOfLimiter: false,
+				_stickyTopOffset: null,
+				_stickyBottomOffset: null,
+				_marginLeft: null
+			} );
+		} );
+
+		describe( 'view.isSticky', () => {
+			beforeEach( () => {
+				testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+					height: 20
+				} );
+			} );
+
+			it( 'is true if beyond the top of the viewport (panel is active)', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( { top: -10, height: 100 } );
+
+				expect( view.isSticky ).to.be.false;
+
+				view.isActive = true;
+
+				expect( view.isSticky ).to.be.true;
+			} );
+
+			it( 'is false if beyond the top of the viewport (panel is inactive)', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( { top: -10, height: 100 } );
+
+				expect( view.isSticky ).to.be.false;
+
+				view.isActive = false;
+
+				expect( view.isSticky ).to.be.false;
+			} );
+
+			it( 'is false if in the viewport (panel is active)', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( { top: 10, height: 100 } );
+
+				expect( view.isSticky ).to.be.false;
+
+				view.isActive = true;
+
+				expect( view.isSticky ).to.be.false;
+			} );
+
+			it( 'is false if view.limiterElement is smaller than the panel and view.limiterBottomOffset (panel is active)', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( { top: -10, height: 60 } );
+
+				view.limiterBottomOffset = 50;
+
+				expect( view.isSticky ).to.be.false;
+
+				view.isActive = true;
+
+				expect( view.isSticky ).to.be.false;
+			} );
+		} );
+
+		describe( 'view._isStickyToTheBottomOfLimiter', () => {
+			it( 'is true if view.isSticky is true and reached the bottom edge of view.limiterElement', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+					top: -80,
+					bottom: 60,
+					height: 140,
+					width: 100,
+					left: 0,
+					right: 100
+				} );
+
+				testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+					height: 20
+				} );
+
+				expect( view.isSticky ).to.be.false;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
+
+				view.isActive = true;
+
+				expect( view.isSticky ).to.be.true;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.true;
+			} );
+
+			it( 'is false if view.isSticky is true and not reached the bottom edge of view.limiterElement', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+					top: -10,
+					bottom: 90,
+					height: 100,
+					width: 100,
+					left: 0,
+					right: 100
+				} );
+
+				testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+					height: 20
+				} );
+
+				expect( view.isSticky ).to.be.false;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
+
+				view.isActive = true;
+
+				expect( view.isSticky ).to.be.true;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
+			} );
+
+			it( 'is false if view.isSticky is false', () => {
+				testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+					top: 10
+				} );
+
+				expect( view.isSticky ).to.be.false;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
+
+				view.isActive = true;
+
+				expect( view.isSticky ).to.be.false;
+				expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
+			} );
+		} );
+
+		describe( 'after scrolling', () => {
+			it( 'should do nothing if scrolled element does not contain the panel', () => {
+				view.isActive = true;
+
+				const separateElement = document.createElement( 'div' );
+
+				view.checkIfShouldBeSticky( separateElement );
+
+				expect( view.isSticky ).to.be.false;
+			} );
+
+			describe( 'if there is one scrollable non-window parent', () => {
+				let scrollableContainer;
+
+				beforeEach( () => {
+					scrollableContainer = document.createElement( 'div' );
+					scrollableContainer.className = 'scrollable';
+					scrollableContainer.style.overflow = 'scroll';
+					scrollableContainer.appendChild( limiterElement );
+					global.document.body.appendChild( scrollableContainer );
+
+					view.isActive = true;
+				} );
+
+				afterEach( () => {
+					scrollableContainer.remove();
+				} );
+
+				describe( 'scrolled the container', () => {
+					it( 'should make panel sticky to the top if the limiter top is not visible', () => {
+						const stickToTopSpy = testUtils.sinon.spy( view, '_stickToTopOfAncestors' );
+
+						testUtils.sinon.stub( scrollableContainer, 'getBoundingClientRect' ).returns( {
+							top: 40,
+							bottom: 140,
+							height: 100,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+							top: 20,
+							bottom: 200,
+							height: 180,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+							height: 20
+						} );
+
+						view.checkIfShouldBeSticky( scrollableContainer );
+
+						sinon.assert.calledOnce( stickToTopSpy );
+						assureStickiness( {
+							isSticky: true,
+							_isStickyToTheBottomOfLimiter: false,
+							_stickyTopOffset: 65, // The visual viewport top offset is 25 so original offset of 40 is adjusted.
+							_stickyBottomOffset: null,
+							_marginLeft: '15px' // The visual viewport left offset is 15 so original offset of 0 is adjusted.
+						} );
+					} );
+
+					it( 'should make panel sticky to the bottom if there is enough space left', () => {
+						const stickToBottomSpy = testUtils.sinon.spy( view, '_stickToBottomOfLimiter' );
+
+						testUtils.sinon.stub( scrollableContainer, 'getBoundingClientRect' ).returns( {
+							top: 40,
+							bottom: 140,
+							height: 100,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+							top: -80,
+							bottom: 60,
+							height: 140,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+							height: 20
+						} );
+
+						view.checkIfShouldBeSticky( scrollableContainer );
+
+						expect( view.isSticky ).to.be.true;
+						expect( view._isStickyToTheBottomOfLimiter ).to.be.true;
+
+						sinon.assert.calledOnce( stickToBottomSpy );
+						assureStickiness( {
+							isSticky: true,
+							_isStickyToTheBottomOfLimiter: true,
+							_stickyTopOffset: null,
+							_stickyBottomOffset: 50,
+							_marginLeft: '15px' // The visual viewport left offset is 15 so original offset of 0 is adjusted.
+						} );
+					} );
+
+					it( 'avoid flickering of the panel when sticking to the bottom and offset almost equals the height', () => {
+						const stickToBottomSpy = testUtils.sinon.spy( view, '_stickToBottomOfLimiter' );
+
+						testUtils.sinon.stub( scrollableContainer, 'getBoundingClientRect' ).returns( {
+							top: 40,
+							bottom: 140,
+							height: 100,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						const limiterStub = testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' );
+
+						limiterStub.returns( {
+							top: -12,
+							bottom: 60,
+							height: 140,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+							height: 20
+						} );
+
+						view.checkIfShouldBeSticky( scrollableContainer );
+
+						expect( view.isSticky ).to.be.true;
+						expect( view._isStickyToTheBottomOfLimiter ).to.be.true;
+
+						sinon.assert.calledOnce( stickToBottomSpy );
+						assureStickiness( {
+							isSticky: true,
+							_isStickyToTheBottomOfLimiter: true,
+							_stickyTopOffset: null,
+							_stickyBottomOffset: 50,
+							_marginLeft: '15px' // The visual viewport left offset is 15 so original offset of 0 is adjusted.
+						} );
+
+						// Check if extra `+ 1px` works properly. It should fail.
+						limiterStub.returns( {
+							top: -11,
+							bottom: 60,
+							height: 140,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						view.checkIfShouldBeSticky( scrollableContainer );
+
+						expect( view.isSticky ).to.be.false;
+						expect( view._isStickyToTheBottomOfLimiter ).to.be.false;
+					} );
+
+					it( 'should unstick the panel if the limiter top is still visible', () => {
+						const stickToBottomSpy = testUtils.sinon.spy( view, '_stickToBottomOfLimiter' );
+						const stickToTopSpy = testUtils.sinon.spy( view, '_stickToTopOfAncestors' );
+						const unstickSpy = testUtils.sinon.spy( view, '_unstick' );
+
+						testUtils.sinon.stub( scrollableContainer, 'getBoundingClientRect' ).returns( {
+							top: 20,
+							bottom: 140,
+							height: 120,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+							top: 20,
+							bottom: 200,
+							height: 180,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+							height: 20
+						} );
+
+						view.checkIfShouldBeSticky( scrollableContainer );
+
+						sinon.assert.notCalled( stickToBottomSpy );
+						sinon.assert.notCalled( stickToTopSpy );
+						sinon.assert.calledOnce( unstickSpy );
+						assureStickiness( {
+							isSticky: false,
+							_isStickyToTheBottomOfLimiter: false,
+							_stickyTopOffset: null,
+							_stickyBottomOffset: null,
+							_marginLeft: null
+						} );
+					} );
+
+					it( 'should unstick the panel if there is not enough space left in the limiter', () => {
+						const spy = sinon.spy( view, '_unstick' );
+
+						testUtils.sinon.stub( scrollableContainer, 'getBoundingClientRect' ).returns( {
+							top: 40,
+							bottom: 140,
+							height: 100,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+							top: -80,
+							bottom: 60,
+							height: 140,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+							height: 100
+						} );
+
+						view.checkIfShouldBeSticky( scrollableContainer );
+
+						sinon.assert.calledOnce( spy );
+						assureStickiness( {
+							isSticky: false,
+							_isStickyToTheBottomOfLimiter: false,
+							_stickyTopOffset: null,
+							_stickyBottomOffset: null,
+							_marginLeft: null
+						} );
+					} );
+
+					it( 'should unstick the panel if panel limiter is not visible in the viewport', () => {
+						const spy = sinon.spy( view, '_unstick' );
+
+						testUtils.sinon.stub( scrollableContainer, 'getBoundingClientRect' ).returns( {
+							top: 120,
+							bottom: 140,
+							height: 100,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+							top: -80,
+							bottom: 60,
+							height: 140,
+							width: 100,
+							left: 0,
+							right: 100
+						} );
+
+						testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+							height: 20
+						} );
+
+						view.checkIfShouldBeSticky( scrollableContainer );
+
+						sinon.assert.calledOnce( spy );
+						assureStickiness( {
+							isSticky: false,
+							_isStickyToTheBottomOfLimiter: false,
+							_stickyTopOffset: null,
+							_stickyBottomOffset: null,
+							_marginLeft: null
+						} );
+					} );
+				} );
+			} );
+
+			describe( 'if there are multiple scrollable non-window parents', () => {
+				let scrollableOuterParent, scrollableInnerParent;
+
+				beforeEach( () => {
+					scrollableOuterParent = document.createElement( 'div' );
+					scrollableOuterParent.className = 'scrollable-outer';
+					scrollableOuterParent.style.overflow = 'scroll';
+
+					scrollableInnerParent = document.createElement( 'div' );
+					scrollableInnerParent.className = 'scrollable-inner';
+					scrollableInnerParent.style.overflow = 'scroll';
+
+					scrollableInnerParent.appendChild( limiterElement );
+					scrollableOuterParent.appendChild( scrollableInnerParent );
+					global.document.body.appendChild( scrollableOuterParent );
+
+					view.isActive = true;
+				} );
+
+				afterEach( () => {
+					scrollableInnerParent.remove();
+					scrollableOuterParent.remove();
+				} );
+
+				it( 'should unstick the panel if the limiter is still visible', () => {
+					const unstickSpy = testUtils.sinon.spy( view, '_unstick' );
+
+					testUtils.sinon.stub( scrollableOuterParent, 'getBoundingClientRect' ).returns( {
+						top: 10,
+						bottom: 160,
+						height: 150,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( scrollableInnerParent, 'getBoundingClientRect' ).returns( {
+						top: 20,
+						bottom: 140,
+						height: 120,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+						top: 40,
+						bottom: 100,
+						height: 60,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+						height: 20
+					} );
+
+					view.checkIfShouldBeSticky( scrollableOuterParent );
+
+					sinon.assert.calledOnce( unstickSpy );
+					assureStickiness( {
+						isSticky: false,
+						_isStickyToTheBottomOfLimiter: false,
+						_stickyTopOffset: null,
+						_stickyBottomOffset: null,
+						_marginLeft: null
+					} );
+				} );
+
+				it( 'should stick the panel to the top if the outer container was scrolled over the limiter top', () => {
+					const stickToTopSpy = testUtils.sinon.spy( view, '_stickToTopOfAncestors' );
+
+					testUtils.sinon.stub( scrollableOuterParent, 'getBoundingClientRect' ).returns( {
+						top: 50,
+						bottom: 160,
+						height: 150,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( scrollableInnerParent, 'getBoundingClientRect' ).returns( {
+						top: 20,
+						bottom: 140,
+						height: 120,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+						top: 40,
+						bottom: 140,
+						height: 100,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+						height: 20
+					} );
+
+					view.checkIfShouldBeSticky( scrollableOuterParent );
+
+					sinon.assert.calledOnce( stickToTopSpy );
+					assureStickiness( {
+						isSticky: true,
+						_isStickyToTheBottomOfLimiter: false,
+						_stickyTopOffset: 75, // The visual viewport top offset is 25 so original offset of 0 is adjusted.
+						_stickyBottomOffset: null,
+						_marginLeft: '15px' // The visual viewport left offset is 15 so original offset of 0 is adjusted.
+					} );
+				} );
+
+				it( 'should unstick the panel if the outer container was scrolled but there is no space below', () => {
+					const unstickSpy = testUtils.sinon.spy( view, '_unstick' );
+
+					testUtils.sinon.stub( scrollableOuterParent, 'getBoundingClientRect' ).returns( {
+						top: 50,
+						bottom: 160,
+						height: 150,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( scrollableInnerParent, 'getBoundingClientRect' ).returns( {
+						top: 20,
+						bottom: 140,
+						height: 120,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+						top: 40,
+						bottom: 110,
+						height: 60,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+						height: 20
+					} );
+
+					view.checkIfShouldBeSticky( scrollableOuterParent );
+
+					sinon.assert.calledOnce( unstickSpy );
+					assureStickiness( {
+						isSticky: false,
+						_isStickyToTheBottomOfLimiter: false,
+						_stickyTopOffset: null,
+						_stickyBottomOffset: null,
+						_marginLeft: null
+					} );
+				} );
+
+				it( 'should unstick the panel if the outer container was scrolled over the inner container top', () => {
+					const unstickSpy = testUtils.sinon.spy( view, '_unstick' );
+
+					testUtils.sinon.stub( scrollableOuterParent, 'getBoundingClientRect' ).returns( {
+						top: 50,
+						bottom: 160,
+						height: 150,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( scrollableInnerParent, 'getBoundingClientRect' ).returns( {
+						top: -20,
+						bottom: 50,
+						height: 70,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( limiterElement, 'getBoundingClientRect' ).returns( {
+						top: 0,
+						bottom: 40,
+						height: 40,
+						width: 100,
+						left: 0,
+						right: 100
+					} );
+
+					testUtils.sinon.stub( contentPanelElement, 'getBoundingClientRect' ).returns( {
+						height: 20
+					} );
+
+					view.checkIfShouldBeSticky( scrollableOuterParent );
+
+					sinon.assert.calledOnce( unstickSpy );
+					assureStickiness( {
+						isSticky: false,
+						_isStickyToTheBottomOfLimiter: false,
+						_stickyTopOffset: null,
+						_stickyBottomOffset: null,
+						_marginLeft: null
+					} );
+				} );
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-ui/theme/components/panel/stickypanel.css
+++ b/packages/ckeditor5-ui/theme/components/panel/stickypanel.css
@@ -3,22 +3,15 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-:root {
-	--ck-visual-viewport-left: 0px;
-	--ck-visual-viewport-top: 0px;
-}
-
 .ck.ck-sticky-panel {
 	& .ck-sticky-panel__content_sticky {
 		z-index: var(--ck-z-panel); /* #315 */
 		position: fixed;
 		top: 0;
-		transform: translate(var(--ck-visual-viewport-left, 0px), var(--ck-visual-viewport-top, 0px));
 	}
 
 	& .ck-sticky-panel__content_sticky_bottom-limit {
 		top: auto;
 		position: absolute;
-		transform: none;
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): Sticky toolbar with viewport top offset and visual viewport is now truly sticky. See #18022. See #7718.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
