### PR TITLE
Fix emoji panel on the small screen.

### DIFF
--- a/packages/ckeditor5-emoji/theme/emojipicker.css
+++ b/packages/ckeditor5-emoji/theme/emojipicker.css
@@ -5,6 +5,7 @@
 
 .ck.ck-emoji {
 	width: 320px;
+	min-width: 320px;
 }
 
 .ck .ck.ck-emoji__search {
@@ -37,4 +38,5 @@
 
 div.ck.ck-balloon-panel.ck-emoji-picker-balloon {
 	z-index: calc( var( --ck-z-dialog ) + 1 );
+	min-width: 320px;
 }

--- a/packages/ckeditor5-emoji/theme/emojipickerform.css
+++ b/packages/ckeditor5-emoji/theme/emojipickerform.css
@@ -5,6 +5,7 @@
 
 .ck.ck-form.ck-emoji-picker-form {
 	padding-bottom: 0;
+	min-width: 320px;
 
 	/*
 	 * `.ck-form` overrides styling of all dropdowns by adding border around them.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Type: Message. Closes #18552.

---

### Additional information


In version 45.0.0, when opening the emoji picker on a small screen, the panel would shrink and cause layout issues. This regression was introduced when the emoji picker was refactored to use a form wrapper in [commit d9b8005](https://github.com/ckeditor/ckeditor5/commit/d9b8005d2a94df074a6f889cfb8af5aa5cdc24fd).

While the original emoji component had a fixed width of 320px, the newly introduced form wrapper lacked width constraints, allowing it to shrink on small screens.

#### Solution

Added explicit `min-width: 320px` to all three components in the emoji picker hierarchy:

1. The emoji component itself (`.ck.ck-emoji`)
2. The form wrapper (`.ck.ck-form.ck-emoji-picker-form`)
3. The balloon panel container (`.ck.ck-balloon-panel.ck-emoji-picker-balloon`)

This ensures that all parts of the component maintain their appropriate size on small screens, preventing layout issues and maintaining consistent behavior across all screen sizes.

