### PR TITLE
CssTransitionDisablerMixin should allow late initialization.

### DIFF
--- a/packages/ckeditor5-ui/src/bindings/csstransitiondisablermixin.ts
+++ b/packages/ckeditor5-ui/src/bindings/csstransitiondisablermixin.ts
@@ -58,13 +58,15 @@ export default function CssTransitionDisablerMixin<Base extends Constructor<View
 		}
 
 		protected initializeCssTransitionDisablerMixin(): void {
-			this.extendTemplate( {
-				attributes: {
-					class: [
-						this.bindTemplate.if( '_isCssTransitionsDisabled', 'ck-transitions-disabled' )
-					]
-				}
-			} );
+			if ( this.template ) {
+				this.extendTemplate( {
+					attributes: {
+						class: [
+							this.bindTemplate.if( '_isCssTransitionsDisabled', 'ck-transitions-disabled' )
+						]
+					}
+				} );
+			}
 		}
 	}
 

--- a/packages/ckeditor5-ui/tests/bindings/csstransitiondisablermixin.js
+++ b/packages/ckeditor5-ui/tests/bindings/csstransitiondisablermixin.js
@@ -61,4 +61,35 @@ describe( 'cssTransitionDisablerMixin()', () => {
 			expect( view.element.classList.contains( 'ck-transitions-disabled' ) ).to.be.false;
 		} );
 	} );
+
+	it( 'should allow late initialization', () => {
+		const LateInitView = CssTransitionDisablerMixin( View );
+
+		view.destroy();
+
+		expect( () => new LateInitView() ).to.not.throw();
+
+		view = new LateInitView();
+
+		view.setTemplate( {
+			tag: 'div'
+		} );
+
+		view.initializeCssTransitionDisablerMixin();
+
+		view.render();
+
+		expect( view._isCssTransitionsDisabled ).to.be.false;
+		expect( view.element.classList.contains( 'ck-transitions-disabled' ) ).to.be.false;
+
+		view.disableCssTransitions();
+
+		expect( view._isCssTransitionsDisabled ).to.be.true;
+		expect( view.element.classList.contains( 'ck-transitions-disabled' ) ).to.be.true;
+
+		view.enableCssTransitions();
+
+		expect( view._isCssTransitionsDisabled ).to.be.false;
+		expect( view.element.classList.contains( 'ck-transitions-disabled' ) ).to.be.false;
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (ui): `CssTransitionDisablerMixin` should allow late initialization. Closes #18626.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
