### PR TITLE
Improve fullscreen demo revision history sidebar styling

### DIFF
--- a/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-default.html
+++ b/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-default.html
@@ -100,6 +100,10 @@
 		padding-right: var(--ck-spacing-large);
 	}
 
+	.presence {
+		height: 55px;
+	}
+
 	#default_revision-viewer-container {
 		display: none;
 	}

--- a/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-default.html
+++ b/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-default.html
@@ -116,6 +116,7 @@
 		border: 1px solid var(--ck-color-base-border);
 		border-left: 0;
 		padding-right: 0;
+		min-width: 300px;
 	}
 
 	#demo-container .ck.ck-editor {
@@ -424,31 +425,11 @@
 		box-shadow: 5px 5px 0 #b3b3b3;
 	}
 
-
-
 	/* ---------------------- Umberto overrides ------------------------ */
 
-	/* Style the document editor like Google Docs.*/
-
-	@media only screen and (min-width: 1360px) {
-		.main .main__content.main__content-wide {
-			padding-right: 0;
-		}
-	}
-
 	@media only screen and (min-width: 1600px) {
-		.main .main__content.main__content-wide {
-			width: 24cm;
-		}
-
-		.main .main__content.main__content-wide .main__content-inner {
-			width: auto;
-			margin: 0 50px;
-		}
-
-		/* Keep "page" look based on viewport width. */
-		.main__content-wide .document-editor__editable-container .document-editor__editable.ck-editor__editable {
-			width: 60%;
-		}
+		.main .main__content-inner {
+            width: 905px;
+        }
 	}
 </style>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (fullscreen): Make revision history sidebar is wider in the Fullscreen mode docs demo. Closes https://github.com/cksource/ckeditor5-commercial/issues/7310.

Internal (fullscreen): Improve tippy balloon position. Closes https://github.com/cksource/ckeditor5-commercial/issues/7311.

---

### Additional information

Fixed by making the whole guide container wider.

Before:

![image](https://github.com/user-attachments/assets/6d4d0883-cebb-4cd5-8d98-c683dbd7f09b)

![image](https://github.com/user-attachments/assets/8b694f55-4b71-4798-94d2-d6ecdb02ff77)


After:

![image](https://github.com/user-attachments/assets/df4afbbd-25cf-4d9a-b0d3-8cf21a408ecb)

![image](https://github.com/user-attachments/assets/65146ba1-6f9b-4f0e-9214-d2bd04f0dfce)

