### PR TITLE
Force DOM selection update after some view children changes on Safari.

### DIFF
--- a/packages/ckeditor5-engine/src/view/renderer.ts
+++ b/packages/ckeditor5-engine/src/view/renderer.ts
@@ -1117,6 +1117,12 @@ export default class Renderer extends /* #__PURE__ */ ObservableMixin() {
 		const oldViewSelection = domSelection && this.domConverter.domSelectionToView( domSelection );
 
 		if ( oldViewSelection && this.selection.isEqual( oldViewSelection ) ) {
+			// Safari has a bug where the DOM selection does not reflect the user's visible selection,
+			// especially after complex DOM mutations. Force selection update if any DOM children were changed.
+			if ( env.isSafari && this.markedChildren.size && this.selection.isCollapsed ) {
+				return true;
+			}
+
 			return false;
 		}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (engine): Force DOM selection update after some view-children were changed on Safari.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
