### PR TITLE
Added re-exports and aligned naming in the `ckeditor5-alignment`, `ckeditor5-autoformat` and `ckeditor5-autosave` packages

### DIFF
--- a/packages/ckeditor5-alignment/src/alignmentcommand.ts
+++ b/packages/ckeditor5-alignment/src/alignmentcommand.ts
@@ -12,7 +12,7 @@ import { first } from 'ckeditor5/src/utils.js';
 import type { Element, Writer } from 'ckeditor5/src/engine.js';
 
 import { isDefault } from './utils.js';
-import type { SupportedOption } from './alignmentconfig.js';
+import type { AlignmentSupportedOption } from './alignmentconfig.js';
 
 const ALIGNMENT = 'alignment';
 
@@ -26,7 +26,7 @@ export class AlignmentCommand extends Command {
 	 * @observable
 	 * @readonly
 	 */
-	declare public value: SupportedOption;
+	declare public value: AlignmentSupportedOption;
 
 	/**
 	 * @inheritDoc
@@ -40,7 +40,7 @@ export class AlignmentCommand extends Command {
 		this.isEnabled = Boolean( firstBlock ) && this._canBeAligned( firstBlock );
 
 		if ( this.isEnabled && firstBlock.hasAttribute( 'alignment' ) ) {
-			this.value = firstBlock.getAttribute( 'alignment' ) as SupportedOption;
+			this.value = firstBlock.getAttribute( 'alignment' ) as AlignmentSupportedOption;
 		} else {
 			this.value = locale.contentLanguageDirection === 'rtl' ? 'right' : 'left';
 		}
@@ -55,7 +55,7 @@ export class AlignmentCommand extends Command {
 	 * @param options.value The value to apply.
 	 * @fires execute
 	 */
-	public override execute( options: { value?: SupportedOption } = {} ): void {
+	public override execute( options: { value?: AlignmentSupportedOption } = {} ): void {
 		const editor = this.editor;
 		const locale = editor.locale;
 		const model = editor.model;

--- a/packages/ckeditor5-alignment/src/alignmentconfig.ts
+++ b/packages/ckeditor5-alignment/src/alignmentconfig.ts
@@ -24,7 +24,7 @@
  * See {@link module:core/editor/editorconfig~EditorConfig all editor configuration options}.
  */
 export interface AlignmentConfig {
-	options?: Array<SupportedOption | AlignmentFormat>;
+	options?: Array<AlignmentSupportedOption | AlignmentFormat>;
 }
 
 /**
@@ -69,8 +69,8 @@ export interface AlignmentConfig {
  * See the demo of {@glink features/text-alignment#configuring-alignment-options custom alignment options}.
  */
 export type AlignmentFormat = {
-	name: SupportedOption;
+	name: AlignmentSupportedOption;
 	className?: string;
 };
 
-export type SupportedOption = 'left' | 'right' | 'center' | 'justify';
+export type AlignmentSupportedOption = 'left' | 'right' | 'center' | 'justify';

--- a/packages/ckeditor5-alignment/src/alignmentediting.ts
+++ b/packages/ckeditor5-alignment/src/alignmentediting.ts
@@ -12,7 +12,7 @@ import type { AttributeDescriptor } from 'ckeditor5/src/engine.js';
 
 import { AlignmentCommand } from './alignmentcommand.js';
 import { isDefault, isSupported, normalizeAlignmentOptions, supportedOptions } from './utils.js';
-import type { AlignmentFormat, SupportedOption } from './alignmentconfig.js';
+import type { AlignmentFormat, AlignmentSupportedOption } from './alignmentconfig.js';
 
 /**
  * The alignment editing feature. It introduces the {@link module:alignment/alignmentcommand~AlignmentCommand command} and adds
@@ -95,7 +95,7 @@ export class AlignmentEditing extends Plugin {
  * Prepare downcast conversion definition for inline alignment styling.
  */
 function buildDowncastInlineDefinition( options: Array<AlignmentFormat> ) {
-	const view: Record<string, { key: 'style'; value: { 'text-align': SupportedOption } }> = {};
+	const view: Record<string, { key: 'style'; value: { 'text-align': AlignmentSupportedOption } }> = {};
 
 	for ( const { name } of options ) {
 		view[ name ] = {

--- a/packages/ckeditor5-alignment/src/alignmentui.ts
+++ b/packages/ckeditor5-alignment/src/alignmentui.ts
@@ -22,7 +22,7 @@ import { IconAlignCenter, IconAlignJustify, IconAlignLeft, IconAlignRight } from
 import type { Locale } from 'ckeditor5/src/utils.js';
 
 import { isSupported, normalizeAlignmentOptions } from './utils.js';
-import type { AlignmentFormat, SupportedOption } from './alignmentconfig.js';
+import type { AlignmentFormat, AlignmentSupportedOption } from './alignmentconfig.js';
 import { type AlignmentCommand } from './alignmentcommand.js';
 
 const iconsMap = /* #__PURE__ */ ( () => new Map( [
@@ -52,7 +52,7 @@ export class AlignmentUI extends Plugin {
 	 *
 	 * @readonly
 	 */
-	public get localizedOptionTitles(): Record<SupportedOption, string> {
+	public get localizedOptionTitles(): Record<AlignmentSupportedOption, string> {
 		const t = this.editor.t;
 
 		return {
@@ -98,7 +98,7 @@ export class AlignmentUI extends Plugin {
 	 *
 	 * @param option The name of the alignment option for which the button is added.
 	 */
-	private _addButton( option: SupportedOption ): void {
+	private _addButton( option: AlignmentSupportedOption ): void {
 		const editor = this.editor;
 
 		editor.ui.componentFactory.add( `alignment:${ option }`, locale => this._createButton( locale, option ) );
@@ -113,7 +113,7 @@ export class AlignmentUI extends Plugin {
 	 */
 	private _createButton(
 		locale: Locale,
-		option: SupportedOption,
+		option: AlignmentSupportedOption,
 		buttonAttrs: Partial<Button> = {}
 	): ButtonView {
 		const editor = this.editor;

--- a/packages/ckeditor5-alignment/src/index.ts
+++ b/packages/ckeditor5-alignment/src/index.ts
@@ -11,7 +11,7 @@ export { Alignment } from './alignment.js';
 export { AlignmentEditing } from './alignmentediting.js';
 export { AlignmentUI } from './alignmentui.js';
 export { AlignmentCommand } from './alignmentcommand.js';
-export type { AlignmentConfig } from './alignmentconfig.js';
+export type { AlignmentConfig, AlignmentFormat, AlignmentSupportedOption } from './alignmentconfig.js';
 
 export {
 	supportedOptions as _ALIGNMENT_SUPPORTED_OPTIONS,

--- a/packages/ckeditor5-alignment/src/utils.ts
+++ b/packages/ckeditor5-alignment/src/utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { CKEditorError, logWarning, type Locale } from 'ckeditor5/src/utils.js';
-import type { AlignmentFormat, SupportedOption } from './alignmentconfig.js';
+import type { AlignmentFormat, AlignmentSupportedOption } from './alignmentconfig.js';
 
 /**
  * @module alignment/utils
@@ -20,7 +20,7 @@ import type { AlignmentFormat, SupportedOption } from './alignmentconfig.js';
  *
  * @internal
  */
-export const supportedOptions: ReadonlyArray<SupportedOption> = [ 'left', 'right', 'center', 'justify' ];
+export const supportedOptions: ReadonlyArray<AlignmentSupportedOption> = [ 'left', 'right', 'center', 'justify' ];
 
 /**
  * Checks whether the passed option is supported by {@link module:alignment/alignmentediting~AlignmentEditing}.

--- a/packages/ckeditor5-autoformat/src/index.ts
+++ b/packages/ckeditor5-autoformat/src/index.ts
@@ -9,6 +9,6 @@
 
 export { Autoformat } from './autoformat.js';
 export { blockAutoformatEditing } from './blockautoformatediting.js';
-export { inlineAutoformatEditing } from './inlineautoformatediting.js';
+export { inlineAutoformatEditing, type AutoformatTestCallback } from './inlineautoformatediting.js';
 
 import './augmentation.js';

--- a/packages/ckeditor5-autoformat/src/inlineautoformatediting.ts
+++ b/packages/ckeditor5-autoformat/src/inlineautoformatediting.ts
@@ -30,7 +30,7 @@ import type { Delete, LastTextLineData } from 'ckeditor5/src/typing.js';
 
 import { type Autoformat } from './autoformat.js';
 
-export type TestCallback = ( text: string ) => {
+export type AutoformatTestCallback = ( text: string ) => {
 	remove: Array<Array<number>>;
 	format: Array<Array<number>>;
 };
@@ -95,11 +95,11 @@ export type TestCallback = ( text: string ) => {
 export function inlineAutoformatEditing(
 	editor: Editor,
 	plugin: Autoformat,
-	testRegexpOrCallback: RegExp | TestCallback,
+	testRegexpOrCallback: RegExp | AutoformatTestCallback,
 	formatCallback: ( writer: Writer, rangesToFormat: Array<Range> ) => boolean | undefined
 ): void {
 	let regExp: RegExp;
-	let testCallback: TestCallback | undefined;
+	let testCallback: AutoformatTestCallback | undefined;
 
 	if ( testRegexpOrCallback instanceof RegExp ) {
 		regExp = testRegexpOrCallback;

--- a/packages/ckeditor5-autosave/src/index.ts
+++ b/packages/ckeditor5-autosave/src/index.ts
@@ -7,6 +7,6 @@
  * @module autosave
  */
 
-export { Autosave, type AutosaveConfig } from './autosave.js';
+export { Autosave, type AutosaveConfig, type AutosaveAdapter } from './autosave.js';
 
 import './augmentation.js';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (alignment): Added re-exports and aligned naming in the `ckeditor5-alignment` package.

Internal (autoformat): Added re-exports and aligned naming in the `ckeditor5-autoformat` package.

Internal (autosave): Added re-exports in the `ckeditor5-autosave` package.

---

### Additional information

Part of ckeditor/ckeditor5#18590.
