### PR TITLE
Fixed upcasting the `width` attribute from figure table wrapper.

### DIFF
--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
@@ -398,7 +398,15 @@ export default class TableColumnResizeEditing extends Plugin {
 			model: {
 				name: 'table',
 				key: 'tableWidth',
-				value: ( viewElement: ViewElement ) => viewElement.getStyle( 'width' )
+				value: ( viewElement: ViewElement ) => {
+					const parent = viewElement.parent!;
+
+					if ( parent.is( 'element', 'figure' ) ) {
+						return;
+					}
+
+					return viewElement.getStyle( 'width' );
+				}
 			}
 		} );
 

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -202,7 +202,7 @@ describe( 'TableColumnResizeEditing', () => {
 			it( 'the table width style set on <figure> element and on <table> should be convert to tableWidth attribute correctly', () => {
 				editor.setData(
 					`<figure class="table" style="width: 200px">
-						<table style=";width:100px">
+						<table style="width:100px">
 							<colgroup>
 								<col style="width:50%;">
 								<col style="width:50%;">

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -199,6 +199,42 @@ describe( 'TableColumnResizeEditing', () => {
 				);
 			} );
 
+			it( 'the table width style set on <figure> element and on <table> should be convert to tableWidth attribute correctly', () => {
+				editor.setData(
+					`<figure class="table" style="width: 200px">
+						<table style=";width:100px">
+							<colgroup>
+								<col style="width:50%;">
+								<col style="width:50%;">
+							</colgroup>
+							<tbody>
+								<tr>
+									<td>11</td>
+									<td>12</td>
+								</tr>
+							</tbody>
+						</table>
+					</figure>`
+				);
+
+				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+					'<table tableWidth="200px">' +
+						'<tableRow>' +
+							'<tableCell>' +
+								'<paragraph>11</paragraph>' +
+							'</tableCell>' +
+							'<tableCell>' +
+								'<paragraph>12</paragraph>' +
+							'</tableCell>' +
+						'</tableRow>' +
+						'<tableColumnGroup>' +
+							'<tableColumn columnWidth="50%"></tableColumn>' +
+							'<tableColumn columnWidth="50%"></tableColumn>' +
+						'</tableColumnGroup>' +
+					'</table>'
+				);
+			} );
+
 			describe( 'when upcasting <colgroup> element', () => {
 				it( 'should handle the correct number of <col> elements', () => {
 					editor.setData(


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (table): Should apply the proper `width` attribute when it's  applied both on `<table>` and `<figure>` element. Closes #18469.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
