### PR TITLE
Allow inner markers in mention text e.g @someone@somedomain.com

### DIFF
--- a/packages/ckeditor5-mention/src/mentionui.ts
+++ b/packages/ckeditor5-mention/src/mentionui.ts
@@ -685,7 +685,14 @@ function getLastValidMarkerInText(
 	let lastValidMarker: any;
 
 	for ( const feed of feedsWithPattern ) {
-		const currentMarkerLastIndex = text.lastIndexOf( feed.marker );
+		// RegExp to check inner markers inside the text such as @me@mysite.com
+		const markerInside = `${feed.marker}[\\S]+${feed.marker}[\\S]+`;
+		let currentMarkerLastIndex: any;
+		if (text.match(markerInside)) {
+			currentMarkerLastIndex = text.lastIndexOf( feed.marker, text.lastIndexOf(feed.marker) - 1);
+		} else {
+			currentMarkerLastIndex = text.lastIndexOf( feed.marker );
+		}
 
 		if ( currentMarkerLastIndex > 0 && !text.substring( currentMarkerLastIndex - 1 ).match( feed.pattern ) ) {
 			continue;


### PR DESCRIPTION
Allow @someone@somedomain.com mentions compatible with existing mentions to not implement a new clone with few changes to support this kind of mentions.

To support old feature request explained in github.com/ckeditor/ckeditor5/issues/12907  and recent improvement request https://github.com/ckeditor/ckeditor5/issues/18370
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Type: Message. Closes #18370 #12907

---

### Additional information

If focusing only to mentions @someone@somedomain.com It could be more strict in regex in mentionui.ts:getLastValidMarkerInText() , such as:

```
//const markerInside = `${feed.marker}(([a-z0-9_]+([a-z0-9_\.-]+[a-z0-9_]+)?)${feed.marker}([a-z\.\-]+[a-z]+))`;
```

but using  `${feed.marker}[\\S]+${feed.marker}[\\S]+`; as in PR  will be more back compatible. 

----
As a future note in mentionui.ts:createRegExp() :
  
```
const pattern = `(?:^|[ ${ openAfterCharacters }])(${ marker })(${ mentionCharacters }${ numberOfCharacters }@?${ mentionCharacters }${ numberOfCharacters })`;
```

It could be used to add new options about how many characters are allowed in domain... But this is out of this issue.