### PR TITLE
Added upcast converters for legacy HTML table attributes.

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.ts
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.ts
@@ -332,7 +332,6 @@ export default class UpcastHelpers extends ConversionHelpers<UpcastDispatcher> {
 			key: string;
 			value: unknown |
 				( ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => unknown );
-			name?: string;
 		};
 		converterPriority?: PriorityString;
 	} ): this {
@@ -1072,7 +1071,7 @@ function prepareToAttributeConverter(
 			config.model.value( data.viewItem, conversionApi, data ) : config.model.value;
 
 		// Do not convert if attribute building function returned falsy value.
-		if ( modelValue === null ) {
+		if ( modelValue === null || modelValue === undefined ) {
 			return;
 		}
 

--- a/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
@@ -301,11 +301,32 @@ describe( 'UpcastHelpers', () => {
 
 		it( 'should not do anything if returned model attribute is null', () => {
 			upcastHelpers.elementToAttribute( { view: 'strong', model: 'bold' } );
+
+			// On a high priority, so we could check if it does not consume anything before the above converter.
 			upcastHelpers.elementToAttribute( {
 				view: 'strong',
 				model: {
 					key: 'bold',
 					value: () => null
+				},
+				converterPriority: 'high'
+			} );
+
+			expectResult(
+				new ViewAttributeElement( viewDocument, 'strong', null, new ViewText( viewDocument, 'foo' ) ),
+				'<$text bold="true">foo</$text>'
+			);
+		} );
+
+		it( 'should not do anything if returned model attribute is undefined', () => {
+			upcastHelpers.elementToAttribute( { view: 'strong', model: 'bold' } );
+
+			// On a high priority, so we could check if it does not consume anything before the above converter.
+			upcastHelpers.elementToAttribute( {
+				view: 'strong',
+				model: {
+					key: 'bold',
+					value: () => undefined
 				},
 				converterPriority: 'high'
 			} );
@@ -752,6 +773,19 @@ describe( 'UpcastHelpers', () => {
 				allowAttributes: [ 'styled' ]
 			} );
 
+			// Run this first to verify if it does not consume.
+			upcastHelpers.attributeToAttribute( {
+				view: {
+					key: 'class',
+					value: 'styled'
+				},
+				model: {
+					key: 'styled',
+					value: () => null
+				}
+			} );
+
+			// This runs later as the above should not consume anything.
 			upcastHelpers.attributeToAttribute( {
 				view: {
 					key: 'class',
@@ -763,6 +797,18 @@ describe( 'UpcastHelpers', () => {
 				}
 			} );
 
+			expectResult(
+				new ViewAttributeElement( viewDocument, 'img', { class: 'styled' } ),
+				'<imageBlock styled="true"></imageBlock>'
+			);
+		} );
+
+		it( 'should not do anything if returned model attribute is undefined', () => {
+			schema.extend( 'imageBlock', {
+				allowAttributes: [ 'styled' ]
+			} );
+
+			// Run this first to verify if it does not consume.
 			upcastHelpers.attributeToAttribute( {
 				view: {
 					key: 'class',
@@ -770,7 +816,19 @@ describe( 'UpcastHelpers', () => {
 				},
 				model: {
 					key: 'styled',
-					value: () => null
+					value: () => undefined
+				}
+			} );
+
+			// This runs later as the above should not consume anything.
+			upcastHelpers.attributeToAttribute( {
+				view: {
+					key: 'class',
+					value: 'styled'
+				},
+				model: {
+					key: 'styled',
+					value: true
 				}
 			} );
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/table/tablecellproperties/model.html
+++ b/packages/ckeditor5-paste-from-office/tests/_data/table/tablecellproperties/model.html
@@ -1,4 +1,4 @@
-<table tableBorderColor="{}" tableBorderStyle="none" tableBorderWidth="{}">
+<table tableBorderColor="{}" tableBorderStyle="none" tableBorderWidth="{}" tableWidth="597px">
 	<tableRow>
 		<tableCell tableCellBackgroundColor="#CCCCCC" tableCellBorderColor="windowtext" tableCellPadding="{"top":"0px","bottom":"0px","right":"7px","left":"7px"}" tableCellWidth="59.0%">
 			<paragraph><$text bold="true">Project Phase</$text></paragraph>

--- a/packages/ckeditor5-table/src/converters/tableproperties.ts
+++ b/packages/ckeditor5-table/src/converters/tableproperties.ts
@@ -15,6 +15,8 @@ import { first } from 'ckeditor5/src/utils.js';
  *
  * @param options.modelAttribute The attribute to set.
  * @param options.styleName The style name to convert.
+ * @param options.attributeName The HTML attribute name to convert.
+ * @param options.attributeType The HTML attribute type for value normalization.
  * @param options.viewElement The view element name that should be converted.
  * @param options.defaultValue The default value for the specified `modelAttribute`.
  * @param options.shouldUpcast The function which returns `true` if style should be upcasted from this element.
@@ -24,6 +26,8 @@ export function upcastStyleToAttribute(
 	options: {
 		modelAttribute: string;
 		styleName: string;
+		attributeName?: string;
+		attributeType?: 'length' | 'color';
 		viewElement: string | RegExp;
 		defaultValue: string;
 		reduceBoxSides?: boolean;
@@ -33,6 +37,8 @@ export function upcastStyleToAttribute(
 	const {
 		modelAttribute,
 		styleName,
+		attributeName,
+		attributeType,
 		viewElement,
 		defaultValue,
 		reduceBoxSides = false,
@@ -49,6 +55,9 @@ export function upcastStyleToAttribute(
 		model: {
 			key: modelAttribute,
 			value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
+				// Consume the style even if not applied to the element so it won't be processed by other converters.
+				conversionApi.consumable.consume( viewElement, { styles: styleName } );
+
 				if ( !shouldUpcast( viewElement ) ) {
 					return;
 				}
@@ -58,12 +67,48 @@ export function upcastStyleToAttribute(
 				const normalized = viewElement.getNormalizedStyle( styleName ) as Record<Side, string>;
 				const value = reduceBoxSides ? reduceBoxSidesValue( normalized ) : normalized;
 
-				if ( localDefaultValue !== value ) {
-					return value;
-				}
+				return localDefaultValue === value ? null : value;
 			}
 		}
 	} );
+
+	if ( attributeName ) {
+		conversion.for( 'upcast' ).attributeToAttribute( {
+			view: {
+				name: viewElement,
+				attributes: {
+					[ attributeName ]: /.+/
+				}
+			},
+			model: {
+				key: modelAttribute,
+				value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
+					// Consume the attribute even if not applied to the element so it won't be processed by other converters.
+					conversionApi.consumable.consume( viewElement, { attributes: attributeName } );
+
+					// Convert attributes of table and table cell elements, ignore figure.
+					// Do not convert attribute if related style is set as it has a higher priority.
+					// Do not convert attribute if the element is a table inside a figure with the related style set.
+					if (
+						viewElement.name == 'figure' ||
+						viewElement.hasStyle( styleName ) ||
+						viewElement.name == 'table' && viewElement.parent!.name == 'figure' && viewElement.parent!.hasStyle( styleName )
+					) {
+						return;
+					}
+
+					const localDefaultValue = getDefaultValueAdjusted( defaultValue, '', data );
+					let value = viewElement.getAttribute( attributeName );
+
+					if ( value && attributeType == 'length' && !value.endsWith( 'px' ) ) {
+						value += 'px';
+					}
+
+					return localDefaultValue === value ? null : value;
+				}
+			}
+		} );
+	}
 }
 
 export interface StyleValues {

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.ts
@@ -110,6 +110,8 @@ export default class TableCellPropertiesEditing extends Plugin {
 		enableProperty( schema, conversion, {
 			modelAttribute: 'tableCellHeight',
 			styleName: 'height',
+			attributeName: 'height',
+			attributeType: 'length',
 			defaultValue: defaultTableCellProperties.height
 		} );
 		editor.commands.add( 'tableCellHeight', new TableCellHeightCommand( editor, defaultTableCellProperties.height ) );
@@ -127,6 +129,8 @@ export default class TableCellPropertiesEditing extends Plugin {
 		enableProperty( schema, conversion, {
 			modelAttribute: 'tableCellBackgroundColor',
 			styleName: 'background-color',
+			attributeName: 'bgcolor',
+			attributeType: 'color',
 			defaultValue: defaultTableCellProperties.backgroundColor
 		} );
 		editor.commands.add(
@@ -210,6 +214,9 @@ function enableHorizontalAlignmentProperty( schema: Schema, conversion: Conversi
 			model: {
 				key: 'tableCellHorizontalAlignment',
 				value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
+					// Consume the style even if not applied to the element so it won't be processed by other converters.
+					conversionApi.consumable.consume( viewElement, { styles: 'text-align' } );
+
 					const localDefaultValue = getDefaultValueAdjusted( defaultValue, 'left', data );
 					const align = viewElement.getStyle( 'text-align' );
 
@@ -228,6 +235,9 @@ function enableHorizontalAlignmentProperty( schema: Schema, conversion: Conversi
 			model: {
 				key: 'tableCellHorizontalAlignment',
 				value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
+					// Consume the attribute even if not applied to the element so it won't be processed by other converters.
+					conversionApi.consumable.consume( viewElement, { attributes: 'align' } );
+
 					const localDefaultValue = getDefaultValueAdjusted( defaultValue, 'left', data );
 					const align = viewElement.getAttribute( 'align' );
 
@@ -273,6 +283,9 @@ function enableVerticalAlignmentProperty( schema: Schema, conversion: Conversion
 			model: {
 				key: 'tableCellVerticalAlignment',
 				value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
+					// Consume the style even if not applied to the element so it won't be processed by other converters.
+					conversionApi.consumable.consume( viewElement, { styles: 'vertical-align' } );
+
 					const localDefaultValue = getDefaultValueAdjusted( defaultValue, 'middle', data );
 					const align = viewElement.getStyle( 'vertical-align' );
 
@@ -291,6 +304,9 @@ function enableVerticalAlignmentProperty( schema: Schema, conversion: Conversion
 			model: {
 				key: 'tableCellVerticalAlignment',
 				value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
+					// Consume the attribute even if not applied to the element so it won't be processed by other converters.
+					conversionApi.consumable.consume( viewElement, { attributes: 'valign' } );
+
 					const localDefaultValue = getDefaultValueAdjusted( defaultValue, 'middle', data );
 					const valign = viewElement.getAttribute( 'valign' );
 

--- a/packages/ckeditor5-table/src/tablecellwidth/tablecellwidthediting.ts
+++ b/packages/ckeditor5-table/src/tablecellwidth/tablecellwidthediting.ts
@@ -55,6 +55,8 @@ export default class TableCellWidthEditing extends Plugin {
 		enableProperty( editor.model.schema, editor.conversion, {
 			modelAttribute: 'tableCellWidth',
 			styleName: 'width',
+			attributeName: 'width',
+			attributeType: 'length',
 			defaultValue: defaultTableCellProperties.width
 		} );
 

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
@@ -396,7 +396,6 @@ export default class TableColumnResizeEditing extends Plugin {
 				}
 			},
 			model: {
-				name: 'table',
 				key: 'tableWidth',
 				value: ( viewElement: ViewElement ) => {
 					const parent = viewElement.parent!;

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
@@ -111,6 +111,8 @@ export default class TablePropertiesEditing extends Plugin {
 		enableTableToFigureProperty( schema, conversion, {
 			modelAttribute: 'tableWidth',
 			styleName: 'width',
+			attributeName: 'width',
+			attributeType: 'length',
 			defaultValue: defaultTableProperties.width
 		} );
 		editor.commands.add( 'tableWidth', new TableWidthCommand( editor, defaultTableProperties.width ) );
@@ -118,6 +120,8 @@ export default class TablePropertiesEditing extends Plugin {
 		enableTableToFigureProperty( schema, conversion, {
 			modelAttribute: 'tableHeight',
 			styleName: 'height',
+			attributeName: 'height',
+			attributeType: 'length',
 			defaultValue: defaultTableProperties.height
 		} );
 		editor.commands.add( 'tableHeight', new TableHeightCommand( editor, defaultTableProperties.height ) );
@@ -126,6 +130,8 @@ export default class TablePropertiesEditing extends Plugin {
 		enableProperty( schema, conversion, {
 			modelAttribute: 'tableBackgroundColor',
 			styleName: 'background-color',
+			attributeName: 'bgcolor',
+			attributeType: 'color',
 			defaultValue: defaultTableProperties.backgroundColor
 		} );
 		editor.commands.add(
@@ -221,6 +227,9 @@ function enableAlignmentProperty( schema: Schema, conversion: Conversion, defaul
 			model: {
 				key: 'tableAlignment',
 				value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
+					// Consume the style even if not applied to the element so it won't be processed by other converters.
+					conversionApi.consumable.consume( viewElement, { styles: 'float' } );
+
 					const localDefaultValue = getDefaultValueAdjusted( defaultValue, '', data );
 					let align = viewElement.getStyle( 'float' );
 
@@ -245,6 +254,9 @@ function enableAlignmentProperty( schema: Schema, conversion: Conversion, defaul
 			model: {
 				key: 'tableAlignment',
 				value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
+					// Consume the styles even if not applied to the element so it won't be processed by other converters.
+					conversionApi.consumable.consume( viewElement, { styles: [ 'margin-left', 'margin-right' ] } );
+
 					const localDefaultValue = getDefaultValueAdjusted( defaultValue, '', data );
 					const align = 'center';
 
@@ -255,14 +267,17 @@ function enableAlignmentProperty( schema: Schema, conversion: Conversion, defaul
 		// Support for the `align` attribute as the backward compatibility while pasting from other sources.
 		.attributeToAttribute( {
 			view: {
+				name: 'table',
 				attributes: {
 					align: ALIGN_VALUES_REG_EXP
 				}
 			},
 			model: {
-				name: 'table',
 				key: 'tableAlignment',
 				value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
+					// Consume the attribute even if not applied to the element so it won't be processed by other converters.
+					conversionApi.consumable.consume( viewElement, { attributes: 'align' } );
+
 					const localDefaultValue = getDefaultValueAdjusted( defaultValue, '', data );
 					const align = viewElement.getAttribute( 'align' );
 
@@ -283,6 +298,8 @@ function enableProperty(
 	options: {
 		modelAttribute: string;
 		styleName: string;
+		attributeName?: string;
+		attributeType?: 'length' | 'color';
 		defaultValue: string;
 	}
 ) {
@@ -304,6 +321,8 @@ function enableTableToFigureProperty(
 	options: {
 		modelAttribute: string;
 		styleName: string;
+		attributeName?: string;
+		attributeType?: 'length' | 'color';
 		defaultValue: string;
 	}
 ) {

--- a/packages/ckeditor5-table/src/utils/common.ts
+++ b/packages/ckeditor5-table/src/utils/common.ts
@@ -17,7 +17,7 @@ import type {
 	DocumentSelection
 } from 'ckeditor5/src/engine.js';
 
-import { downcastAttributeToStyle, upcastStyleToAttribute } from './../converters/tableproperties.js';
+import { downcastAttributeToStyle, upcastStyleToAttribute } from '../converters/tableproperties.js';
 import type TableUtils from '../tableutils.js';
 
 /**
@@ -75,6 +75,8 @@ export function enableProperty(
 	options: {
 		modelAttribute: string;
 		styleName: string;
+		attributeName?: string;
+		attributeType?: 'length' | 'color';
 		defaultValue: string;
 		reduceBoxSides?: boolean;
 	}

--- a/packages/ckeditor5-table/tests/manual/tablepropertieslegacyhtml.html
+++ b/packages/ckeditor5-table/tests/manual/tablepropertieslegacyhtml.html
@@ -1,0 +1,21 @@
+<div style="display:flex">
+	<div>
+		<div id="editor">
+			<table border="0" cellpadding="5" cellspacing="0" width="200" bgcolor="#6495ed" align="left">
+				<tr>
+					<td width="70" height="60" align="right" valign="middle" bgcolor="#d2691e">a</td>
+					<td width="130">b</td>
+				</tr>
+				<tr>
+					<td colspan="2" height="60" valign="bottom" align="center">c</td>
+				</tr>
+			</table>
+		</div>
+
+	</div>
+	<div style="padding-left: 2em;" class="ck-content">
+		<h2>Source data</h2>
+
+		<div id="cloned-source"></div>
+	</div>
+</div>

--- a/packages/ckeditor5-table/tests/manual/tablepropertieslegacyhtml.js
+++ b/packages/ckeditor5-table/tests/manual/tablepropertieslegacyhtml.js
@@ -1,0 +1,37 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor.js';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset.js';
+import Alignment from '@ckeditor/ckeditor5-alignment/src/alignment.js';
+import IndentBlock from '@ckeditor/ckeditor5-indent/src/indentblock.js';
+import Indent from '@ckeditor/ckeditor5-indent/src/indent.js';
+
+import TableProperties from '../../src/tableproperties.js';
+import TableCellProperties from '../../src/tablecellproperties.js';
+
+const sourceElement = document.querySelector( '#editor' );
+const clonedSource = sourceElement.cloneNode( true );
+
+document.querySelector( '#cloned-source' ).append( ...clonedSource.childNodes );
+
+ClassicEditor
+	.create( sourceElement, {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
+		plugins: [ ArticlePluginSet, Alignment, Indent, IndentBlock, TableProperties, TableCellProperties ],
+		toolbar: [
+			'heading', '|', 'insertTable', '|', 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
+		],
+		table: {
+			contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells', 'tableProperties', 'tableCellProperties' ],
+			tableToolbar: [ 'bold', 'italic' ]
+		}
+	} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/packages/ckeditor5-table/tests/manual/tablepropertieslegacyhtml.md
+++ b/packages/ckeditor5-table/tests/manual/tablepropertieslegacyhtml.md
@@ -1,0 +1,1 @@
+### Handling of legacy HTML table attributes

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -99,6 +99,11 @@ describe( 'table cell properties', () => {
 
 			describe( 'upcast conversion', () => {
 				it( 'should not upcast border values which are same as default', () => {
+					// But it should consume it, so GHS won't store it.
+					editor.conversion.for( 'upcast' ).add( dispatcher => dispatcher.on( 'element:td', ( evt, data, conversionApi ) => {
+						expect( conversionApi.consumable.test( data.viewItem, { styles: 'border' } ) ).to.be.false;
+					}, { priority: 'lowest' } ) );
+
 					editor.setData( '<table><tr><td style="border:1px solid #f00">foo</td></tr></table>' );
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
@@ -621,6 +626,72 @@ describe( 'table cell properties', () => {
 
 					expect( tableCell.getAttribute( 'tableCellBackgroundColor' ) ).to.equal( 'rgb(253, 253, 119)' );
 				} );
+
+				it( 'should upcast bgcolor attribute', () => {
+					editor.setData( '<table><tr><td bgcolor="#f00">foo</td></tr></table>' );
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					expect( tableCell.getAttribute( 'tableCellBackgroundColor' ) ).to.equal( '#f00' );
+				} );
+
+				it( 'should upcast background-color style and ignore bgcolor attribute', () => {
+					editor.setData( '<table><tr><td bgcolor="blue" style="background-color:#f00">foo</td></tr></table>' );
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					expect( tableCell.getAttribute( 'tableCellBackgroundColor' ) ).to.equal( '#f00' );
+				} );
+
+				it( 'should consume background color style even if it is default', async () => {
+					const editor = await VirtualTestEditor.create( {
+						plugins: [ TableCellPropertiesEditing, Paragraph, TableEditing ],
+						table: {
+							tableCellProperties: {
+								defaultProperties: {
+									backgroundColor: '#f00'
+								}
+							}
+						}
+					} );
+					const model = editor.model;
+
+					// But it should consume it, so GHS won't store it.
+					editor.conversion.for( 'upcast' ).add( dispatcher => dispatcher.on( 'element:td', ( evt, data, conversionApi ) => {
+						expect( conversionApi.consumable.test( data.viewItem, { styles: 'background-color' } ) ).to.be.false;
+					}, { priority: 'lowest' } ) );
+
+					editor.setData( '<table><tr><td style="background-color:#f00">foo</td></tr></table>' );
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					expect( tableCell.hasAttribute( 'tableCellBackgroundColor' ) ).to.be.false;
+
+					await editor.destroy();
+				} );
+
+				it( 'should consume bgcolor attribute even if it is default', async () => {
+					const editor = await VirtualTestEditor.create( {
+						plugins: [ TableCellPropertiesEditing, Paragraph, TableEditing ],
+						table: {
+							tableCellProperties: {
+								defaultProperties: {
+									backgroundColor: '#f00'
+								}
+							}
+						}
+					} );
+					const model = editor.model;
+
+					// But it should consume it, so GHS won't store it.
+					editor.conversion.for( 'upcast' ).add( dispatcher => dispatcher.on( 'element:td', ( evt, data, conversionApi ) => {
+						expect( conversionApi.consumable.test( data.viewItem, { attributes: 'bgcolor' } ) ).to.be.false;
+					}, { priority: 'lowest' } ) );
+
+					editor.setData( '<table><tr><td bgcolor="#f00">foo</td></tr></table>' );
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					expect( tableCell.hasAttribute( 'tableCellBackgroundColor' ) ).to.be.false;
+
+					await editor.destroy();
+				} );
 			} );
 
 			describe( 'downcast conversion', () => {
@@ -693,6 +764,11 @@ describe( 'table cell properties', () => {
 
 			describe( 'upcast conversion', () => {
 				it( 'should upcast text-align:left style (due to the default value of the property)', () => {
+					// But it should consume it, so GHS won't store it.
+					editor.conversion.for( 'upcast' ).add( dispatcher => dispatcher.on( 'element:td', ( evt, data, conversionApi ) => {
+						expect( conversionApi.consumable.test( data.viewItem, { styles: 'text-align' } ) ).to.be.false;
+					}, { priority: 'lowest' } ) );
+
 					editor.setData( '<table><tr><td style="text-align:left">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
@@ -748,6 +824,58 @@ describe( 'table cell properties', () => {
 
 						expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'justify' );
 					} );
+				} );
+
+				it( 'should consume horizontal alignment style even if it is default', async () => {
+					const editor = await VirtualTestEditor.create( {
+						plugins: [ TableCellPropertiesEditing, Paragraph, TableEditing ],
+						table: {
+							tableCellProperties: {
+								defaultProperties: {
+									horizontalAlignment: 'center'
+								}
+							}
+						}
+					} );
+					const model = editor.model;
+
+					// But it should consume it, so GHS won't store it.
+					editor.conversion.for( 'upcast' ).add( dispatcher => dispatcher.on( 'element:td', ( evt, data, conversionApi ) => {
+						expect( conversionApi.consumable.test( data.viewItem, { styles: 'text-align' } ) ).to.be.false;
+					}, { priority: 'lowest' } ) );
+
+					editor.setData( '<table><tr><td style="text-align:center">foo</td></tr></table>' );
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					expect( tableCell.hasAttribute( 'tableCellHorizontalAlignment' ) ).to.be.false;
+
+					await editor.destroy();
+				} );
+
+				it( 'should consume align attribute even if it is default', async () => {
+					const editor = await VirtualTestEditor.create( {
+						plugins: [ TableCellPropertiesEditing, Paragraph, TableEditing ],
+						table: {
+							tableCellProperties: {
+								defaultProperties: {
+									horizontalAlignment: 'center'
+								}
+							}
+						}
+					} );
+					const model = editor.model;
+
+					// But it should consume it, so GHS won't store it.
+					editor.conversion.for( 'upcast' ).add( dispatcher => dispatcher.on( 'element:td', ( evt, data, conversionApi ) => {
+						expect( conversionApi.consumable.test( data.viewItem, { attributes: 'align' } ) ).to.be.false;
+					}, { priority: 'lowest' } ) );
+
+					editor.setData( '<table><tr><td align="center">foo</td></tr></table>' );
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					expect( tableCell.hasAttribute( 'tableCellHorizontalAlignment' ) ).to.be.false;
+
+					await editor.destroy();
 				} );
 
 				describe( 'for RTL content language', () => {
@@ -992,6 +1120,11 @@ describe( 'table cell properties', () => {
 				} );
 
 				it( 'should not upcast "middle" vertical-align (due to the default value of the property)', () => {
+					// But it should consume it, so GHS won't store it.
+					editor.conversion.for( 'upcast' ).add( dispatcher => dispatcher.on( 'element:td', ( evt, data, conversionApi ) => {
+						expect( conversionApi.consumable.test( data.viewItem, { styles: 'vertical-align' } ) ).to.be.false;
+					}, { priority: 'lowest' } ) );
+
 					editor.setData( '<table><tr><td style="vertical-align:middle">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
@@ -1017,6 +1150,58 @@ describe( 'table cell properties', () => {
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
 					expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.be.undefined;
+				} );
+
+				it( 'should consume vertical alignment style even if it is default', async () => {
+					const editor = await VirtualTestEditor.create( {
+						plugins: [ TableCellPropertiesEditing, Paragraph, TableEditing ],
+						table: {
+							tableCellProperties: {
+								defaultProperties: {
+									verticalAlignment: 'bottom'
+								}
+							}
+						}
+					} );
+					const model = editor.model;
+
+					// But it should consume it, so GHS won't store it.
+					editor.conversion.for( 'upcast' ).add( dispatcher => dispatcher.on( 'element:td', ( evt, data, conversionApi ) => {
+						expect( conversionApi.consumable.test( data.viewItem, { styles: 'vertical-align' } ) ).to.be.false;
+					}, { priority: 'lowest' } ) );
+
+					editor.setData( '<table><tr><td style="vertical-align:bottom">foo</td></tr></table>' );
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					expect( tableCell.hasAttribute( 'tableCellHorizontalAlignment' ) ).to.be.false;
+
+					await editor.destroy();
+				} );
+
+				it( 'should consume valign attribute even if it is default', async () => {
+					const editor = await VirtualTestEditor.create( {
+						plugins: [ TableCellPropertiesEditing, Paragraph, TableEditing ],
+						table: {
+							tableCellProperties: {
+								defaultProperties: {
+									verticalAlignment: 'bottom'
+								}
+							}
+						}
+					} );
+					const model = editor.model;
+
+					// But it should consume it, so GHS won't store it.
+					editor.conversion.for( 'upcast' ).add( dispatcher => dispatcher.on( 'element:td', ( evt, data, conversionApi ) => {
+						expect( conversionApi.consumable.test( data.viewItem, { attributes: 'valign' } ) ).to.be.false;
+					}, { priority: 'lowest' } ) );
+
+					editor.setData( '<table><tr><td valign="bottom">foo</td></tr></table>' );
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					expect( tableCell.hasAttribute( 'tableCellHorizontalAlignment' ) ).to.be.false;
+
+					await editor.destroy();
 				} );
 			} );
 
@@ -1167,11 +1352,77 @@ describe( 'table cell properties', () => {
 			} );
 
 			describe( 'upcast conversion', () => {
-				it( 'should upcast height attribute on table cell', () => {
+				it( 'should upcast height style on table cell', () => {
 					editor.setData( '<table><tr><td style="height:20px">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
 					expect( tableCell.getAttribute( 'tableCellHeight' ) ).to.equal( '20px' );
+				} );
+
+				it( 'should upcast height attribute on table cell', () => {
+					editor.setData( '<table><tr><td height="20">foo</td></tr></table>' );
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					expect( tableCell.getAttribute( 'tableCellHeight' ) ).to.equal( '20px' );
+				} );
+
+				it( 'should upcast height style on table cell and ignore height attribute', () => {
+					editor.setData( '<table><tr><td height="100" style="height:20px">foo</td></tr></table>' );
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					expect( tableCell.getAttribute( 'tableCellHeight' ) ).to.equal( '20px' );
+				} );
+
+				it( 'should consume height style even if it is default', async () => {
+					const editor = await VirtualTestEditor.create( {
+						plugins: [ TableCellPropertiesEditing, Paragraph, TableEditing ],
+						table: {
+							tableCellProperties: {
+								defaultProperties: {
+									height: '123px'
+								}
+							}
+						}
+					} );
+					const model = editor.model;
+
+					// But it should consume it, so GHS won't store it.
+					editor.conversion.for( 'upcast' ).add( dispatcher => dispatcher.on( 'element:td', ( evt, data, conversionApi ) => {
+						expect( conversionApi.consumable.test( data.viewItem, { styles: 'height' } ) ).to.be.false;
+					}, { priority: 'lowest' } ) );
+
+					editor.setData( '<table><tr><td style="height:123px">foo</td></tr></table>' );
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					expect( tableCell.hasAttribute( 'tableCellHeight' ) ).to.be.false;
+
+					await editor.destroy();
+				} );
+
+				it( 'should consume height attribute even if it is default', async () => {
+					const editor = await VirtualTestEditor.create( {
+						plugins: [ TableCellPropertiesEditing, Paragraph, TableEditing ],
+						table: {
+							tableCellProperties: {
+								defaultProperties: {
+									height: '123px'
+								}
+							}
+						}
+					} );
+					const model = editor.model;
+
+					// But it should consume it, so GHS won't store it.
+					editor.conversion.for( 'upcast' ).add( dispatcher => dispatcher.on( 'element:td', ( evt, data, conversionApi ) => {
+						expect( conversionApi.consumable.test( data.viewItem, { attributes: 'height' } ) ).to.be.false;
+					}, { priority: 'lowest' } ) );
+
+					editor.setData( '<table><tr><td height="123">foo</td></tr></table>' );
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					expect( tableCell.hasAttribute( 'tableCellHeight' ) ).to.be.false;
+
+					await editor.destroy();
 				} );
 			} );
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -1173,7 +1173,7 @@ describe( 'table cell properties', () => {
 					editor.setData( '<table><tr><td style="vertical-align:bottom">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.hasAttribute( 'tableCellHorizontalAlignment' ) ).to.be.false;
+					expect( tableCell.hasAttribute( 'tableCellVerticalAlignment' ) ).to.be.false;
 
 					await editor.destroy();
 				} );
@@ -1199,7 +1199,7 @@ describe( 'table cell properties', () => {
 					editor.setData( '<table><tr><td valign="bottom">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.hasAttribute( 'tableCellHorizontalAlignment' ) ).to.be.false;
+					expect( tableCell.hasAttribute( 'tableCellVerticalAlignment' ) ).to.be.false;
 
 					await editor.destroy();
 				} );

--- a/packages/ckeditor5-table/tests/tablecellwidth/tablecellwidthediting.js
+++ b/packages/ckeditor5-table/tests/tablecellwidth/tablecellwidthediting.js
@@ -109,7 +109,7 @@ describe( 'TableCellWidthEditing', () => {
 				editor.setData( '<table><tr><td style="width:123px">foo</td></tr></table>' );
 				const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-				expect( tableCell.hasAttribute( 'tableCellHeight' ) ).to.be.false;
+				expect( tableCell.hasAttribute( 'tableCellWidth' ) ).to.be.false;
 
 				await editor.destroy();
 			} );
@@ -135,7 +135,7 @@ describe( 'TableCellWidthEditing', () => {
 				editor.setData( '<table><tr><td width="123">foo</td></tr></table>' );
 				const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-				expect( tableCell.hasAttribute( 'tableCellHeight' ) ).to.be.false;
+				expect( tableCell.hasAttribute( 'tableCellWidth' ) ).to.be.false;
 
 				await editor.destroy();
 			} );

--- a/packages/ckeditor5-table/tests/tablecellwidth/tablecellwidthediting.js
+++ b/packages/ckeditor5-table/tests/tablecellwidth/tablecellwidthediting.js
@@ -11,6 +11,8 @@ import TableCellWidthCommand from '../../src/tablecellwidth/commands/tablecellwi
 
 import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
 import { assertTableCellStyle } from '../_utils/utils.js';
+import TableCellPropertiesEditing from '../../src/tablecellproperties/tablecellpropertiesediting.js';
+import TableEditing from '../../src/tableediting.js';
 
 describe( 'TableCellWidthEditing', () => {
 	let editor, model;
@@ -49,8 +51,15 @@ describe( 'TableCellWidthEditing', () => {
 		} );
 
 		describe( 'upcast conversion', () => {
-			it( 'should upcast width attribute on table cell', () => {
+			it( 'should upcast width style on table cell', () => {
 				editor.setData( '<table><tr><td style="width:20px">foo</td></tr></table>' );
+				const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+				expect( tableCell.getAttribute( 'tableCellWidth' ) ).to.equal( '20px' );
+			} );
+
+			it( 'should upcast width style on table cell even if it has width attribute set', () => {
+				editor.setData( '<table><tr><td width="50" style="width:20px">foo</td></tr></table>' );
 				const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
 				expect( tableCell.getAttribute( 'tableCellWidth' ) ).to.equal( '20px' );
@@ -77,6 +86,58 @@ describe( 'TableCellWidthEditing', () => {
 
 				expect( tableCell00.getAttribute( 'tableCellWidth' ) ).to.equal( '94px' );
 				expect( tableCell01.getAttribute( 'tableCellWidth' ) ).to.equal( '291px' );
+			} );
+
+			it( 'should consume width style even if it is default', async () => {
+				const editor = await VirtualTestEditor.create( {
+					plugins: [ TableCellPropertiesEditing, Paragraph, TableEditing ],
+					table: {
+						tableCellProperties: {
+							defaultProperties: {
+								width: '123px'
+							}
+						}
+					}
+				} );
+				const model = editor.model;
+
+				// But it should consume it, so GHS won't store it.
+				editor.conversion.for( 'upcast' ).add( dispatcher => dispatcher.on( 'element:td', ( evt, data, conversionApi ) => {
+					expect( conversionApi.consumable.test( data.viewItem, { styles: 'width' } ) ).to.be.false;
+				}, { priority: 'lowest' } ) );
+
+				editor.setData( '<table><tr><td style="width:123px">foo</td></tr></table>' );
+				const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+				expect( tableCell.hasAttribute( 'tableCellHeight' ) ).to.be.false;
+
+				await editor.destroy();
+			} );
+
+			it( 'should consume width attribute even if it is default', async () => {
+				const editor = await VirtualTestEditor.create( {
+					plugins: [ TableCellPropertiesEditing, Paragraph, TableEditing ],
+					table: {
+						tableCellProperties: {
+							defaultProperties: {
+								width: '123px'
+							}
+						}
+					}
+				} );
+				const model = editor.model;
+
+				// But it should consume it, so GHS won't store it.
+				editor.conversion.for( 'upcast' ).add( dispatcher => dispatcher.on( 'element:td', ( evt, data, conversionApi ) => {
+					expect( conversionApi.consumable.test( data.viewItem, { attributes: 'width' } ) ).to.be.false;
+				}, { priority: 'lowest' } ) );
+
+				editor.setData( '<table><tr><td width="123">foo</td></tr></table>' );
+				const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+				expect( tableCell.hasAttribute( 'tableCellHeight' ) ).to.be.false;
+
+				await editor.destroy();
 			} );
 		} );
 

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -1267,7 +1267,7 @@ describe( 'table properties', () => {
 					expect( table.getAttribute( 'tableHeight' ) ).to.equal( '543px' );
 				} );
 
-				it( 'should consume width style even if it is default', async () => {
+				it( 'should consume height style even if it is default', async () => {
 					const editor = await VirtualTestEditor.create( {
 						plugins: [ TablePropertiesEditing, Paragraph, TableEditing ],
 						table: {
@@ -1293,7 +1293,7 @@ describe( 'table properties', () => {
 					await editor.destroy();
 				} );
 
-				it( 'should consume width attribute even if it is default', async () => {
+				it( 'should consume height attribute even if it is default', async () => {
 					const editor = await VirtualTestEditor.create( {
 						plugins: [ TablePropertiesEditing, Paragraph, TableEditing ],
 						table: {
@@ -1471,7 +1471,7 @@ describe( 'table properties', () => {
 					await editor.destroy();
 				} );
 
-				it( 'should consume width attribute even if it is default', async () => {
+				it( 'should consume align attribute even if it is default', async () => {
 					const editor = await VirtualTestEditor.create( {
 						plugins: [ TablePropertiesEditing, Paragraph, TableEditing ],
 						table: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (table): The legacy HTML table attributes are now normalized to editor features (`width`, `height`, `bgcolor`). Closes #18575.

Other (engine): The `atributeToAtribute` and `elementToAtribute` upcast helpers should not consume anything if conversion callback returns `undefined` value. See #18575.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
