### PR TITLE
Add missing consume for `image_resize` class on image elements.

### DIFF
--- a/packages/ckeditor5-image/src/imageresize/imageresizeediting.ts
+++ b/packages/ckeditor5-image/src/imageresize/imageresizeediting.ts
@@ -210,5 +210,12 @@ export default class ImageResizeEditing extends Plugin {
 					}
 				}
 			} );
+
+		editor.conversion.for( 'upcast' )
+			.add( dispatcher => {
+				dispatcher.on( `element:${ imageType === 'imageBlock' ? 'figure' : 'img' }`, ( evt, data, conversionApi ) => {
+					conversionApi.consumable.consume( data.viewItem, { classes: [ 'image_resized' ] } );
+				} );
+			} );
 	}
 }

--- a/packages/ckeditor5-image/src/imageresize/imageresizeediting.ts
+++ b/packages/ckeditor5-image/src/imageresize/imageresizeediting.ts
@@ -213,11 +213,7 @@ export default class ImageResizeEditing extends Plugin {
 
 		editor.conversion.for( 'upcast' ).add( dispatcher => {
 			dispatcher.on( `element:${ imageType === 'imageBlock' ? 'figure' : 'img' }`, ( evt, data, conversionApi ) => {
-				const consumed = conversionApi.consumable.consume( data.viewItem, { classes: [ 'image_resized' ] } );
-
-				if ( consumed ) {
-					conversionApi.consumable.consume( data.viewItem, { styles: [ 'aspect-ratio' ] } );
-				}
+				conversionApi.consumable.consume( data.viewItem, { classes: [ 'image_resized' ] } );
 			} );
 		} );
 	}

--- a/packages/ckeditor5-image/src/imageresize/imageresizeediting.ts
+++ b/packages/ckeditor5-image/src/imageresize/imageresizeediting.ts
@@ -211,11 +211,14 @@ export default class ImageResizeEditing extends Plugin {
 				}
 			} );
 
-		editor.conversion.for( 'upcast' )
-			.add( dispatcher => {
-				dispatcher.on( `element:${ imageType === 'imageBlock' ? 'figure' : 'img' }`, ( evt, data, conversionApi ) => {
-					conversionApi.consumable.consume( data.viewItem, { classes: [ 'image_resized' ] } );
-				} );
+		editor.conversion.for( 'upcast' ).add( dispatcher => {
+			dispatcher.on( `element:${ imageType === 'imageBlock' ? 'figure' : 'img' }`, ( evt, data, conversionApi ) => {
+				const consumed = conversionApi.consumable.consume( data.viewItem, { classes: [ 'image_resized' ] } );
+
+				if ( consumed ) {
+					conversionApi.consumable.consume( data.viewItem, { styles: [ 'aspect-ratio' ] } );
+				}
 			} );
+		} );
 	}
 }

--- a/packages/ckeditor5-image/src/imagesizeattributes.ts
+++ b/packages/ckeditor5-image/src/imagesizeattributes.ts
@@ -130,6 +130,18 @@ export default class ImageSizeAttributes extends Plugin {
 			attachDowncastConverter( dispatcher, 'height', 'height', false );
 		} );
 
+		// Consume `aspect-ratio` style if `width` and `height` attributes are set on the image.
+		editor.conversion.for( 'upcast' ).add( dispatcher => {
+			dispatcher.on( 'element:img', ( evt, data, conversionApi ) => {
+				const width = data.viewItem.getAttribute( 'width' );
+				const height = data.viewItem.getAttribute( 'height' );
+
+				if ( width && height ) {
+					conversionApi.consumable.consume( data.viewItem, { styles: [ 'aspect-ratio' ] } );
+				}
+			} );
+		} );
+
 		function attachDowncastConverter(
 			dispatcher: DowncastDispatcher,
 			modelAttributeName: string,

--- a/packages/ckeditor5-image/tests/imageresize/imageresizeediting.js
+++ b/packages/ckeditor5-image/tests/imageresize/imageresizeediting.js
@@ -98,6 +98,19 @@ describe( 'ImageResizeEditing', () => {
 			editor = await createEditor();
 		} );
 
+		it( 'consumes image_resized class during upcast', () => {
+			const consumeSpy = sinon.spy( ( evt, data, conversionApi ) => {
+				expect( conversionApi.consumable.test( data.viewItem, { classes: [ 'image_resized' ] } ) ).to.be.false;
+			} );
+
+			editor.data.upcastDispatcher.on( 'element:figure', consumeSpy, { priority: 'lowest' } );
+			editor.setData(
+				`<figure class="image image_resized" style="width:100px;"><img src="${ IMAGE_SRC_FIXTURE }"></figure>`
+			);
+
+			expect( consumeSpy.calledOnce ).to.be.true;
+		} );
+
 		describe( 'width', () => {
 			it( 'upcasts 100px width correctly', () => {
 				editor.setData( `<figure class="image" style="width:100px;"><img src="${ IMAGE_SRC_FIXTURE }"></figure>` );
@@ -268,6 +281,24 @@ describe( 'ImageResizeEditing', () => {
 	describe( 'conversion (inline images)', () => {
 		beforeEach( async () => {
 			editor = await createEditor();
+		} );
+
+		it( 'consumes image_resized class during upcast', () => {
+			const consumeSpy = sinon.spy( ( evt, data, conversionApi ) => {
+				expect( conversionApi.consumable.test( data.viewItem, { classes: [ 'image_resized' ] } ) ).to.be.false;
+			} );
+
+			editor.data.upcastDispatcher.on( 'element:img', consumeSpy, { priority: 'lowest' } );
+			editor.setData(
+				'<p>Lore' +
+					'<span class="image-inline">' +
+						`<img src="${ IMAGE_SRC_FIXTURE }" style="width:100px;" class="image_resized">` +
+					'</span>' +
+					'ipsum' +
+				'</p>'
+			);
+
+			expect( consumeSpy.calledOnce ).to.be.true;
 		} );
 
 		describe( 'width', () => {

--- a/packages/ckeditor5-image/tests/imageresize/imageresizeediting.js
+++ b/packages/ckeditor5-image/tests/imageresize/imageresizeediting.js
@@ -111,32 +111,6 @@ describe( 'ImageResizeEditing', () => {
 			expect( consumeSpy.calledOnce ).to.be.true;
 		} );
 
-		it( 'consumes aspect-ratio style if image_resized class present on element', () => {
-			const consumeSpy = sinon.spy( ( evt, data, conversionApi ) => {
-				expect( conversionApi.consumable.test( data.viewItem, { styles: [ 'aspect-ratio' ] } ) ).to.be.false;
-			} );
-
-			editor.data.upcastDispatcher.on( 'element:figure', consumeSpy, { priority: 'lowest' } );
-			editor.setData(
-				`<figure class="image image_resized" style="width:100px;aspect-ratio:1/1;"><img src="${ IMAGE_SRC_FIXTURE }"></figure>`
-			);
-
-			expect( consumeSpy.calledOnce ).to.be.true;
-		} );
-
-		it( 'should not consume aspect-ratio style if image_resized class not present on element', () => {
-			const consumeSpy = sinon.spy( ( evt, data, conversionApi ) => {
-				expect( conversionApi.consumable.test( data.viewItem, { styles: [ 'aspect-ratio' ] } ) ).to.be.true;
-			} );
-
-			editor.data.upcastDispatcher.on( 'element:figure', consumeSpy, { priority: 'lowest' } );
-			editor.setData(
-				`<figure class="image" style="width:100px;aspect-ratio:1/1;"><img src="${ IMAGE_SRC_FIXTURE }"></figure>`
-			);
-
-			expect( consumeSpy.calledOnce ).to.be.true;
-		} );
-
 		describe( 'width', () => {
 			it( 'upcasts 100px width correctly', () => {
 				editor.setData( `<figure class="image" style="width:100px;"><img src="${ IMAGE_SRC_FIXTURE }"></figure>` );
@@ -321,40 +295,6 @@ describe( 'ImageResizeEditing', () => {
 						`<img src="${ IMAGE_SRC_FIXTURE }" style="width:100px;" class="image_resized">` +
 					'</span>' +
 					'ipsum' +
-				'</p>'
-			);
-
-			expect( consumeSpy.calledOnce ).to.be.true;
-		} );
-
-		it( 'consumes aspect-ratio style if image_resized class present on element', () => {
-			const consumeSpy = sinon.spy( ( evt, data, conversionApi ) => {
-				expect( conversionApi.consumable.test( data.viewItem, { styles: [ 'aspect-ratio' ] } ) ).to.be.false;
-			} );
-			editor.data.upcastDispatcher.on( 'element:img', consumeSpy, { priority: 'lowest' } );
-			editor.setData(
-				'<p>Lorem ' +
-					'<span class="image-inline">' +
-						`<img src="${ IMAGE_SRC_FIXTURE }" style="width:100px;aspect-ratio:1/1;" class="image_resized">` +
-					'</span>' +
-					' ipsum' +
-				'</p>'
-			);
-			expect( consumeSpy.calledOnce ).to.be.true;
-		} );
-
-		it( 'should not consume aspect-ratio style if image_resized class not present on element', () => {
-			const consumeSpy = sinon.spy( ( evt, data, conversionApi ) => {
-				expect( conversionApi.consumable.test( data.viewItem, { styles: [ 'aspect-ratio' ] } ) ).to.be.true;
-			} );
-
-			editor.data.upcastDispatcher.on( 'element:img', consumeSpy, { priority: 'lowest' } );
-			editor.setData(
-				'<p>Lorem ' +
-					'<span class="image-inline">' +
-						`<img src="${ IMAGE_SRC_FIXTURE }" style="width:100px;aspect-ratio:1/1;">` +
-					'</span>' +
-					' ipsum' +
 				'</p>'
 			);
 

--- a/packages/ckeditor5-image/tests/imageresize/imageresizeediting.js
+++ b/packages/ckeditor5-image/tests/imageresize/imageresizeediting.js
@@ -111,6 +111,32 @@ describe( 'ImageResizeEditing', () => {
 			expect( consumeSpy.calledOnce ).to.be.true;
 		} );
 
+		it( 'consumes aspect-ratio style if image_resized class present on element', () => {
+			const consumeSpy = sinon.spy( ( evt, data, conversionApi ) => {
+				expect( conversionApi.consumable.test( data.viewItem, { styles: [ 'aspect-ratio' ] } ) ).to.be.false;
+			} );
+
+			editor.data.upcastDispatcher.on( 'element:figure', consumeSpy, { priority: 'lowest' } );
+			editor.setData(
+				`<figure class="image image_resized" style="width:100px;aspect-ratio:1/1;"><img src="${ IMAGE_SRC_FIXTURE }"></figure>`
+			);
+
+			expect( consumeSpy.calledOnce ).to.be.true;
+		} );
+
+		it( 'should not consume aspect-ratio style if image_resized class not present on element', () => {
+			const consumeSpy = sinon.spy( ( evt, data, conversionApi ) => {
+				expect( conversionApi.consumable.test( data.viewItem, { styles: [ 'aspect-ratio' ] } ) ).to.be.true;
+			} );
+
+			editor.data.upcastDispatcher.on( 'element:figure', consumeSpy, { priority: 'lowest' } );
+			editor.setData(
+				`<figure class="image" style="width:100px;aspect-ratio:1/1;"><img src="${ IMAGE_SRC_FIXTURE }"></figure>`
+			);
+
+			expect( consumeSpy.calledOnce ).to.be.true;
+		} );
+
 		describe( 'width', () => {
 			it( 'upcasts 100px width correctly', () => {
 				editor.setData( `<figure class="image" style="width:100px;"><img src="${ IMAGE_SRC_FIXTURE }"></figure>` );
@@ -295,6 +321,40 @@ describe( 'ImageResizeEditing', () => {
 						`<img src="${ IMAGE_SRC_FIXTURE }" style="width:100px;" class="image_resized">` +
 					'</span>' +
 					'ipsum' +
+				'</p>'
+			);
+
+			expect( consumeSpy.calledOnce ).to.be.true;
+		} );
+
+		it( 'consumes aspect-ratio style if image_resized class present on element', () => {
+			const consumeSpy = sinon.spy( ( evt, data, conversionApi ) => {
+				expect( conversionApi.consumable.test( data.viewItem, { styles: [ 'aspect-ratio' ] } ) ).to.be.false;
+			} );
+			editor.data.upcastDispatcher.on( 'element:img', consumeSpy, { priority: 'lowest' } );
+			editor.setData(
+				'<p>Lorem ' +
+					'<span class="image-inline">' +
+						`<img src="${ IMAGE_SRC_FIXTURE }" style="width:100px;aspect-ratio:1/1;" class="image_resized">` +
+					'</span>' +
+					' ipsum' +
+				'</p>'
+			);
+			expect( consumeSpy.calledOnce ).to.be.true;
+		} );
+
+		it( 'should not consume aspect-ratio style if image_resized class not present on element', () => {
+			const consumeSpy = sinon.spy( ( evt, data, conversionApi ) => {
+				expect( conversionApi.consumable.test( data.viewItem, { styles: [ 'aspect-ratio' ] } ) ).to.be.true;
+			} );
+
+			editor.data.upcastDispatcher.on( 'element:img', consumeSpy, { priority: 'lowest' } );
+			editor.setData(
+				'<p>Lorem ' +
+					'<span class="image-inline">' +
+						`<img src="${ IMAGE_SRC_FIXTURE }" style="width:100px;aspect-ratio:1/1;">` +
+					'</span>' +
+					' ipsum' +
 				'</p>'
 			);
 

--- a/packages/ckeditor5-image/tests/imagesizeattributes.js
+++ b/packages/ckeditor5-image/tests/imagesizeattributes.js
@@ -131,6 +131,32 @@ describe( 'ImageSizeAttributes', () => {
 
 					expect( editor.model.document.getRoot().getChild( 0 ).getChild( 1 ).getAttribute( 'height' ) ).to.be.undefined;
 				} );
+
+				it( 'should consume aspect-ratio style during upcast when width and height are set', () => {
+					const consumeSpy = sinon.spy( ( evt, data, conversionApi ) => {
+						expect( conversionApi.consumable.test( data.viewItem, { styles: [ 'aspect-ratio' ] } ) ).to.be.false;
+					} );
+
+					editor.data.upcastDispatcher.on( 'element:img', consumeSpy, { priority: 'lowest' } );
+					editor.setData(
+						'<p>Lorem <img width="100" height="50" style="aspect-ratio: 2/1;" src="/assets/sample.png"> ipsum</p>'
+					);
+
+					expect( consumeSpy ).to.be.called;
+				} );
+
+				it( 'should not consume aspect-ratio style during upcast when width or height is missing', () => {
+					const consumeSpy = sinon.spy( ( evt, data, conversionApi ) => {
+						expect( conversionApi.consumable.test( data.viewItem, { styles: [ 'aspect-ratio' ] } ) ).to.be.true;
+					} );
+
+					editor.data.upcastDispatcher.on( 'element:img', consumeSpy, { priority: 'lowest' } );
+					editor.setData(
+						'<p>Lorem <img width="100" style="aspect-ratio: 2/1;" src="/assets/sample.png"> ipsum</p>'
+					);
+
+					expect( consumeSpy ).to.be.called;
+				} );
 			} );
 
 			describe( 'block images', () => {
@@ -178,6 +204,32 @@ describe( 'ImageSizeAttributes', () => {
 					);
 
 					expect( editor.model.document.getRoot().getChild( 0 ).getAttribute( 'height' ) ).to.be.undefined;
+				} );
+
+				it( 'should consume aspect-ratio style during upcast when width and height are set', () => {
+					const consumeSpy = sinon.spy( ( evt, data, conversionApi ) => {
+						expect( conversionApi.consumable.test( data.viewItem, { styles: [ 'aspect-ratio' ] } ) ).to.be.false;
+					} );
+
+					editor.data.upcastDispatcher.on( 'element:img', consumeSpy, { priority: 'lowest' } );
+					editor.setData(
+						'<figure class="image"><img width="100" height="50" style="aspect-ratio: 2/1;" src="/assets/sample.png"></figure>'
+					);
+
+					expect( consumeSpy ).to.be.called;
+				} );
+
+				it( 'should not consume aspect-ratio style during upcast when width or height is missing', () => {
+					const consumeSpy = sinon.spy( ( evt, data, conversionApi ) => {
+						expect( conversionApi.consumable.test( data.viewItem, { styles: [ 'aspect-ratio' ] } ) ).to.be.true;
+					} );
+
+					editor.data.upcastDispatcher.on( 'element:img', consumeSpy, { priority: 'lowest' } );
+					editor.setData(
+						'<figure class="image"><img height="50" style="aspect-ratio: 2/1;" src="/assets/sample.png"></figure>'
+					);
+
+					expect( consumeSpy ).to.be.called;
 				} );
 			} );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (image): Consume `image_resize` class and `aspect-ratio` style during the upcast of the images. Closes #18287 

---

### Additional information

Previously, the `image_resize` class was incorrectly consumed by the General HTML Support (GHS) plugin. This class is meant to be handled by the `ImageResize` plugin only, as it is automatically applied by it. This PR ensures that GHS no longer consumes this attribute.
