### PR TITLE
Add config property to disable cloud token auto-refresh

### DIFF
--- a/packages/ckeditor5-cloud-services/src/cloudservices.ts
+++ b/packages/ckeditor5-cloud-services/src/cloudservices.ts
@@ -51,8 +51,6 @@ export class CloudServices extends ContextPlugin implements CloudServicesConfig 
 
 	/**
 	 * Specifies whether the token should be automatically refreshed when it expires.
-	 *
-	 * When set to `false`, the token will not be automatically refreshed, and you will need to handle token refresh manually.
 	 */
 	public readonly autoRefresh: boolean = true;
 

--- a/packages/ckeditor5-cloud-services/src/cloudservices.ts
+++ b/packages/ckeditor5-cloud-services/src/cloudservices.ts
@@ -54,7 +54,7 @@ export class CloudServices extends ContextPlugin implements CloudServicesConfig 
 	 *
 	 * When set to `false`, the token will not be automatically refreshed, and you will need to handle token refresh manually.
 	 */
-	public autoRefresh: boolean = true;
+	public readonly autoRefresh: boolean = true;
 
 	/**
 	 * Other plugins use this token for the authorization process. It handles token requesting and refreshing.

--- a/packages/ckeditor5-cloud-services/src/cloudservices.ts
+++ b/packages/ckeditor5-cloud-services/src/cloudservices.ts
@@ -50,6 +50,13 @@ export class CloudServices extends ContextPlugin implements CloudServicesConfig 
 	public readonly bundleVersion?: string;
 
 	/**
+	 * Specifies whether the token should be automatically refreshed when it expires.
+	 *
+	 * When set to `false`, the token will not be automatically refreshed, and you will need to handle token refresh manually.
+	 */
+	public autoRefresh: boolean = true;
+
+	/**
 	 * Other plugins use this token for the authorization process. It handles token requesting and refreshing.
 	 * Its value is `null` when {@link module:cloud-services/cloudservicesconfig~CloudServicesConfig#tokenUrl} is not provided.
 	 *
@@ -107,7 +114,7 @@ export class CloudServices extends ContextPlugin implements CloudServicesConfig 
 		// behavior we need to catch the exception and destroy the uninitialized token instance.
 		// See: https://github.com/ckeditor/ckeditor5/issues/17531
 		const cloudServicesCore: CloudServicesCore = this.context.plugins.get( 'CloudServicesCore' );
-		const uninitializedToken = cloudServicesCore.createToken( this.tokenUrl );
+		const uninitializedToken = cloudServicesCore.createToken( this.tokenUrl, { autoRefresh: this.autoRefresh } );
 
 		try {
 			this.token = await uninitializedToken.init();
@@ -131,7 +138,7 @@ export class CloudServices extends ContextPlugin implements CloudServicesConfig 
 		}
 
 		const cloudServicesCore: CloudServicesCore = this.context.plugins.get( 'CloudServicesCore' );
-		const token = await cloudServicesCore.createToken( tokenUrl ).init();
+		const token = await cloudServicesCore.createToken( tokenUrl, { autoRefresh: this.autoRefresh } ).init();
 
 		this._tokens.set( tokenUrl, token );
 

--- a/packages/ckeditor5-cloud-services/src/cloudservicesconfig.ts
+++ b/packages/ckeditor5-cloud-services/src/cloudservicesconfig.ts
@@ -131,4 +131,25 @@ export interface CloudServicesConfig {
 	 * the new bundle (build + configuration) from the old ones.
 	 */
 	bundleVersion?: string;
+
+	/**
+	 * Specifies whether the token should be automatically refreshed when it expires.
+	 *
+	 * When set to `false`, the token will not be automatically refreshed, and you will need to handle token refresh manually.
+	 *
+	 * ```ts
+	 * ClassicEditor
+	 * 	.create( document.querySelector( '#editor' ), {
+	 * 		cloudServices: {
+	 * 			tokenUrl: 'https://example.com/cs-token-endpoint',
+	 * 			autoRefresh: false // Disable automatic token refresh
+	 * 		}
+	 * 	} )
+	 * 	.then( ... )
+	 * 	.catch( ... );
+	 * ```
+	 *
+	 * @default true
+	 */
+	autoRefresh?: boolean;
 }

--- a/packages/ckeditor5-cloud-services/src/token/token.ts
+++ b/packages/ckeditor5-cloud-services/src/token/token.ts
@@ -57,9 +57,8 @@ export class Token extends /* #__PURE__ */ ObservableMixin() {
 	 *
 	 * @param tokenUrlOrRefreshToken Endpoint address to download the token or a callback that provides the token. If the
 	 * value is a function it has to match the {@link module:cloud-services/token/token~Token#refreshToken} interface.
-	 * @param options Token options.
 	 */
-	constructor( tokenUrlOrRefreshToken: TokenUrl, options: TokenOptions ) {
+	constructor( tokenUrlOrRefreshToken: TokenUrl, options: TokenOptions = {} ) {
 		super();
 
 		if ( !tokenUrlOrRefreshToken ) {
@@ -86,7 +85,7 @@ export class Token extends /* #__PURE__ */ ObservableMixin() {
 			this._refresh = () => defaultRefreshToken( tokenUrlOrRefreshToken );
 		}
 
-		this._options = { ...options };
+		this._options = { ...DEFAULT_OPTIONS, ...options };
 	}
 
 	/**
@@ -242,9 +241,8 @@ export class Token extends /* #__PURE__ */ ObservableMixin() {
 	 *
 	 * @param tokenUrlOrRefreshToken Endpoint address to download the token or a callback that provides the token. If the
 	 * value is a function it has to match the {@link module:cloud-services/token/token~Token#refreshToken} interface.
-	 * @param options Token options. If not provided, default options will be used.
 	 */
-	public static create( tokenUrlOrRefreshToken: TokenUrl, options: TokenOptions = DEFAULT_OPTIONS ): Promise<InitializedToken> {
+	public static create( tokenUrlOrRefreshToken: TokenUrl, options: TokenOptions = {} ): Promise<InitializedToken> {
 		const token = new Token( tokenUrlOrRefreshToken, options );
 
 		return token.init();
@@ -267,9 +265,11 @@ export interface TokenOptions {
 	initValue?: string;
 
 	/**
-	 * Specifies whether the token should be automatically refreshed when it expires.
+	 * Specifies whether to start the refresh automatically.
+	 *
+	 * @default true
 	 */
-	autoRefresh: boolean;
+	autoRefresh?: boolean;
 }
 
 /**

--- a/packages/ckeditor5-cloud-services/src/token/token.ts
+++ b/packages/ckeditor5-cloud-services/src/token/token.ts
@@ -228,6 +228,16 @@ export class Token extends /* #__PURE__ */ ObservableMixin() {
 				return DEFAULT_TOKEN_REFRESH_TIMEOUT_TIME;
 			}
 
+			// Check if the token expire time exceeds 32-bit integer range
+			// It could happen if the token expire time is provided in milliseconds instead of seconds.
+			if ( tokenExpireTime > 2147483647 ) {
+				console.warn(
+					'Token expiration time exceeds 32-bit integer range. This might cause unpredictable token refresh timing. ' +
+					'Token expiration time should always be provided in seconds.',
+					{ tokenExpireTime }
+				);
+			}
+
 			const tokenRefreshTimeoutTime = Math.floor( ( ( tokenExpireTime * 1000 ) - Date.now() ) / 2 );
 
 			return tokenRefreshTimeoutTime;

--- a/packages/ckeditor5-cloud-services/src/token/token.ts
+++ b/packages/ckeditor5-cloud-services/src/token/token.ts
@@ -57,8 +57,9 @@ export class Token extends /* #__PURE__ */ ObservableMixin() {
 	 *
 	 * @param tokenUrlOrRefreshToken Endpoint address to download the token or a callback that provides the token. If the
 	 * value is a function it has to match the {@link module:cloud-services/token/token~Token#refreshToken} interface.
+	 * @param options Token options.
 	 */
-	constructor( tokenUrlOrRefreshToken: TokenUrl, options: TokenOptions = {} ) {
+	constructor( tokenUrlOrRefreshToken: TokenUrl, options: TokenOptions ) {
 		super();
 
 		if ( !tokenUrlOrRefreshToken ) {
@@ -85,7 +86,7 @@ export class Token extends /* #__PURE__ */ ObservableMixin() {
 			this._refresh = () => defaultRefreshToken( tokenUrlOrRefreshToken );
 		}
 
-		this._options = { ...DEFAULT_OPTIONS, ...options };
+		this._options = { ...options };
 	}
 
 	/**
@@ -241,8 +242,9 @@ export class Token extends /* #__PURE__ */ ObservableMixin() {
 	 *
 	 * @param tokenUrlOrRefreshToken Endpoint address to download the token or a callback that provides the token. If the
 	 * value is a function it has to match the {@link module:cloud-services/token/token~Token#refreshToken} interface.
+	 * @param options Token options. If not provided, default options will be used.
 	 */
-	public static create( tokenUrlOrRefreshToken: TokenUrl, options: TokenOptions = {} ): Promise<InitializedToken> {
+	public static create( tokenUrlOrRefreshToken: TokenUrl, options: TokenOptions = DEFAULT_OPTIONS ): Promise<InitializedToken> {
 		const token = new Token( tokenUrlOrRefreshToken, options );
 
 		return token.init();
@@ -265,11 +267,9 @@ export interface TokenOptions {
 	initValue?: string;
 
 	/**
-	 * Specifies whether to start the refresh automatically.
-	 *
-	 * @default true
+	 * Specifies whether the token should be automatically refreshed when it expires.
 	 */
-	autoRefresh?: boolean;
+	autoRefresh: boolean;
 }
 
 /**

--- a/packages/ckeditor5-cloud-services/tests/_utils/tokenmock.js
+++ b/packages/ckeditor5-cloud-services/tests/_utils/tokenmock.js
@@ -7,14 +7,6 @@ import { Token } from '../../src/token/token.js';
 
 export class TokenMock extends Token {
 	/**
-	 * @param {String|Function} tokenUrlOrRefreshToken
-	 * @param {Object} [options]
-	 */
-	constructor( tokenUrlOrRefreshToken, options = { autoRefresh: true } ) {
-		super( tokenUrlOrRefreshToken, options );
-	}
-
-	/**
 	 * Overrides request and set the next token
 	 *
 	 * @returns {Promise.<Token>}

--- a/packages/ckeditor5-cloud-services/tests/_utils/tokenmock.js
+++ b/packages/ckeditor5-cloud-services/tests/_utils/tokenmock.js
@@ -7,6 +7,14 @@ import { Token } from '../../src/token/token.js';
 
 export class TokenMock extends Token {
 	/**
+	 * @param {String|Function} tokenUrlOrRefreshToken
+	 * @param {Object} [options]
+	 */
+	constructor( tokenUrlOrRefreshToken, options = { autoRefresh: true } ) {
+		super( tokenUrlOrRefreshToken, options );
+	}
+
+	/**
 	 * Overrides request and set the next token
 	 *
 	 * @returns {Promise.<Token>}

--- a/packages/ckeditor5-cloud-services/tests/token/token.js
+++ b/packages/ckeditor5-cloud-services/tests/token/token.js
@@ -211,6 +211,23 @@ describe( 'Token', () => {
 
 			clock.restore();
 		} );
+
+		it( 'should warn when token expiration time exceeds 32-bit integer range', () => {
+			const consoleStub = sinon.stub( console, 'warn' );
+			const tokenValue = `header.${ btoa( JSON.stringify( { exp: 2147483648 } ) ) }.signature`;
+			const token = new Token( 'http://token-endpoint', { initValue: tokenValue } );
+
+			token.init();
+
+			sinon.assert.calledWithMatch( consoleStub,
+				'Token expiration time exceeds 32-bit integer range. This might cause unpredictable token refresh timing. ' +
+				'Token expiration time should always be provided in seconds.',
+				{ tokenExpireTime: 2147483648 }
+			);
+
+			consoleStub.restore();
+			token.destroy();
+		} );
 	} );
 
 	describe( 'destroy', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (cloud-services): Added a configuration property: `config.cloudServices.autoRefresh` that allows disabling the automatic token refresh mechanism. When set to `false`, the token must be refreshed manually, enabling custom token handling.

---

### Additional information

Additionally, regarding the last issue we debugged, I added `console.warn` when someone sets the token expiration time in milliseconds instead of seconds."