### PR TITLE
Fullscreen: change manu bar and toolbar borders

### DIFF
--- a/packages/ckeditor5-fullscreen/theme/fullscreen.css
+++ b/packages/ckeditor5-fullscreen/theme/fullscreen.css
@@ -74,10 +74,22 @@ Fullscreen layout:
 /* If the fullscreen container is not directly in the body, we need to make sure it's positioned absolutely. */
 :not(body> .ck-fullscreen__main-wrapper).ck-fullscreen__main-wrapper {
 	position: absolute;
+
+	& .ck-fullscreen__top-wrapper {
+		border-top: 1px solid var(--ck-color-base-border);
+		border-left: 1px solid var(--ck-color-base-border);
+		border-right: 1px solid var(--ck-color-base-border);
+	}
 }
 
 .ck-fullscreen__menu-bar .ck.ck-menu-bar {
 	border: none;
+}
+
+.ck.ck-fullscreen__toolbar .ck-toolbar {
+	border-left: 0;
+	border-right: 0;
+	border-radius: 0;
 }
 
 .ck-fullscreen__main-wrapper .ck-fullscreen__editable-wrapper {
@@ -114,11 +126,13 @@ Fullscreen layout:
 
 .ck-fullscreen__main-wrapper .ck-fullscreen__editable .ck.ck-editor__editable:not(.ck-editor__nested-editable) {
 	box-sizing: border-box;
-	width: calc(210mm + 2px); /* Make sure the border is taken into account. */
-	max-width: calc(210mm + 2px); /* Make sure the border is taken into account. */
+	/* Make sure the border is taken into account. */
+	width: calc(210mm + 2px);
+	max-width: calc(210mm + 2px);
 	min-height: 297mm;
 	height: fit-content;
-	margin: 0; /* Reset margins that may be present on editable. We add them in other places. */
+	/* Reset margins that may be present on editable. We add them in other places. */
+	margin: 0;
 	padding: 20mm 12mm;
 	border: 1px var(--ck-color-base-border) solid;
 	background: hsl(0, 0%, 100%);

--- a/packages/ckeditor5-fullscreen/theme/fullscreen.css
+++ b/packages/ckeditor5-fullscreen/theme/fullscreen.css
@@ -79,6 +79,7 @@ Fullscreen layout:
 		border-top: 1px solid var(--ck-color-base-border);
 		border-left: 1px solid var(--ck-color-base-border);
 		border-right: 1px solid var(--ck-color-base-border);
+		border-radius: var(--ck-border-radius) 0;
 	}
 }
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (fullscreen): Fullscreen: change manu bar and toolbar borders. Closes https://github.com/ckeditor/ckeditor5/issues/18515.

---

### Additional information

Removed side borders and border radius.


### Side borders

Before:

![image](https://github.com/user-attachments/assets/0f0ae74e-3de9-41da-83d5-7e78cbed02ec)

After:

![image](https://github.com/user-attachments/assets/ea5f962d-e763-48af-a36b-830b3c33045a)

### Fullscreen in container

Before:

![image](https://github.com/user-attachments/assets/74ccf6d3-d390-4dd6-a0c1-c428f80fef8e)

After:

![image](https://github.com/user-attachments/assets/02a5b305-cda8-4fa0-8e03-6b1e6dfa5fd9)


