### PR TITLE
The model selection in read-only mode should be always updated

### DIFF
--- a/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
@@ -303,8 +303,9 @@ export default class SelectionObserver extends Observer {
 		// Mark the latest focus change as complete (we got new selection after the focus so the selection is in the focused element).
 		this.focusObserver.flush();
 
-		// Ignore selection change as the editable is not focused.
-		if ( !this.view.document.isFocused ) {
+		// Ignore selection change as the editable is not focused. Note that in read-only mode, we have to update
+		// the model selection as there won't be any focus change to flush the pending selection changes.
+		if ( !this.view.document.isFocused && !this.view.document.isReadOnly ) {
 			// @if CK_DEBUG_TYPING // if ( ( window as any ).logCKETyping ) {
 			// @if CK_DEBUG_TYPING // 	console.info( ..._buildLogMessage( this, 'SelectionObserver',
 			// @if CK_DEBUG_TYPING // 		'Ignore selection change while editable is not focused'

--- a/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
@@ -125,7 +125,7 @@ describe( 'SelectionObserver', () => {
 
 	it( 'should not fire selectionChange while editable is not focused', done => {
 		viewDocument.on( 'selectionChange', () => {
-			throw 'selectionChange fired while editable is not focused';
+			throw new Error( 'selectionChange fired while editable is not focused' );
 		} );
 
 		viewDocument.isFocused = false;
@@ -147,21 +147,23 @@ describe( 'SelectionObserver', () => {
 
 	// See https://github.com/ckeditor/ckeditor5/issues/18514.
 	it( 'should fire selectionChange while editable is not focused but the editor is in read-only mode', done => {
-		viewDocument.on( 'selectionChange', () => done() );
+		const spy = sinon.spy();
 
-		viewDocument.isFocused = false;
+		viewDocument.on( 'selectionChange', spy );
+
 		viewDocument.isReadOnly = true;
-
+		viewDocument.isFocused = false;
 		changeDomSelection();
 
 		setTimeout( () => {
-			throw 'selectionChange was not fired in read-only mode';
+			expect( spy.calledOnce ).to.be.true;
+			done();
 		}, 100 );
 	} );
 
 	it( 'should not fire selectionChange while user is composing', done => {
 		viewDocument.on( 'selectionChange', () => {
-			throw 'selectionChange fired while composing';
+			throw new Error( 'selectionChange fired while composing' );
 		} );
 
 		viewDocument.isComposing = true;
@@ -273,7 +275,7 @@ describe( 'SelectionObserver', () => {
 
 	it( 'should not fire selectionChange for ignored target', done => {
 		viewDocument.on( 'selectionChange', () => {
-			throw 'selectionChange fired in ignored elements';
+			throw new Error( 'selectionChange fired in ignored elements' );
 		} );
 
 		view.getObserver( MutationObserver ).disable();
@@ -286,7 +288,7 @@ describe( 'SelectionObserver', () => {
 
 	it( 'should not fire selectionChange on render', done => {
 		viewDocument.on( 'selectionChange', () => {
-			throw 'selectionChange on render';
+			throw new Error( 'selectionChange on render' );
 		} );
 
 		setTimeout( done, 70 );
@@ -302,7 +304,7 @@ describe( 'SelectionObserver', () => {
 		view.getObserver( SelectionObserver ).disable();
 
 		viewDocument.on( 'selectionChange', () => {
-			throw 'selectionChange on render';
+			throw new Error( 'selectionChange on render' );
 		} );
 
 		setTimeout( done, 70 );
@@ -656,7 +658,7 @@ describe( 'SelectionObserver', () => {
 			}, { priority: 'highest' } );
 
 			viewDocument.on( 'selectionChange', () => {
-				throw 'selectionChange fired';
+				throw new Error( 'selectionChange fired' );
 			} );
 
 			viewDocument.isSelecting = false;

--- a/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
@@ -145,6 +145,20 @@ describe( 'SelectionObserver', () => {
 		}, 100 );
 	} );
 
+	// See https://github.com/ckeditor/ckeditor5/issues/18514.
+	it( 'should fire selectionChange while editable is not focused but the editor is in read-only mode', done => {
+		viewDocument.on( 'selectionChange', () => done() );
+
+		viewDocument.isFocused = false;
+		viewDocument.isReadOnly = true;
+
+		changeDomSelection();
+
+		setTimeout( () => {
+			throw 'selectionChange was not fired in read-only mode';
+		}, 100 );
+	} );
+
 	it( 'should not fire selectionChange while user is composing', done => {
 		viewDocument.on( 'selectionChange', () => {
 			throw 'selectionChange fired while composing';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (engine): Copying content in read-only mode should use the current document selection. Closes #18514.

---

### Additional information

This is fixing the issue introduced in #17870.