### PR TITLE
Added re-exports and aligned naming in the `ckeditor5-core` package

### DIFF
--- a/packages/ckeditor5-core/src/accessibility.ts
+++ b/packages/ckeditor5-core/src/accessibility.ts
@@ -44,7 +44,7 @@ export class Accessibility {
 	 * * unless specified otherwise, new keystrokes are added into the `'contentEditing'` category and the `'common'`
 	 * keystroke group within that category while using the {@link #addKeystrokeInfos} method.
 	 */
-	public readonly keystrokeInfos: KeystrokeInfos = new Map();
+	public readonly keystrokeInfos: KeystrokeInfoDefinitions = new Map();
 
 	/**
 	 * The editor instance.
@@ -455,12 +455,12 @@ export interface AddKeystrokeInfosData {
 	keystrokes: Array<KeystrokeInfoDefinition>;
 }
 
-export type KeystrokeInfos = Map<string, KeystrokeInfoCategory>;
+export type KeystrokeInfoDefinitions = Map<string, KeystrokeInfoCategoryDefinition>;
 
 /**
  * A category of keystrokes in {@link module:core/accessibility~Accessibility#keystrokeInfos}.
  */
-export type KeystrokeInfoCategory = {
+export type KeystrokeInfoCategoryDefinition = {
 
 	/**
 	 * The unique id of the category.
@@ -480,13 +480,13 @@ export type KeystrokeInfoCategory = {
 	/**
 	 * Groups of keystrokes within the category.
 	 */
-	groups: Map<string, KeystrokeInfoGroup>;
+	groups: Map<string, KeystrokeInfoGroupDefinition>;
 };
 
 /**
  * A group of keystrokes in {@link module:core/accessibility~Accessibility#keystrokeInfos}.
  */
-export type KeystrokeInfoGroup = {
+export type KeystrokeInfoGroupDefinition = {
 
 	/**
 	 * The unique id of the group.

--- a/packages/ckeditor5-core/src/index.ts
+++ b/packages/ckeditor5-core/src/index.ts
@@ -7,42 +7,57 @@
  * @module core
  */
 
-export { Plugin, type PluginDependencies, type PluginConstructor } from './plugin.js';
+export {
+	Plugin,
+	type PluginDependencies,
+	type PluginConstructor,
+	type PluginInterface,
+	type PluginClassConstructor,
+	type PluginFunctionConstructor,
+	type PluginStaticMembers,
+	type LoadedPlugins
+} from './plugin.js';
+
 export { Command, type CommandExecuteEvent } from './command.js';
 export { MultiCommand } from './multicommand.js';
-export type { CommandsMap } from './commandcollection.js';
-export type { PluginsMap, PluginCollection } from './plugincollection.js';
+export { CommandCollection, type CommandsMap } from './commandcollection.js';
+export type { PluginsMap, PluginCollection, PluginEntry } from './plugincollection.js';
 
 export { Context, type ContextConfig } from './context.js';
-export { ContextPlugin, type ContextPluginDependencies } from './contextplugin.js';
-export { type EditingKeystrokeCallback } from './editingkeystrokehandler.js';
+export { ContextPlugin, type ContextInterface, type ContextPluginDependencies } from './contextplugin.js';
+export { EditingKeystrokeHandler, type EditingKeystrokeCallback } from './editingkeystrokehandler.js';
 
 export type { PartialBy, NonEmptyArray, HexColor } from './typings.js';
 
-export { Editor, type EditorReadyEvent, type EditorDestroyEvent } from './editor/editor.js';
+export { Editor, type EditorCollectUsageDataEvent, type EditorReadyEvent, type EditorDestroyEvent } from './editor/editor.js';
 export type {
 	EditorConfig,
 	LanguageConfig,
 	ToolbarConfig,
 	ToolbarConfigItem,
 	UiConfig,
-	ViewportOffsetConfig
+	ViewportOffsetConfig,
+	PoweredByConfig
 } from './editor/editorconfig.js';
 
 export { attachToForm } from './editor/utils/attachtoform.js';
 export { ElementApiMixin, type ElementApi } from './editor/utils/elementapimixin.js';
 export { secureSourceElement } from './editor/utils/securesourceelement.js';
 
-export { PendingActions, type PendingAction } from './pendingactions.js';
+export { PendingActions, type PendingAction, type PendingActionsAddEvent, type PendingActionsRemoveEvent } from './pendingactions.js';
 
-export type {
-	KeystrokeInfos as KeystrokeInfoDefinitions,
-	KeystrokeInfoGroup as KeystrokeInfoGroupDefinition,
-	KeystrokeInfoCategory as KeystrokeInfoCategoryDefinition,
-	KeystrokeInfoDefinition as KeystrokeInfoDefinition
+export {
+	Accessibility,
+	DEFAULT_GROUP_ID as _DEFAULT_ACCESSIBILITY_GROUP_ID,
+	type AddKeystrokeInfoCategoryData,
+	type AddKeystrokeInfoGroupData,
+	type AddKeystrokeInfosData,
+	type KeystrokeInfoDefinition,
+	type KeystrokeInfoDefinitions,
+	type KeystrokeInfoGroupDefinition,
+	type KeystrokeInfoCategoryDefinition
 } from './accessibility.js';
 
-export { DEFAULT_GROUP_ID as _DEFAULT_ACCESSIBILITY_GROUP_ID } from './accessibility.js';
 export {
 	getEditorUsageData as _getEditorUsageData,
 	type EditorUsageData as _EditorUsageData


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (core): Added re-exports and aligned naming in the `ckeditor5-core` package.

---

### Additional information

Part of ckeditor/ckeditor5#18590.