### PR TITLE
Export HtmlToMarkdown

### DIFF
--- a/packages/ckeditor5-markdown-gfm/src/index.ts
+++ b/packages/ckeditor5-markdown-gfm/src/index.ts
@@ -11,5 +11,6 @@ export { default as Markdown } from './markdown.js';
 export { default as PasteFromMarkdownExperimental } from './pastefrommarkdownexperimental.js';
 export { default as GFMDataProcessor } from './gfmdataprocessor.js';
 export { MarkdownToHtml } from './markdown2html/markdown2html.js';
+export { HtmlToMarkdown } from './html2markdown/html2markdown.js';
 
 import './augmentation.js';


### PR DESCRIPTION
Type: markdown-gfm. Closes #18573.