### PR TITLE
Other (markdown-gfm): Upgrade `marked`.

### DIFF
--- a/packages/ckeditor5-markdown-gfm/package.json
+++ b/packages/ckeditor5-markdown-gfm/package.json
@@ -21,10 +21,11 @@
     "@ckeditor/ckeditor5-clipboard": "45.2.0",
     "@ckeditor/ckeditor5-core": "45.2.0",
     "@ckeditor/ckeditor5-engine": "45.2.0",
-    "@types/marked": "4.3.2",
     "@types/turndown": "5.0.5",
     "ckeditor5": "45.2.0",
-    "marked": "4.0.12",
+    "marked": "15.0.12",
+    "marked-mangle": "1.1.10",
+    "marked-xhtml": "1.0.12",
     "turndown": "7.2.0",
     "turndown-plugin-gfm": "1.0.2"
   },

--- a/packages/ckeditor5-markdown-gfm/src/markdown2html/markdown2html.ts
+++ b/packages/ckeditor5-markdown-gfm/src/markdown2html/markdown2html.ts
@@ -7,7 +7,9 @@
  * @module markdown-gfm/markdown2html/markdown2html
  */
 
-import { marked } from 'marked';
+import { marked, type MarkedOptions } from 'marked';
+import { mangle } from 'marked-mangle';
+import { markedXhtml } from 'marked-xhtml';
 
 /**
  * This is a helper class used by the {@link module:markdown-gfm/markdown Markdown feature} to convert Markdown to HTML.
@@ -16,14 +18,15 @@ export class MarkdownToHtml {
 	private _parser: typeof marked;
 
 	private _options = {
+		async: false,
 		gfm: true,
-		breaks: true,
-		tables: true,
-		xhtml: true,
-		headerIds: false
-	};
+		breaks: true
+	} satisfies MarkedOptions;
 
 	constructor() {
+		marked.use( mangle() );
+		marked.use( markedXhtml() );
+
 		// Overrides.
 		marked.use( {
 			tokenizer: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (markdown-gfm): Upgrade `marked`.

---

Some tests are failing because of differences between how Markdown is parsed to HTML and vice versa in `marked` and `turndown`.