### PR TITLE
Passed default option for manual tests on ci

### DIFF
--- a/scripts/check-manual-tests.sh
+++ b/scripts/check-manual-tests.sh
@@ -24,6 +24,8 @@ fi
 if [ ! -z "$IDENTITY_FILE" ]
 then
   MANUAL_TEST_SERVER_OPTIONS="$MANUAL_TEST_SERVER_OPTIONS -i $IDENTITY_FILE"
+else
+  MANUAL_TEST_SERVER_OPTIONS="$MANUAL_TEST_SERVER_OPTIONS --no-identity-file"
 fi
 
 echo "Starting the manual test server..."


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Manual tests on CI will now use `--no-identity-file` option by default, if no `--identity-file` option was specified.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
