### PR TITLE
Improve how license type messages are logged to the console.

### DIFF
--- a/packages/ckeditor5-core/src/editor/editor.ts
+++ b/packages/ckeditor5-core/src/editor/editor.ts
@@ -49,6 +49,9 @@ import type { EditorConfig } from './editorconfig.js';
 declare global {
 	// eslint-disable-next-line no-var
 	var CKEDITOR_GLOBAL_LICENSE_KEY: string | undefined;
+
+	// eslint-disable-next-line no-var
+	var CKEDITOR_WARNING_SUPPRESSIONS: Record<string, boolean>;
 }
 
 /**
@@ -544,11 +547,13 @@ export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 
 			if ( [ 'development', 'evaluation', 'trial' ].includes( licensePayload.licenseType ) ) {
 				const { licenseType } = licensePayload;
-				const sessionStarted = sessionStorage.getItem( 'ckeditor5-development-session-started' );
 
-				if ( !sessionStarted ) {
+				window.CKEDITOR_WARNING_SUPPRESSIONS = window.CKEDITOR_WARNING_SUPPRESSIONS || {};
+
+				if ( !window.CKEDITOR_WARNING_SUPPRESSIONS[ licenseType ] ) {
 					warnAboutNonProductionLicenseKey( licenseType );
-					sessionStorage.setItem( 'ckeditor5-development-session-started', 'true' );
+
+					window.CKEDITOR_WARNING_SUPPRESSIONS[ licenseType ] = true;
 				}
 			}
 

--- a/packages/ckeditor5-core/tests/editor/licensecheck.js
+++ b/packages/ckeditor5-core/tests/editor/licensecheck.js
@@ -461,8 +461,8 @@ describe( 'Editor - license check', () => {
 					// eslint-disable-next-line no-new
 					new TestEditor( { licenseKey } );
 
-					expect( consoleInfoStub.secondCall ).to.not.exist;
-					expect( consoleWarnStub.secondCall ).to.not.exist;
+					sinon.assert.calledOnce( consoleInfoStub );
+					sinon.assert.calledOnce( consoleWarnStub );
 
 					dateNow.restore();
 				} );
@@ -552,8 +552,8 @@ describe( 'Editor - license check', () => {
 				// eslint-disable-next-line no-new
 				new TestEditor( { licenseKey } );
 
-				expect( consoleInfoStub.secondCall ).to.not.exist;
-				expect( consoleWarnStub.secondCall ).to.not.exist;
+				sinon.assert.calledOnce( consoleInfoStub );
+				sinon.assert.calledOnce( consoleWarnStub );
 			} );
 
 			it( 'should not block the editor if 10 minutes have not passed (development license)', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (core): Non-production license notifications should only be displayed once per page load.

---

### Additional information

Closes https://github.com/cksource/ckeditor5-commercial/issues/7398.
