### PR TITLE
Remove `htmlEmptyElement` if all `htmlXX` attributes removed.

### DIFF
--- a/packages/ckeditor5-html-support/package.json
+++ b/packages/ckeditor5-html-support/package.json
@@ -41,7 +41,6 @@
     "@ckeditor/ckeditor5-editor-classic": "45.0.0",
     "@ckeditor/ckeditor5-editor-multi-root": "45.0.0",
     "@ckeditor/ckeditor5-essentials": "45.0.0",
-    "@ckeditor/ckeditor5-bold": "45.0.0",
     "@ckeditor/ckeditor5-font": "45.0.0",
     "@ckeditor/ckeditor5-highlight": "45.0.0",
     "@ckeditor/ckeditor5-horizontal-line": "45.0.0",

--- a/packages/ckeditor5-html-support/package.json
+++ b/packages/ckeditor5-html-support/package.json
@@ -41,6 +41,7 @@
     "@ckeditor/ckeditor5-editor-classic": "45.0.0",
     "@ckeditor/ckeditor5-editor-multi-root": "45.0.0",
     "@ckeditor/ckeditor5-essentials": "45.0.0",
+    "@ckeditor/ckeditor5-bold": "45.0.0",
     "@ckeditor/ckeditor5-font": "45.0.0",
     "@ckeditor/ckeditor5-highlight": "45.0.0",
     "@ckeditor/ckeditor5-horizontal-line": "45.0.0",

--- a/packages/ckeditor5-html-support/src/datafilter.ts
+++ b/packages/ckeditor5-html-support/src/datafilter.ts
@@ -761,7 +761,7 @@ export default class DataFilter extends Plugin {
 				inheritAllFrom: '$inlineObject'
 			} );
 
-			// Helper function to check if an element has any HTML attributes
+			// Helper function to check if an element has any HTML attributes.
 			const hasHtmlAttributes = ( element: Element | Item ): boolean =>
 				Array
 					.from( element.getAttributeKeys() )

--- a/packages/ckeditor5-html-support/src/datafilter.ts
+++ b/packages/ckeditor5-html-support/src/datafilter.ts
@@ -782,7 +782,7 @@ export default class DataFilter extends Plugin {
 							continue;
 						}
 
-						// Check if the element still has any html* attributes
+						// Check if the element still has any html* attributes.
 						const hasHtmlAttributes = Array
 							.from( item.getAttributeKeys() )
 							.some( key => key.startsWith( 'html' ) );

--- a/packages/ckeditor5-html-support/src/datafilter.ts
+++ b/packages/ckeditor5-html-support/src/datafilter.ts
@@ -783,7 +783,7 @@ export default class DataFilter extends Plugin {
 						// Find htmlEmptyElement instances in the range that lost their html attribute.
 						for ( const { item } of change.range ) {
 							if ( item.is( 'element', 'htmlEmptyElement' ) && !hasHtmlAttributes( item ) ) {
-								elementsToRemove.add( item as Element );
+								elementsToRemove.add( item );
 							}
 						}
 					}
@@ -794,7 +794,7 @@ export default class DataFilter extends Plugin {
 
 						for ( const { item } of writer.createRangeOn( insertedElement ) ) {
 							if ( item.is( 'element', 'htmlEmptyElement' ) && !hasHtmlAttributes( item ) ) {
-								elementsToRemove.add( item as Element );
+								elementsToRemove.add( item );
 							}
 						}
 					}

--- a/packages/ckeditor5-html-support/tests/datafilter.js
+++ b/packages/ckeditor5-html-support/tests/datafilter.js
@@ -34,7 +34,7 @@ describe( 'DataFilter', () => {
 
 		return ClassicTestEditor
 			.create( editorElement, {
-				plugins: [ Bold, Paragraph, FontColorEditing, LinkEditing, GeneralHtmlSupport, Clipboard ]
+				plugins: [ Paragraph, FontColorEditing, LinkEditing, GeneralHtmlSupport ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;
@@ -1830,7 +1830,19 @@ describe( 'DataFilter', () => {
 			} );
 		} );
 
-		it( 'should not insert empty element if has no attributes', () => {
+		it( 'should not insert empty element if has no attributes', async () => {
+			await editor.destroy();
+
+			editor = await ClassicTestEditor.create( editorElement, {
+				plugins: [ Bold, Paragraph, FontColorEditing, LinkEditing, GeneralHtmlSupport, Clipboard ]
+			} );
+
+			model = editor.model;
+
+			dataFilter = editor.plugins.get( 'DataFilter' );
+			dataSchema = editor.plugins.get( 'DataSchema' );
+			htmlSupport = editor.plugins.get( 'GeneralHtmlSupport' );
+
 			const schema = editor.model.schema;
 
 			dataFilter.allowEmptyElement( 'span' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (html-support): Removing formatting from empty HTML no longer crashes the editor. Closes https://github.com/ckeditor/ckeditor5/issues/18089
Fix (html-support): Pasting empty HTML element no longer crashes the editor. Closes https://github.com/ckeditor/ckeditor5/issues/18100
