### PR TITLE
Fixed matching font family when there are excessive spaces in the font-family property

### DIFF
--- a/packages/ckeditor5-font/src/fontfamily/fontfamilyui.ts
+++ b/packages/ckeditor5-font/src/fontfamily/fontfamilyui.ts
@@ -21,7 +21,7 @@ import {
 	type ListDropdownButtonDefinition
 } from 'ckeditor5/src/ui.js';
 
-import { normalizeOptions } from './utils.js';
+import { normalizeFontFamilies, normalizeOptions } from './utils.js';
 import { FONT_FAMILY } from '../utils.js';
 
 import type { FontFamilyOption } from '../fontconfig.js';
@@ -186,7 +186,10 @@ function _prepareListOptions( options: Array<FontFamilyOption>, command: FontFam
 				return false;
 			}
 
-			return value.split( ',' )[ 0 ].replace( /'/g, '' ).toLowerCase() === option.model.toLowerCase();
+			const valueNormalized = normalizeFontFamilies( value )[ 0 ].toLowerCase();
+			const optionNormalized = normalizeFontFamilies( option.model )[ 0 ].toLowerCase();
+
+			return valueNormalized === optionNormalized;
 		} );
 
 		// Try to set a dropdown list item style.

--- a/packages/ckeditor5-font/src/fontfamily/utils.ts
+++ b/packages/ckeditor5-font/src/fontfamily/utils.ts
@@ -24,6 +24,17 @@ export function normalizeOptions( configuredOptions: Array<string | FontFamilyOp
 }
 
 /**
+ * Normalizes the CSS `font-family` property value to an array of unquoted and trimmed font faces.
+ *
+ * @internal
+ */
+export function normalizeFontFamilies( fontDefinition: string ): Array<string> {
+	return fontDefinition
+		.replace( /["']/g, '' ).split( ',' )
+		.map( name => name.trim() );
+}
+
+/**
  * Returns an option definition either created from string shortcut.
  * If object is passed then this method will return it without alternating it. Returns undefined for item than cannot be parsed.
  *
@@ -59,7 +70,7 @@ function getOptionDefinition( option: string | FontFamilyOption ): FontFamilyOpt
  */
 function generateFontPreset( fontDefinition: string ): FontFamilyOption {
 	// Remove quotes from font names. They will be normalized later.
-	const fontNames = fontDefinition.replace( /"|'/g, '' ).split( ',' );
+	const fontNames = normalizeFontFamilies( fontDefinition );
 
 	// The first matched font name will be used as dropdown list item title and as model value.
 	const firstFontName = fontNames[ 0 ];

--- a/packages/ckeditor5-font/tests/fontfamily/fontfamilyui.js
+++ b/packages/ckeditor5-font/tests/fontfamily/fontfamilyui.js
@@ -163,6 +163,28 @@ describe( 'FontFamilyUI', () => {
 					.to.deep.equal( [ false, false, true, false, false, false, false, false, false ] );
 			} );
 
+			it( 'should activate the current option in the dropdown for full font family definitions even if includes spaces', () => {
+				// Make sure that list view is not created before first dropdown open.
+				expect( dropdown.listView ).to.be.undefined;
+
+				// Trigger list view creation (lazy init).
+				dropdown.isOpen = true;
+
+				const listView = dropdown.listView;
+
+				command.value = undefined;
+
+				// The first item is 'default' font family.
+				expect( listView.items.map( item => item.children.first.isOn ) )
+					.to.deep.equal( [ true, false, false, false, false, false, false, false, false ] );
+
+				command.value = 'Courier New , Courier, monospace';
+
+				// The third item is 'Courier New' font family.
+				expect( listView.items.map( item => item.children.first.isOn ) )
+					.to.deep.equal( [ false, false, true, false, false, false, false, false, false ] );
+			} );
+
 			it( 'should apply the complete font-family value (list of font-families)', () => {
 				dropdown.render();
 				document.body.appendChild( dropdown.element );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (font): The font dropdown correctly reflects the applied font, even if the font-style CSS property includes excessive spaces. Closes #18558.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
