### PR TITLE
Font, Bold and Italic attributes in existing downcast converters should be applied on text only

### DIFF
--- a/packages/ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorediting.ts
+++ b/packages/ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorediting.ts
@@ -125,7 +125,7 @@ export default class FontBackgroundColorEditing extends Plugin {
 
 		editor.conversion.for( 'downcast' ).attributeToElement( {
 			model: FONT_BACKGROUND_COLOR,
-			view: renderDowncastElement( 'background-color' )
+			view: renderDowncastElement( 'background-color', editor.model.schema )
 		} );
 
 		editor.commands.add( FONT_BACKGROUND_COLOR, new FontBackgroundColorCommand( editor ) );

--- a/packages/ckeditor5-font/src/fontcolor/fontcolorediting.ts
+++ b/packages/ckeditor5-font/src/fontcolor/fontcolorediting.ts
@@ -137,13 +137,7 @@ export default class FontColorEditing extends Plugin {
 
 		editor.conversion.for( 'downcast' ).attributeToElement( {
 			model: FONT_COLOR,
-			view: ( value, conversionApi, { item } ) => {
-				if ( !item.is( '$textProxy' ) ) {
-					return null;
-				}
-
-				return renderDowncastElement( 'color' )( value, conversionApi );
-			}
+			view: renderDowncastElement( 'color', editor.model.schema )
 		} );
 
 		editor.commands.add( FONT_COLOR, new FontColorCommand( editor ) );

--- a/packages/ckeditor5-font/src/fontcolor/fontcolorediting.ts
+++ b/packages/ckeditor5-font/src/fontcolor/fontcolorediting.ts
@@ -137,7 +137,13 @@ export default class FontColorEditing extends Plugin {
 
 		editor.conversion.for( 'downcast' ).attributeToElement( {
 			model: FONT_COLOR,
-			view: renderDowncastElement( 'color' )
+			view: ( value, conversionApi, { item } ) => {
+				if ( !item.is( '$textProxy' ) ) {
+					return null;
+				}
+
+				return renderDowncastElement( 'color' )( value, conversionApi );
+			}
 		} );
 
 		editor.commands.add( FONT_COLOR, new FontColorCommand( editor ) );

--- a/packages/ckeditor5-font/src/fontfamily/fontfamilyediting.ts
+++ b/packages/ckeditor5-font/src/fontfamily/fontfamilyediting.ts
@@ -99,7 +99,11 @@ export default class FontFamilyEditing extends Plugin {
 
 		editor.conversion.for( 'downcast' ).attributeToElement( {
 			model: FONT_FAMILY,
-			view: ( attributeValue, { writer } ) => {
+			view: ( attributeValue, { writer }, { item } ) => {
+				if ( !item.is( '$textProxy' ) ) {
+					return null;
+				}
+
 				return writer.createAttributeElement( 'span', { style: 'font-family:' + attributeValue }, { priority: 7 } );
 			}
 		} );

--- a/packages/ckeditor5-font/src/fontfamily/fontfamilyediting.ts
+++ b/packages/ckeditor5-font/src/fontfamily/fontfamilyediting.ts
@@ -100,7 +100,7 @@ export default class FontFamilyEditing extends Plugin {
 		editor.conversion.for( 'downcast' ).attributeToElement( {
 			model: FONT_FAMILY,
 			view: ( attributeValue, { writer }, { item } ) => {
-				if ( !item.is( '$textProxy' ) ) {
+				if ( !item.is( 'selection' ) && !editor.model.schema.isInline( item ) ) {
 					return null;
 				}
 

--- a/packages/ckeditor5-font/src/fontsize/fontsizeediting.ts
+++ b/packages/ckeditor5-font/src/fontsize/fontsizeediting.ts
@@ -136,8 +136,8 @@ export default class FontSizeEditing extends Plugin {
 
 		editor.conversion.for( 'downcast' ).attributeToElement( {
 			model: FONT_SIZE,
-			view: ( attributeValue, { writer } ) => {
-				if ( !attributeValue ) {
+			view: ( attributeValue, { writer }, { item } ) => {
+				if ( !attributeValue || !item.is( '$textProxy' ) ) {
 					return;
 				}
 

--- a/packages/ckeditor5-font/src/fontsize/fontsizeediting.ts
+++ b/packages/ckeditor5-font/src/fontsize/fontsizeediting.ts
@@ -137,7 +137,7 @@ export default class FontSizeEditing extends Plugin {
 		editor.conversion.for( 'downcast' ).attributeToElement( {
 			model: FONT_SIZE,
 			view: ( attributeValue, { writer }, { item } ) => {
-				if ( !attributeValue || !item.is( '$textProxy' ) ) {
+				if ( !attributeValue || !item.is( 'selection' ) && !editor.model.schema.isInline( item ) ) {
 					return;
 				}
 

--- a/packages/ckeditor5-font/src/utils.ts
+++ b/packages/ckeditor5-font/src/utils.ts
@@ -15,7 +15,9 @@ import type {
 	ViewElement,
 	MatcherPattern,
 	ViewElementDefinition,
-	DowncastConversionApi
+	DowncastConversionApi,
+	Schema,
+	Item
 } from 'ckeditor5/src/engine.js';
 
 /**
@@ -90,11 +92,20 @@ export function renderUpcastAttribute( styleAttr: string ) {
  *
  * **Note**: The `styleAttr` parameter should be either `'color'` or `'background-color'`.
  */
-export function renderDowncastElement( styleAttr: string ) {
-	return ( modelAttributeValue: string, { writer }: DowncastConversionApi ): ViewAttributeElement =>
-		writer.createAttributeElement( 'span', {
+export function renderDowncastElement( styleAttr: string, schema: Schema ) {
+	return (
+		modelAttributeValue: string,
+		{ writer }: DowncastConversionApi,
+		{ item }: { item: Item }
+	): ViewAttributeElement | null => {
+		if ( !schema.isInline( item ) ) {
+			return null;
+		}
+
+		return writer.createAttributeElement( 'span', {
 			style: `${ styleAttr }:${ modelAttributeValue }`
 		}, { priority: 7 } );
+	};
 }
 
 /**

--- a/packages/ckeditor5-font/tests/fontcolor/fontcolorediting.js
+++ b/packages/ckeditor5-font/tests/fontcolor/fontcolorediting.js
@@ -181,6 +181,14 @@ describe( 'FontColorEditing', () => {
 				} );
 			} );
 		} );
+
+		it( 'should downcast `fontColor` attribute only for text', () => {
+			setModelData( doc, '<paragraph fontColor="red"><$text fontColor="red">foo</$text></paragraph>' );
+
+			expect( editor.getData() ).to.equal(
+				'<p><span style="color:blue;">foo</span></p>'
+			);
+		} );
 	} );
 
 	describe( 'data pipeline conversions', () => {

--- a/packages/ckeditor5-font/tests/fontcolor/fontcolorediting.js
+++ b/packages/ckeditor5-font/tests/fontcolor/fontcolorediting.js
@@ -182,11 +182,33 @@ describe( 'FontColorEditing', () => {
 			} );
 		} );
 
-		it( 'should downcast `fontColor` attribute only for text', () => {
-			setModelData( doc, '<paragraph fontColor="red"><$text fontColor="red">foo</$text></paragraph>' );
+		it( 'should downcast `fontColor` attribute only for text and inline object', () => {
+			editor.model.schema.register( 'inlineObject', {
+				inheritAllFrom: '$inlineObject'
+			} );
+
+			editor.conversion.elementToElement( {
+				model: 'inlineObject',
+				view: {
+					name: 'span',
+					classes: 'inline-object'
+				}
+			} );
+
+			setModelData( doc,
+				'<paragraph fontColor="red">' +
+					'<$text fontColor="red">foo</$text>' +
+					'<inlineObject fontColor="red"></inlineObject>' +
+				'</paragraph>'
+			);
 
 			expect( editor.getData() ).to.equal(
-				'<p><span style="color:red;">foo</span></p>'
+				'<p>' +
+					'<span style="color:red;">' +
+						'foo' +
+						'<span class="inline-object">&nbsp;</span>' +
+					'</span>' +
+				'</p>'
 			);
 		} );
 	} );

--- a/packages/ckeditor5-font/tests/fontcolor/fontcolorediting.js
+++ b/packages/ckeditor5-font/tests/fontcolor/fontcolorediting.js
@@ -186,7 +186,7 @@ describe( 'FontColorEditing', () => {
 			setModelData( doc, '<paragraph fontColor="red"><$text fontColor="red">foo</$text></paragraph>' );
 
 			expect( editor.getData() ).to.equal(
-				'<p><span style="color:blue;">foo</span></p>'
+				'<p><span style="color:red;">foo</span></p>'
 			);
 		} );
 	} );

--- a/packages/ckeditor5-font/tests/fontfamily/fontfamilyediting.js
+++ b/packages/ckeditor5-font/tests/fontfamily/fontfamilyediting.js
@@ -117,11 +117,33 @@ describe( 'FontFamilyEditing', () => {
 					expect( editor.getData() ).to.equal( '<p>f<span style="font-family:Arial, Helvetica, sans-serif;">o</span>o</p>' );
 				} );
 
-				it( 'should downcast `fontFamily` attribute only for text', () => {
-					setModelData( doc, '<paragraph fontFamily="Arial"><$text fontFamily="Arial">foo</$text></paragraph>' );
+				it( 'should downcast `fontFamily` attribute only for text and inline objects', () => {
+					editor.model.schema.register( 'inlineObject', {
+						inheritAllFrom: '$inlineObject'
+					} );
+
+					editor.conversion.elementToElement( {
+						model: 'inlineObject',
+						view: {
+							name: 'span',
+							classes: 'inline-object'
+						}
+					} );
+
+					setModelData( doc,
+						'<paragraph fontFamily="Arial">' +
+							'<$text fontFamily="Arial">foo</$text>' +
+							'<inlineObject fontFamily="Arial"></inlineObject>' +
+						'</paragraph>'
+					);
 
 					expect( editor.getData() ).to.equal(
-						'<p><span style="font-family:Arial;">foo</span></p>'
+						'<p>' +
+							'<span style="font-family:Arial;">' +
+								'foo' +
+								'<span class="inline-object">&nbsp;</span>' +
+							'</span>' +
+						'</p>'
 					);
 				} );
 			} );

--- a/packages/ckeditor5-font/tests/fontfamily/fontfamilyediting.js
+++ b/packages/ckeditor5-font/tests/fontfamily/fontfamilyediting.js
@@ -116,6 +116,14 @@ describe( 'FontFamilyEditing', () => {
 
 					expect( editor.getData() ).to.equal( '<p>f<span style="font-family:Arial, Helvetica, sans-serif;">o</span>o</p>' );
 				} );
+
+				it( 'should downcast `fontFamily` attribute only for text', () => {
+					setModelData( doc, '<paragraph fontFamily="Arial"><$text fontFamily="Arial">foo</$text></paragraph>' );
+
+					expect( editor.getData() ).to.equal(
+						'<p><span style="font-family:Arial;">foo</span></p>'
+					);
+				} );
 			} );
 
 			describe( 'data pipeline conversions', () => {

--- a/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
@@ -126,11 +126,33 @@ describe( 'FontSizeEditing', () => {
 					expect( editor.getData() ).to.equal( '<p>f<span style="font-size:8em;">o</span>o</p>' );
 				} );
 
-				it( 'should downcast `fontSize` attribute only for text', () => {
-					setModelData( doc, '<paragraph fontSize="8em"><$text fontSize="8em">foo</$text></paragraph>' );
+				it( 'should downcast `fontSize` attribute only for text and inline objects', () => {
+					editor.model.schema.register( 'inlineObject', {
+						inheritAllFrom: '$inlineObject'
+					} );
+
+					editor.conversion.elementToElement( {
+						model: 'inlineObject',
+						view: {
+							name: 'span',
+							classes: 'inline-object'
+						}
+					} );
+
+					setModelData( doc,
+						'<paragraph fontSize="8em">' +
+							'<$text fontSize="8em">foo</$text>' +
+							'<inlineObject fontSize="8em"></inlineObject>' +
+						'</paragraph>'
+					);
 
 					expect( editor.getData() ).to.equal(
-						'<p><span style="font-size:8em;">foo</span></p>'
+						'<p>' +
+							'<span style="font-size:8em;">' +
+								'foo' +
+								'<span class="inline-object">&nbsp;</span>' +
+							'</span>' +
+						'</p>'
 					);
 				} );
 			} );

--- a/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
@@ -125,6 +125,14 @@ describe( 'FontSizeEditing', () => {
 
 					expect( editor.getData() ).to.equal( '<p>f<span style="font-size:8em;">o</span>o</p>' );
 				} );
+
+				it( 'should downcast `fontSize` attribute only for text', () => {
+					setModelData( doc, '<paragraph fontSize="8em"><$text fontSize="8em">foo</$text></paragraph>' );
+
+					expect( editor.getData() ).to.equal(
+						'<p><span style="font-size:8em;">foo</span></p>'
+					);
+				} );
 			} );
 
 			describe( 'data pipeline conversions', () => {

--- a/packages/ckeditor5-font/tests/utils.js
+++ b/packages/ckeditor5-font/tests/utils.js
@@ -58,11 +58,13 @@ describe( 'utils', () => {
 
 	describe( 'renderDowncastElement()', () => {
 		it( 'should create function executes viewWriter with proper arguments', () => {
-			const downcastViewConverterFn = renderDowncastElement( 'color' );
+			const fakeSchema = { isInline: () => true };
+			const downcastViewConverterFn = renderDowncastElement( 'color', fakeSchema );
 			const fake = testUtils.sinon.fake();
 			const fakeViewWriter = { createAttributeElement: fake };
+			const fakeItem = {};
 
-			downcastViewConverterFn( 'blue', { writer: fakeViewWriter } );
+			downcastViewConverterFn( 'blue', { writer: fakeViewWriter }, { fakeItem } );
 
 			sinon.assert.calledWithExactly( fake, 'span', { style: 'color:blue' }, { priority: 7 } );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (list, basic-styles): Font, Bold and Italic attributes in existing downcast converters should be applied on text only. Closes #18538.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
