### PR TITLE
Speed-up rendering of dropdowns with large amount of items.

### DIFF
--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -712,7 +712,7 @@ function bindViewCollectionItemsToDefinitions(
  *
  * Buttons in dropdowns have reserved space for a check icon when they are toggleable.
  * When at least one button in the list is toggleable, all other buttons (even non-toggleable ones)
- * will have space allocated on their left side to align properly with toggleable buttons.
+ * will have space on their left side to align with toggleable buttons.
  *
  * This function handles a special case where a new toggleable button is added (or removed) to a list
  * where previous buttons weren't toggleable. In that case, those previous buttons will
@@ -754,7 +754,7 @@ function bindDropdownToggleableButtonsAlignment( listItems: ViewCollection ) {
 	};
 
 	// Helper function that checks if a view item is a toggleable button.
-	// Returns the button if it's toggleable, otherwise returns null.
+	// Returns the button if it's toggleable - otherwise, returns null.
 	const pickListItemToggleableButtonIfPresent = ( item: View<HTMLElement> ) => {
 		const listItemButtonView = pickListItemButtonIfPresent( item );
 
@@ -810,7 +810,7 @@ function bindDropdownToggleableButtonsAlignment( listItems: ViewCollection ) {
 		// Check if the current state has changed.
 		const currentToggleable = toggleableButtonsCount > 0;
 
-		// Only update button alignment if we've crossed the threshold between.
+		// Only update button alignment if we've crossed the threshold between
 		// having no toggleable buttons and having at least one.
 		if ( prevToggleable !== currentToggleable ) {
 			updateAllButtonsCheckSpace( currentToggleable );

--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -769,11 +769,11 @@ function bindDropdownToggleableButtonsAlignment( listItems: ViewCollection ) {
 	// Updates all buttons in the list to either allocate space for check marks or not.
 	// This ensures all buttons are properly aligned regardless of their toggleable state.
 	const updateAllButtonsCheckSpace = ( hasSpace: boolean ): void => {
-		for ( const button of listItems ) {
-			const toggleableButton = pickListItemButtonIfPresent( button );
+		for ( const listItem of listItems ) {
+			const listItemButton = pickListItemButtonIfPresent( listItem );
 
-			if ( toggleableButton ) {
-				toggleableButton.hasCheckSpace = hasSpace;
+			if ( listItemButton ) {
+				listItemButton.hasCheckSpace = hasSpace;
 			}
 		}
 	};

--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -740,7 +740,7 @@ function bindViewCollectionItemsToDefinitions(
  * @param listItems Collection of list items to observe for toggleable buttons.
  */
 function bindDropdownToggleableButtonsAlignment( listItems: ViewCollection ) {
-	// Keep track of how many toggleable buttons are in the list
+	// Keep track of how many toggleable buttons are in the list.
 	let toggleableButtonsCount = 0;
 
 	// Helper function that checks if a view item is a list item button.

--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -37,7 +37,8 @@ import {
 	type FocusTracker,
 	type Collection,
 	type Locale,
-	type ObservableChangeEvent
+	type ObservableChangeEvent,
+	type CollectionChangeEvent
 } from '@ckeditor/ckeditor5-utils';
 
 import '../../theme/components/dropdown/toolbardropdown.css';
@@ -663,26 +664,7 @@ function bindViewCollectionItemsToDefinitions(
 	definitions: Collection<ListDropdownItemDefinition>,
 	locale: Locale
 ) {
-	// List item checkboxes have a reserved space for the check icon, so we need to know if there are any checkboxes in the list
-	// to adjust the layout accordingly. It'd look weird if the items on the list were not aligned horizontally.
-	//
-	// Possible theoretical performance problem if many items are added one by one, as this will be called for each item.
-	listItems.on( 'change', () => {
-		// Filter-map. Check all items, leave only these that have buttons and return the buttons.
-		const listItemButtons = [ ...listItems ].reduce<Array<ListItemButtonView>>( ( acc, item ) => {
-			if ( item instanceof ListItemView && item.children.first instanceof ListItemButtonView ) {
-				acc.push( item.children.first );
-			}
-
-			return acc;
-		}, [] );
-
-		const hasAnyCheckboxOnList = listItemButtons.some( button => button.isToggleable );
-
-		listItemButtons.forEach( item => {
-			item.hasCheckSpace = hasAnyCheckboxOnList;
-		} );
-	} );
+	bindDropdownToggleableButtonsAlignment( listItems );
 
 	listItems.bindTo( definitions ).using( def => {
 		if ( def.type === 'separator' ) {
@@ -722,6 +704,117 @@ function bindViewCollectionItemsToDefinitions(
 		}
 
 		return null;
+	} );
+}
+
+/**
+ * Sets up alignment handling for toggleable buttons in a dropdown list.
+ *
+ * Buttons in dropdowns have reserved space for a check icon when they are toggleable.
+ * When at least one button in the list is toggleable, all other buttons (even non-toggleable ones)
+ * will have space allocated on their left side to align properly with toggleable buttons.
+ *
+ * This function handles a special case where a new toggleable button is added (or removed) to a list
+ * where previous buttons weren't toggleable. In that case, those previous buttons will
+ * automatically allocate space to align with the new toggleable button.
+ *
+ * Example:
+ * ```
+ * Before adding toggleable button:
+ * +----------------+
+ * | Normal Button  |
+ * +----------------+
+ * | Another Button |
+ * +----------------+
+ *
+ * After adding toggleable button:
+ * +-------------------+
+ * |    Normal Button  |
+ * +-------------------+
+ * |    Another Button |
+ * +-------------------+
+ * | ✓ Toggle Button   |
+ * +-------------------+
+ * ```
+ *
+ * @param listItems Collection of list items to observe for toggleable buttons.
+ */
+function bindDropdownToggleableButtonsAlignment( listItems: ViewCollection ) {
+	// Keep track of how many toggleable buttons are in the list
+	let toggleableButtonsCount = 0;
+
+	// Helper function that checks if a view item is a list item button.
+	const pickListItemButtonIfPresent = ( item: View<HTMLElement> ) => {
+		// Check if the item is a ListItemView with a ListItemButtonView as its first child.
+		if ( !( item instanceof ListItemView ) || !( item.children.first instanceof ListItemButtonView ) ) {
+			return null;
+		}
+
+		return item.children.first;
+	};
+
+	// Helper function that checks if a view item is a toggleable button.
+	// Returns the button if it's toggleable, otherwise returns null.
+	const pickListItemToggleableButtonIfPresent = ( item: View<HTMLElement> ) => {
+		const listItemButtonView = pickListItemButtonIfPresent( item );
+
+		// Only return buttons that are configured as toggleable.
+		if ( !listItemButtonView || !listItemButtonView.isToggleable ) {
+			return null;
+		}
+
+		return listItemButtonView;
+	};
+
+	// Updates all buttons in the list to either allocate space for check marks or not.
+	// This ensures all buttons are properly aligned regardless of their toggleable state.
+	const updateAllButtonsCheckSpace = ( hasSpace: boolean ): void => {
+		for ( const button of listItems ) {
+			const toggleableButton = pickListItemButtonIfPresent( button );
+
+			if ( toggleableButton ) {
+				toggleableButton.hasCheckSpace = hasSpace;
+			}
+		}
+	};
+
+	// Listen for changes in the list items collection.
+	listItems.on<CollectionChangeEvent<FocusableView>>( 'change', ( evt, data ) => {
+		// Remember the current state - whether we have any toggleable buttons.
+		const prevToggleable = toggleableButtonsCount > 0;
+
+		// Process removed items - decrease count for each toggleable button removed.
+		for ( const item of data.removed ) {
+			if ( pickListItemToggleableButtonIfPresent( item ) ) {
+				toggleableButtonsCount--;
+			}
+		}
+
+		// Process added items - increase count for each toggleable button added.
+		for ( const item of data.added ) {
+			const button = pickListItemButtonIfPresent( item );
+
+			if ( !button ) {
+				continue;
+			}
+
+			if ( button.isToggleable ) {
+				// Check if the button is toggleable and increase the count.
+				toggleableButtonsCount++;
+			}
+
+			// Depending on the current state, set the check space for the button.
+			button.hasCheckSpace = toggleableButtonsCount > 0;
+		}
+
+		// Check if the current state has changed.
+		const currentToggleable = toggleableButtonsCount > 0;
+
+		// Only update button alignment if we've crossed the threshold between.
+		// having no toggleable buttons and having at least one.
+		if ( prevToggleable !== currentToggleable ) {
+			updateAllButtonsCheckSpace( currentToggleable );
+		}
 	} );
 }
 

--- a/packages/ckeditor5-ui/tests/dropdown/utils.js
+++ b/packages/ckeditor5-ui/tests/dropdown/utils.js
@@ -996,6 +996,54 @@ describe( 'utils', () => {
 					}
 				} );
 
+				it( 'should reserve checkbox holder space on non-toggleable items', () => {
+					definitions.addMany( [
+						{
+							type: 'button',
+							model: new Model( { label: 'a', role: 'menuitem' } )
+						},
+						{
+							type: 'button',
+							model: new Model( { label: 'b', role: 'menuitem' } )
+						},
+						{
+							type: 'button',
+							model: new Model( { label: 'c', role: 'menuitemradio' } )
+						}
+					] );
+
+					for ( const item of listItems ) {
+						expect( item.children.first.hasCheckSpace ).to.be.true;
+					}
+				} );
+
+				it( 'should restore checkbox holder space if the only toggleable was removed', () => {
+					definitions.addMany( [
+						{
+							type: 'button',
+							model: new Model( { label: 'a', role: 'menuitem' } )
+						},
+						{
+							type: 'button',
+							model: new Model( { label: 'b', role: 'menuitem' } )
+						},
+						{
+							type: 'button',
+							model: new Model( { label: 'c', role: 'menuitemradio' } )
+						}
+					] );
+
+					for ( const item of listItems ) {
+						expect( item.children.first.hasCheckSpace ).to.be.true;
+					}
+
+					definitions.remove( 2 );
+
+					for ( const item of listItems ) {
+						expect( item.children.first.hasCheckSpace ).to.be.false;
+					}
+				} );
+
 				it( 'should not reserve checkbox holder space if there is at least one toggleable item', () => {
 					definitions.addMany( [
 						{


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Optimized performance of dropdowns when opening with many items. Closes #18094  

---

### Additional information

Previously, after adding each item, the entire list of other items was checked and their flags were updated accordingly. This resulted in behavior close to O(n²) complexity. In the new solution, only the added (or removed) items are checked, and the full item list is updated only once when a new toggleable is added. This change reduced the processing time from **5.6s** to **1.6s**.

#### Before

![obraz](https://github.com/user-attachments/assets/ac268648-1b9e-427b-8b3d-7df3e258e799)

#### After

![obraz](https://github.com/user-attachments/assets/296dcc14-fa95-4d46-a221-d0325b647ee9)