### PR TITLE
Fix restoring scroll position after leaving fullscreen mode for containers with `scroll-behavior: smooth`

### DIFF
--- a/packages/ckeditor5-fullscreen/src/handlers/abstracteditorhandler.ts
+++ b/packages/ckeditor5-fullscreen/src/handlers/abstracteditorhandler.ts
@@ -311,8 +311,10 @@ export default class AbstractEditorHandler {
 		// Restore scroll positions of all ancestors. It may include the closest editable wrapper causing the editor to change
 		// the visible content, which is not what we want. Thus, after executing the command, we use
 		// `editor.editing.view.scrollToTheSelection()` to scroll the editor viewport to the current selection.
+		// Using `behavior: 'instant'` is necessary to force scroll if some of the containers has `scroll-behavior: smooth` set (otherwise
+		// the scroll won't happen).
 		for ( const [ ancestor, value ] of this._savedAncestorsScrollPositions ) {
-			ancestor.scrollTo( value.scrollLeft, value.scrollTop );
+			ancestor.scrollTo( { left: value.scrollLeft, top: value.scrollTop, behavior: 'instant' } );
 		}
 
 		this._savedAncestorsScrollPositions.clear();

--- a/packages/ckeditor5-fullscreen/tests/manual/fullscreen.html
+++ b/packages/ckeditor5-fullscreen/tests/manual/fullscreen.html
@@ -97,9 +97,13 @@
 <div class="custom-fullscreen-container" id="custom-fullscreen-container"></div>
 
 <style>
+	html {
+		scroll-behavior: smooth;
+	}
+
 	.editor-container {
 		width: 400px;
-		height: 200px;
+		height: 1500px;
 		overflow: scroll;
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (fullscreen): Fix restoring scroll position after leaving fullscreen mode for containers with `scroll-behavior: smooth`. Closes https://github.com/ckeditor/ckeditor5/issues/18378.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
