### PR TITLE
Improve pageless demo visuals in fullscreen guide

### DIFF
--- a/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-pageless.html
+++ b/packages/ckeditor5-fullscreen/docs/_snippets/features/fullscreen-pageless.html
@@ -34,12 +34,14 @@
 	}
 
 	.main__content .ck.ck-fullscreen__main-wrapper .ck-fullscreen__editable {
+		width: 100%;
 		margin: 0;
 	}
 
-	.main__content .ck.ck-fullscreen__main-wrapper .editor-content.ck.ck-content {
+	.main__content .ck.ck-fullscreen__main-wrapper .ck-fullscreen__editable .editor-content.ck.ck-content {
 		width: 100%;
 		max-width: 100%;
+		min-height: 0;
 		margin: 0;
 		border: 0;
 		padding: 2em;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (fullscreen): Set proper width and height for the pageless editor demo when it has little content. Closes https://github.com/ckeditor/ckeditor5/issues/18318.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
