### PR TITLE
Increase specificity of `figure.table` fixes due to print mode issues.

### DIFF
--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -81,8 +81,6 @@
 		 * 	* The table is inside a figure element.
 		 * 	* The table has `display: table` style set.
 		 * 	* The block element is placed directly after the table.
-		 *
-		 * The print mode is not affected, the issue happens only in the column split mode or in the print preview mode.
 		 */
 		&:not(.layout-table):has(> table) {
 			display: block;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (table): Improve calculation of pagination page-breaks on documents with long tables. Closes https://github.com/ckeditor/ckeditor5/issues/18600

---

### Additional information

Fully reproducible using instructions from https://github.com/cksource/ckeditor5-commercial/issues/5494

Issue https://github.com/cksource/ckeditor5-commercial/issues/7850
Commercial PR https://github.com/cksource/ckeditor5-commercial/pull/7857
See more https://github.com/cksource/ckeditor5-commercial/pull/7857
