### PR TITLE
Fixes #15862: Handle newline-suppressed scenarios (e.g. limit elements) in AutoLink plugin

### DIFF
--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -265,6 +265,7 @@ export default class AutoLink extends Plugin {
 
 			let rangeToCheck: Range;
 
+			// Previous sibling might not be an element if enter was blocked due to be triggered in a limit element.
 			if ( position.parent.previousSibling?.is( 'element' ) ) {
 				rangeToCheck = model.createRangeIn( position.parent.previousSibling );
 			} else {

--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -263,11 +263,13 @@ export default class AutoLink extends Plugin {
 		enterCommand.on( 'execute', () => {
 			const position = model.document.selection.getFirstPosition()!;
 
-			if ( !position.parent.previousSibling ) {
-				return;
-			}
+			let rangeToCheck: Range;
 
-			const rangeToCheck = model.createRangeIn( position.parent.previousSibling as Element );
+			if ( position.parent.previousSibling?.is( 'element' ) ) {
+				rangeToCheck = model.createRangeIn( position.parent.previousSibling );
+			} else {
+				rangeToCheck = model.createRange( model.createPositionAt( position.parent, 0 ), position );
+			}
 
 			this._checkAndApplyAutoLinkOnRange( rangeToCheck );
 		} );

--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -9,7 +9,7 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import type { ClipboardInputTransformationData } from 'ckeditor5/src/clipboard.js';
-import type { DocumentSelectionChangeEvent, Element, Model, Position, Range, Writer } from 'ckeditor5/src/engine.js';
+import type { DocumentSelectionChangeEvent, Model, Position, Range, Writer } from 'ckeditor5/src/engine.js';
 import { Delete, TextWatcher, getLastTextLine, findAttributeRange, type TextWatcherMatchedDataEvent } from 'ckeditor5/src/typing.js';
 import type { EnterCommand, ShiftEnterCommand } from 'ckeditor5/src/enter.js';
 

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -418,7 +418,7 @@ describe( 'AutoLink', () => {
 		} );
 
 		// https://github.com/ckeditor/ckeditor5/issues/15862
-		it( 'adds linkHref to a text link inside a limit element on enter', () => {
+		it( 'adds linkHref to a text link inside an inline limit element on enter', () => {
 			editor.model.schema.register( 'limit', {
 				isLimit: true,
 				allowIn: '$block',
@@ -444,6 +444,23 @@ describe( 'AutoLink', () => {
 				'<paragraph>outer text' +
 				'<limit>inner text <$text linkHref="https://www.cksource.com">https://www.cksource.com[]</$text> inner text</limit>' +
 				'outer text</paragraph>'
+			);
+		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/15862
+		it( 'adds linkHref to a text link inside a block limit element on enter', () => {
+			setData( model, '<paragraph>https://www.cksource.com[]</paragraph>' );
+
+			editor.model.schema.extend( 'paragraph', {
+				isLimit: true
+			} );
+
+			editor.execute( 'enter' );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph>' +
+				'<$text linkHref="https://www.cksource.com">https://www.cksource.com[]</$text>' +
+				'</paragraph>'
 			);
 		} );
 

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -417,6 +417,36 @@ describe( 'AutoLink', () => {
 			);
 		} );
 
+		// https://github.com/ckeditor/ckeditor5/issues/15862
+		it( 'adds linkHref to a text link inside a limit element on enter', () => {
+			editor.model.schema.register( 'limit', {
+				isLimit: true,
+				allowIn: '$block',
+				allowChildren: '$text'
+			} );
+			editor.conversion.elementToElement( {
+				model: 'limit',
+				view: {
+					name: 'span',
+					classes: 'limit'
+				}
+			} );
+
+			setData( model,
+				'<paragraph>outer text' +
+				'<limit>inner text https://www.cksource.com[] inner text</limit>' +
+				'outer text</paragraph>'
+			);
+
+			editor.execute( 'enter' );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph>outer text' +
+				'<limit>inner text <$text linkHref="https://www.cksource.com">https://www.cksource.com[]</$text> inner text</limit>' +
+				'outer text</paragraph>'
+			);
+		} );
+
 		it( 'adds "mailto:" to link of detected email addresses', () => {
 			simulateTyping( 'newsletter@cksource.com ' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (link): Handle newline-suppressed scenarios (e.g. limit elements) in AutoLink plugin. Closes https://github.com/ckeditor/ckeditor5/issues/15862.

Thanks @jonscheiding!

---

### Additional information

On top of what @jonscheiding  covered, I added a test case for a second scenario. It's a bit more theoretical and does not result in a crash now – just nothing happens. In real life it can be triggered e.g. in this case:

<img width="656" alt="image" src="https://github.com/user-attachments/assets/2d937083-d28b-4025-9bb1-b3a06745cc0c" />

After the change, the link will be autolinked on enter. Before, nothing happens.