### PR TITLE
Fix Alt+F10 behavior with fullscreen on non-Blink browsers

### DIFF
--- a/packages/ckeditor5-fullscreen/src/fullscreenediting.ts
+++ b/packages/ckeditor5-fullscreen/src/fullscreenediting.ts
@@ -63,6 +63,7 @@ export default class FullscreenEditing extends Plugin {
 				this.editor.ui.view.toolbar!.focusTracker.focusedElement = null;
 			}
 
+			// The order of scroll and focus is not important here.
 			this.editor.editing.view.scrollToTheSelection();
 			this.editor.editing.view.focus();
 

--- a/packages/ckeditor5-fullscreen/src/fullscreenediting.ts
+++ b/packages/ckeditor5-fullscreen/src/fullscreenediting.ts
@@ -55,15 +55,16 @@ export default class FullscreenEditing extends Plugin {
 		this.editor.keystrokes.set( 'Ctrl+Shift+F', ( evt, cancel ) => {
 			this.editor.execute( 'toggleFullscreen' );
 
-			// On non-Chromium browsers, the editor view is not blurred properly after moving the editable,
-			// even though the `document.activeElement` is changed. Hence we need to blur the view manually.
+			// On non-Chromium browsers, the editor view and toolbar are not blurred properly after moving the editable,
+			// even though the `document.activeElement` is changed. Hence we need to blur them manually.
 			// Fixes https://github.com/ckeditor/ckeditor5/issues/18250 and https://github.com/ckeditor/ckeditor5/issues/18247.
 			if ( !env.isBlink ) {
 				this.editor.editing.view.document.isFocused = false;
+				this.editor.ui.view.toolbar!.focusTracker.focusedElement = null;
 			}
 
-			this.editor.editing.view.focus();
 			this.editor.editing.view.scrollToTheSelection();
+			this.editor.editing.view.focus();
 
 			cancel();
 		} );

--- a/packages/ckeditor5-fullscreen/src/fullscreenui.ts
+++ b/packages/ckeditor5-fullscreen/src/fullscreenui.ts
@@ -10,6 +10,7 @@
 import { Plugin } from 'ckeditor5/src/core.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 import { IconFullscreenEnter, IconFullscreenLeave } from 'ckeditor5/src/icons.js';
+import { env } from 'ckeditor5/src/utils.js';
 
 import FullscreenEditing from './fullscreenediting.js';
 import '../theme/fullscreen.css';
@@ -82,8 +83,16 @@ export default class FullscreenUI extends Plugin {
 
 		this.listenTo( view, 'execute', () => {
 			editor.execute( COMMAND_NAME );
-			editor.editing.view.focus();
+
+			// On non-Chromium browsers, toolbar is not blurred properly after moving the editable,
+			// even though the `document.activeElement` is changed. Hence we need to blur the view manually.
+			// Fixes https://github.com/ckeditor/ckeditor5/issues/18250 and https://github.com/ckeditor/ckeditor5/issues/18247.
+			if ( !env.isBlink ) {
+				this.editor.ui.view.toolbar!.focusTracker.focusedElement = null;
+			}
+
 			editor.editing.view.scrollToTheSelection();
+			editor.editing.view.focus();
 		} );
 
 		return view;

--- a/packages/ckeditor5-fullscreen/src/fullscreenui.ts
+++ b/packages/ckeditor5-fullscreen/src/fullscreenui.ts
@@ -91,6 +91,7 @@ export default class FullscreenUI extends Plugin {
 				this.editor.ui.view.toolbar!.focusTracker.focusedElement = null;
 			}
 
+			// The order of scroll and focus is not important here.
 			editor.editing.view.scrollToTheSelection();
 			editor.editing.view.focus();
 		} );

--- a/packages/ckeditor5-fullscreen/tests/fullscreenediting.js
+++ b/packages/ckeditor5-fullscreen/tests/fullscreenediting.js
@@ -12,6 +12,7 @@ import env from '@ckeditor/ckeditor5-utils/src/env.js';
 
 import FullscreenEditing from '../src/fullscreenediting.js';
 import FullscreenCommand from '../src/fullscreencommand.js';
+import { ButtonView } from '@ckeditor/ckeditor5-ui';
 
 describe( 'FullscreenEditing', () => {
 	let domElement, editor;
@@ -103,16 +104,28 @@ describe( 'FullscreenEditing', () => {
 			expect( spy.calledTwice ).to.be.true;
 		} );
 
-		it( 'should force editable blur on non-Chromium browsers', () => {
+		it( 'should force editable and toolbar blur on non-Chromium browsers', () => {
 			sinon.stub( env, 'isBlink' ).value( false );
 
+			// Add button to the toolbar.
+			const buttonView = new ButtonView();
+			buttonView.render();
+			editor.ui.view.toolbar.items.add( buttonView );
+
+			// Focus the toolbar button when entering fullscreen mode.
+			editor.ui.view.toolbar.focusTracker.focusedElement = editor.ui.view.toolbar.items.first.element;
+
 			editor.keystrokes.press( keyEventData );
 
 			expect( global.document.activeElement ).to.equal( editor.ui.getEditableElement() );
+			expect( editor.ui.view.toolbar.focusTracker.focusedElement ).to.be.null;
 
+			// Focus the toolbar button when leaving fullscreen mode.
+			editor.ui.view.toolbar.focusTracker.focusedElement = editor.ui.view.toolbar.items.first.element;
 			editor.keystrokes.press( keyEventData );
 
 			expect( global.document.activeElement ).to.equal( editor.ui.getEditableElement() );
+			expect( editor.ui.view.toolbar.focusTracker.focusedElement ).to.be.null;
 		} );
 
 		it( 'should focus the editable element', () => {

--- a/packages/ckeditor5-fullscreen/tests/fullscreenui.js
+++ b/packages/ckeditor5-fullscreen/tests/fullscreenui.js
@@ -11,6 +11,7 @@ import { IconFullscreenEnter, IconFullscreenLeave } from 'ckeditor5/src/icons.js
 
 import FullscreenEditing from '../src/fullscreenediting.js';
 import FullscreenUI from '../src/fullscreenui.js';
+import { env } from '@ckeditor/ckeditor5-utils';
 
 describe( 'FullscreenUI', () => {
 	let domElement, editor;
@@ -93,6 +94,26 @@ describe( 'FullscreenUI', () => {
 				sinon.assert.calledOnce( spy );
 			} );
 
+			it( 'should force toolbar blur on non-Chromium browsers', () => {
+				sinon.stub( env, 'isBlink' ).value( false );
+
+				editor.ui.view.toolbar.items.add( button );
+
+				// Focus the toolbar button when entering fullscreen mode.
+				editor.ui.view.toolbar.focusTracker.focusedElement = editor.ui.view.toolbar.items.first.element;
+
+				button.fire( 'execute' );
+
+				expect( editor.ui.view.toolbar.focusTracker.focusedElement ).to.be.null;
+
+				// Focus the toolbar button when leaving fullscreen mode.
+				editor.ui.view.toolbar.focusTracker.focusedElement = editor.ui.view.toolbar.items.first.element;
+
+				button.fire( 'execute' );
+
+				expect( editor.ui.view.toolbar.focusTracker.focusedElement ).to.be.null;
+			} );
+
 			it( 'should focus the editable element', () => {
 				const spy = sinon.spy( editor.editing.view, 'focus' );
 
@@ -152,6 +173,28 @@ describe( 'FullscreenUI', () => {
 				button.fire( 'execute' );
 
 				sinon.assert.calledOnce( spy );
+			} );
+
+			// This test is purely technical. It's currently impossible to reproduce such a situation
+			// in the browser.
+			it( 'should force toolbar blur on non-Chromium browsers', () => {
+				sinon.stub( env, 'isBlink' ).value( false );
+
+				editor.ui.view.toolbar.items.add( button );
+
+				// Focus the toolbar button when entering fullscreen mode.
+				editor.ui.view.toolbar.focusTracker.focusedElement = editor.ui.view.toolbar.items.first.element;
+
+				button.fire( 'execute' );
+
+				expect( editor.ui.view.toolbar.focusTracker.focusedElement ).to.be.null;
+
+				// Focus the toolbar button when leaving fullscreen mode.
+				editor.ui.view.toolbar.focusTracker.focusedElement = editor.ui.view.toolbar.items.first.element;
+
+				button.fire( 'execute' );
+
+				expect( editor.ui.view.toolbar.focusTracker.focusedElement ).to.be.null;
 			} );
 
 			it( 'should focus the editable element', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (fullscreen): Fix Alt+F10 behavior with fullscreen on non-Blink browsers. Closes https://github.com/ckeditor/ckeditor5/issues/18247.

---

### Additional information

Continuation of https://github.com/ckeditor/ckeditor5/pull/18273. 

Turns out, we also need to manually reset the toolbar `focusedElement` - it isn't set to `null` when toggling fullscreen, so if you do it using a button or shortcut but with toolbar focused, then toolbar can't be "refocused" later by Alt+F10.