### PR TITLE
Internal: Bump required Node version to `>=20.12.0`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "webpack": "^5.94.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.12.0"
   },
   "author": "CKSource (http://cksource.com/)",
   "license": "SEE LICENSE IN LICENSE.md",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Bump required Node version to `>=20.12.0`.

---

We already use `util.styleText` which requires Node 20.12.0.
