### PR TITLE
Restored the missing `--quiet` parameter for a pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
   },
   "lint-staged": {
     "**/*": [
-      "eslint"
+      "eslint --quiet"
     ],
     "**/*.css": [
       "stylelint --quiet --allow-empty-input"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Restored the missing `--quiet` parameter for a pre-commit hook

### Tickets to close

Part of https://github.com/cksource/ckeditor5-internal/issues/4027.
