### PR TITLE
Upcast converter for listItemFontColor

### DIFF
--- a/packages/ckeditor5-list/src/listformatting/listitemfontfamilyintegration.ts
+++ b/packages/ckeditor5-list/src/listformatting/listitemfontfamilyintegration.ts
@@ -54,17 +54,13 @@ export default class ListItemFontFamilyIntegration extends Plugin {
 			isFormatting: true
 		} );
 
-		model.schema.addAttributeCheck( ( context, attributeName ) => {
+		model.schema.addAttributeCheck( context => {
 			const item = context.last;
-
-			if ( attributeName != 'listItemFontFamily' ) {
-				return;
-			}
 
 			if ( !item.getAttribute( 'listItemId' ) ) {
 				return false;
 			}
-		} );
+		}, 'listItemFontFamily' );
 
 		listEditing.registerDowncastStrategy( {
 			scope: 'item',

--- a/packages/ckeditor5-list/src/listformatting/listitemfontfamilyintegration.ts
+++ b/packages/ckeditor5-list/src/listformatting/listitemfontfamilyintegration.ts
@@ -8,6 +8,8 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core.js';
+import { type ViewElement } from 'ckeditor5/src/engine.js';
+
 import ListEditing from '../list/listediting.js';
 
 /**
@@ -52,6 +54,18 @@ export default class ListItemFontFamilyIntegration extends Plugin {
 			isFormatting: true
 		} );
 
+		model.schema.addAttributeCheck( ( context, attributeName ) => {
+			const item = context.last;
+
+			if ( attributeName != 'listItemFontFamily' ) {
+				return;
+			}
+
+			if ( !item.getAttribute( 'listItemId' ) ) {
+				return false;
+			}
+		} );
+
 		listEditing.registerDowncastStrategy( {
 			scope: 'item',
 			attributeName: 'listItemFontFamily',
@@ -61,6 +75,21 @@ export default class ListItemFontFamilyIntegration extends Plugin {
 					writer.setStyle( 'font-family', value as string, viewElement );
 				} else {
 					writer.removeStyle( 'font-family', viewElement );
+				}
+			}
+		} );
+
+		editor.conversion.for( 'upcast' ).attributeToAttribute( {
+			model: {
+				key: 'listItemFontFamily',
+				value: ( viewElement: ViewElement ) => {
+					return viewElement.getStyle( 'font-family' );
+				}
+			},
+			view: {
+				name: 'li',
+				styles: {
+					'font-family': /.*/
 				}
 			}
 		} );

--- a/packages/ckeditor5-list/tests/listformatting/listitemfontfamilyintegration.js
+++ b/packages/ckeditor5-list/tests/listformatting/listitemfontfamilyintegration.js
@@ -12,7 +12,7 @@ import FontFamilyEditing from '@ckeditor/ckeditor5-font/src/fontfamily/fontfamil
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor.js';
 import ModelElement from '@ckeditor/ckeditor5-engine/src/model/element.js';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
-import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
+import { setData as setModelData, getData as getModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view.js';
 
 import stubUid from '../list/_utils/uid.js';
@@ -309,6 +309,178 @@ describe( 'ListItemFontFamilyIntegration', () => {
 						'</p>' +
 					'</li>' +
 				'</ul>'
+			);
+		} );
+	} );
+
+	describe( 'upcast', () => {
+		it( 'should upcast style in <li> to listItemFontFamily attribute (unordered list)', () => {
+			editor.setData(
+				'<ul>' +
+					'<li style="font-family:Arial;">' +
+						'<span style="font-family:Arial;">foo</span>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			expect( getModelData( model, { withoutSelection: true } ) ).to.equalMarkup(
+				'<paragraph listIndent="0" listItemFontFamily="Arial" listItemId="a00" listType="bulleted">' +
+					'<$text fontFamily="Arial">foo</$text>' +
+				'</paragraph>'
+			);
+		} );
+
+		it( 'should upcast style in <li> to listItemFontFamily attribute (ordered list)', () => {
+			editor.setData(
+				'<ol>' +
+					'<li style="font-family:Arial;">' +
+						'<span style="font-family:Arial;">foo</span>' +
+					'</li>' +
+				'</ol>'
+			);
+
+			expect( getModelData( model, { withoutSelection: true } ) ).to.equalMarkup(
+				'<paragraph listIndent="0" listItemFontFamily="Arial" listItemId="a00" listType="numbered">' +
+					'<$text fontFamily="Arial">foo</$text>' +
+				'</paragraph>'
+			);
+		} );
+
+		it( 'should only upcast style set in <li> (not <ul> and not <p>)', () => {
+			editor.setData(
+				'<ul style="font-family:Tahoma;">' +
+					'<li style="font-family:Arial;">' +
+						'<p style="font-family:Verdana;">' +
+							'<span style="font-family:Arial;">foo</span>' +
+						'</p>' +
+					'</li>' +
+				'</ul>' +
+				'<p style="font-family:Helvetica;">baz</p>'
+			);
+
+			expect( getModelData( model, { withoutSelection: true } ) ).to.equalMarkup(
+				'<paragraph listIndent="0" listItemFontFamily="Arial" listItemId="a00" listType="bulleted">' +
+					'<$text fontFamily="Arial">foo</$text>' +
+				'</paragraph>' +
+				'<paragraph>baz</paragraph>'
+			);
+		} );
+
+		it( 'should upcast style in <li> to listItemFontFamily attribute (nested list)', () => {
+			editor.setData(
+				'<ul>' +
+					'<li style="font-family:Arial;">' +
+						'<span style="font-family:Arial;">foo</span>' +
+						'<ul>' +
+							'<li style="font-family:Arial;">' +
+								'<span style="font-family:Arial;">bar</span>' +
+							'</li>' +
+						'</ul>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			expect( getModelData( model, { withoutSelection: true } ) ).to.equalMarkup(
+				'<paragraph listIndent="0" listItemFontFamily="Arial" listItemId="a01" listType="bulleted">' +
+					'<$text fontFamily="Arial">foo</$text>' +
+				'</paragraph>' +
+				'<paragraph listIndent="1" listItemFontFamily="Arial" listItemId="a00" listType="bulleted">' +
+					'<$text fontFamily="Arial">bar</$text>' +
+				'</paragraph>'
+			);
+		} );
+
+		it( 'should upcast style in <li> to listItemFontFamily attribute in multi-block', () => {
+			editor.setData(
+				'<ul>' +
+					'<li style="font-family:Arial;">' +
+						'<p>' +
+							'<span style="font-family:Arial;">foo</span>' +
+						'</p>' +
+						'<p>' +
+							'<span style="font-family:Arial;">bar</span>' +
+						'</p>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			expect( getModelData( model, { withoutSelection: true } ) ).to.equalMarkup(
+				'<paragraph listIndent="0" listItemFontFamily="Arial" listItemId="a00" listType="bulleted">' +
+					'<$text fontFamily="Arial">foo</$text>' +
+				'</paragraph>' +
+				'<paragraph listIndent="0" listItemFontFamily="Arial" listItemId="a00" listType="bulleted">' +
+					'<$text fontFamily="Arial">bar</$text>' +
+				'</paragraph>'
+			);
+		} );
+
+		it( 'should upcast style in <li> to listItemFontFamily attribute for blockquote', () => {
+			editor.setData(
+				'<ul>' +
+					'<li style="font-family:Arial;">' +
+						'<blockquote>' +
+							'<span style="font-family:Arial;">foo</span>' +
+						'</blockquote>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			expect( getModelData( model, { withoutSelection: true } ) ).to.equalMarkup(
+				'<blockQuote listIndent="0" listItemFontFamily="Arial" listItemId="a00" listType="bulleted">' +
+					'<paragraph>' +
+						'<$text fontFamily="Arial">foo</$text>' +
+					'</paragraph>' +
+				'</blockQuote>'
+			);
+		} );
+
+		it( 'should upcast style in <li> to listItemFontFamily attribute for heading', () => {
+			editor.setData(
+				'<ul>' +
+					'<li style="font-family:Arial;">' +
+						'<h2>' +
+							'<span style="font-family:Arial;">foo</span>' +
+						'</h2>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			expect( getModelData( model, { withoutSelection: true } ) ).to.equalMarkup(
+				'<heading1 listIndent="0" listItemFontFamily="Arial" listItemId="a00" listType="bulleted">' +
+					'<$text fontFamily="Arial">foo</$text>' +
+				'</heading1>'
+			);
+		} );
+
+		it( 'should upcast style in <li> to listItemFontFamily attribute for table', () => {
+			editor.setData(
+				'<ul>' +
+					'<li style="font-family:Arial;">' +
+						'<figure class="table">' +
+							'<table>' +
+								'<tbody>' +
+									'<tr>' +
+										'<td>' +
+											'<span style="font-family:Arial;">foo</span>' +
+										'</td>' +
+									'</tr>' +
+								'</tbody>' +
+							'</table>' +
+						'</figure>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			expect( getModelData( model, { withoutSelection: true } ) ).to.equalMarkup(
+				'<table listIndent="0" listItemFontFamily="Arial" listItemId="a00" listType="bulleted">' +
+					'<tableRow>' +
+						'<tableCell>' +
+							'<paragraph>' +
+								'<$text fontFamily="Arial">foo</$text>' +
+							'</paragraph>' +
+						'</tableCell>' +
+					'</tableRow>' +
+				'</table>'
 			);
 		} );
 	} );

--- a/packages/ckeditor5-list/tests/listformatting/listitemfontfamilyintegration.js
+++ b/packages/ckeditor5-list/tests/listformatting/listitemfontfamilyintegration.js
@@ -73,12 +73,8 @@ describe( 'ListItemFontFamilyIntegration', () => {
 	} );
 
 	describe( 'schema', () => {
-		it( 'should allow listItemFontFamily attribute in $listItem', () => {
-			expect( model.schema.checkAttribute( [ '$root', '$listItem' ], 'listItemFontFamily' ) ).to.be.true;
-		} );
-
 		it( 'listItemFontFamily attribute should have isFormatting set to true', () => {
-			expect( editor.model.schema.getAttributeProperties( 'listItemFontFamily' ) ).to.include( {
+			expect( model.schema.getAttributeProperties( 'listItemFontFamily' ) ).to.include( {
 				isFormatting: true
 			} );
 		} );
@@ -502,7 +498,7 @@ describe( 'ListItemFontFamilyIntegration', () => {
 								'<tbody>' +
 									'<tr>' +
 										'<td>' +
-											'<span style="font-family:Arial;">foo</span>' +
+											'foo' +
 										'</td>' +
 									'</tr>' +
 								'</tbody>' +
@@ -517,7 +513,7 @@ describe( 'ListItemFontFamilyIntegration', () => {
 					'<tableRow>' +
 						'<tableCell>' +
 							'<paragraph>' +
-								'<$text fontFamily="Arial">foo</$text>' +
+								'foo' +
 							'</paragraph>' +
 						'</tableCell>' +
 					'</tableRow>' +

--- a/packages/ckeditor5-list/tests/listformatting/listitemfontfamilyintegration.js
+++ b/packages/ckeditor5-list/tests/listformatting/listitemfontfamilyintegration.js
@@ -73,6 +73,17 @@ describe( 'ListItemFontFamilyIntegration', () => {
 	} );
 
 	describe( 'schema', () => {
+		it( 'should allow listItemFontFamily attribute in $listItem', () => {
+			model.schema.register( 'myElement', {
+				inheritAllFrom: '$block',
+				allowAttributesOf: '$listItem'
+			} );
+
+			const modelElement = new ModelElement( 'myElement', { listItemId: 'a' } );
+
+			expect( model.schema.checkAttribute( [ '$root', modelElement ], 'listItemFontFamily' ) ).to.be.true;
+		} );
+
 		it( 'listItemFontFamily attribute should have isFormatting set to true', () => {
 			expect( model.schema.getAttributeProperties( 'listItemFontFamily' ) ).to.include( {
 				isFormatting: true

--- a/packages/ckeditor5-list/tests/listformatting/listitemfontfamilyintegration.js
+++ b/packages/ckeditor5-list/tests/listformatting/listitemfontfamilyintegration.js
@@ -10,6 +10,7 @@ import HeadingEditing from '@ckeditor/ckeditor5-heading/src/headingediting.js';
 import TableEditing from '@ckeditor/ckeditor5-table/src/tableediting.js';
 import FontFamilyEditing from '@ckeditor/ckeditor5-font/src/fontfamily/fontfamilyediting.js';
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor.js';
+import ModelElement from '@ckeditor/ckeditor5-engine/src/model/element.js';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
 import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view.js';
@@ -76,6 +77,28 @@ describe( 'ListItemFontFamilyIntegration', () => {
 			expect( editor.model.schema.getAttributeProperties( 'listItemFontFamily' ) ).to.include( {
 				isFormatting: true
 			} );
+		} );
+
+		it( 'should set proper schema rules', () => {
+			const listItemParagraph = new ModelElement( 'paragraph', { listItemId: 'a' } );
+			const listItemBlockQuote = new ModelElement( 'blockQuote', { listItemId: 'a' } );
+			const listItemHeading = new ModelElement( 'heading1', { listItemId: 'a' } );
+			const listItemTable = new ModelElement( 'table', { listItemId: 'a' } );
+
+			const paragraph = new ModelElement( 'paragraph' );
+			const blockQuote = new ModelElement( 'blockQuote' );
+			const heading = new ModelElement( 'heading1' );
+			const table = new ModelElement( 'table' );
+
+			expect( model.schema.checkAttribute( [ '$root', listItemParagraph ], 'listItemFontFamily' ) ).to.be.true;
+			expect( model.schema.checkAttribute( [ '$root', listItemBlockQuote ], 'listItemFontFamily' ) ).to.be.true;
+			expect( model.schema.checkAttribute( [ '$root', listItemHeading ], 'listItemFontFamily' ) ).to.be.true;
+			expect( model.schema.checkAttribute( [ '$root', listItemTable ], 'listItemFontFamily' ) ).to.be.true;
+
+			expect( model.schema.checkAttribute( [ '$root', paragraph ], 'listItemFontFamily' ) ).to.be.false;
+			expect( model.schema.checkAttribute( [ '$root', blockQuote ], 'listItemFontFamily' ) ).to.be.false;
+			expect( model.schema.checkAttribute( [ '$root', heading ], 'listItemFontFamily' ) ).to.be.false;
+			expect( model.schema.checkAttribute( [ '$root', table ], 'listItemFontFamily' ) ).to.be.false;
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (list): Adds upcast converter for the `listItemFontColor` attribute. Closes #18559.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
