### PR TITLE
Added re-exports and aligned naming in the `ckeditor5-find-and-replace` package

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/findandreplace.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplace.ts
@@ -8,12 +8,12 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core.js';
-import { FindAndReplaceUI, type SearchResetedEvent } from './findandreplaceui.js';
+import { FindAndReplaceUI, type FindResetedEvent } from './findandreplaceui.js';
 import { FindAndReplaceEditing } from './findandreplaceediting.js';
 import type { Marker } from 'ckeditor5/src/engine.js';
 import type { FindNextEvent, FindPreviousEvent, ReplaceAllEvent, ReplaceEvent } from './ui/findandreplaceformview.js';
 
-export type ResultType = {
+export type FindResultType = {
 	id?: string;
 	label?: string;
 	start?: number;
@@ -104,7 +104,7 @@ export class FindAndReplace extends Plugin {
 
 		// Reset the state when the user invalidated last search results, for instance,
 		// by starting typing another search query or changing options.
-		ui.on<SearchResetedEvent>( 'searchReseted', () => {
+		ui.on<FindResetedEvent>( 'searchReseted', () => {
 			state.clear( this.editor.model );
 			findAndReplaceEditing.stop();
 		} );

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceediting.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceediting.ts
@@ -23,7 +23,7 @@ import { FindNextCommand } from './findnextcommand.js';
 import { FindPreviousCommand } from './findpreviouscommand.js';
 import { FindAndReplaceState, type FindCallback } from './findandreplacestate.js';
 import { FindAndReplaceUtils } from './findandreplaceutils.js';
-import type { ResultType } from './findandreplace.js';
+import type { FindResultType } from './findandreplace.js';
 
 import { debounce } from 'es-toolkit/compat';
 
@@ -137,7 +137,7 @@ export class FindAndReplaceEditing extends Plugin {
 	/**
 	 * Initiate a search.
 	 */
-	public find( callbackOrText: string | FindCallback, findAttributes?: FindAttributes ): Collection<ResultType> {
+	public find( callbackOrText: string | FindCallback, findAttributes?: FindAttributes ): Collection<FindResultType> {
 		this._isSearchActive = true;
 		this.editor.execute( 'find', callbackOrText, findAttributes );
 
@@ -264,7 +264,7 @@ export class FindAndReplaceEditing extends Plugin {
 		} );
 
 		// Run search callback again on updated nodes.
-		const changedSearchResults: Array<ResultType> = [];
+		const changedSearchResults: Array<FindResultType> = [];
 		const findAndReplaceUtils: FindAndReplaceUtils = this.editor.plugins.get( 'FindAndReplaceUtils' );
 
 		changedNodes.forEach( nodeToCheck => {

--- a/packages/ckeditor5-find-and-replace/src/findandreplacestate.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplacestate.ts
@@ -9,7 +9,7 @@
 
 import type { Model, Item } from 'ckeditor5/src/engine.js';
 import { ObservableMixin, Collection, type CollectionChangeEvent, type ObservableChangeEvent } from 'ckeditor5/src/utils.js';
-import type { ResultType } from './findandreplace.js';
+import type { FindResultType } from './findandreplace.js';
 
 /**
  * The object storing find and replace plugin state for a given editor instance.
@@ -20,7 +20,7 @@ export class FindAndReplaceState extends /* #__PURE__ */ ObservableMixin() {
 	 *
 	 * @observable
 	 */
-	declare public results: Collection<ResultType>;
+	declare public results: Collection<FindResultType>;
 
 	/**
 	 * Currently highlighted search result in {@link #results matched results}.
@@ -28,7 +28,7 @@ export class FindAndReplaceState extends /* #__PURE__ */ ObservableMixin() {
 	 * @readonly
 	 * @observable
 	 */
-	declare public highlightedResult: ResultType | null;
+	declare public highlightedResult: FindResultType | null;
 
 	/**
 	 * Currently highlighted search result offset in {@link #results matched results}.
@@ -94,7 +94,7 @@ export class FindAndReplaceState extends /* #__PURE__ */ ObservableMixin() {
 		this.set( 'matchCase', false );
 		this.set( 'matchWholeWords', false );
 
-		this.results.on<CollectionChangeEvent<ResultType>>( 'change', ( eventInfo, { removed, index } ) => {
+		this.results.on<CollectionChangeEvent<FindResultType>>( 'change', ( eventInfo, { removed, index } ) => {
 			if ( Array.from( removed ).length ) {
 				let highlightedResultRemoved = false;
 
@@ -117,7 +117,7 @@ export class FindAndReplaceState extends /* #__PURE__ */ ObservableMixin() {
 			}
 		} );
 
-		this.on<ObservableChangeEvent<ResultType | null>>( 'change:highlightedResult', ( ) => {
+		this.on<ObservableChangeEvent<FindResultType | null>>( 'change:highlightedResult', ( ) => {
 			this.refreshHighlightOffset( model );
 		} );
 	}
@@ -167,7 +167,7 @@ export class FindAndReplaceState extends /* #__PURE__ */ ObservableMixin() {
  *
  * @internal
  */
-export function sortSearchResultsByMarkerPositions( model: Model, results: Array<ResultType> ): Array<ResultType> {
+export function sortSearchResultsByMarkerPositions( model: Model, results: Array<FindResultType> ): Array<FindResultType> {
 	const sortMapping = { before: -1, same: 0, after: 1, different: 1 };
 
 	// `compareWith` doesn't play well with multi-root documents, so we need to sort results by root name first
@@ -193,7 +193,7 @@ export type FindCallback = ( { item, text }: { item: Item; text: string } ) => F
  * while searching for next item and the search will start from the beginning of the document.
  */
 export type FindCallbackResultObject = {
-	results: Array<ResultType>;
+	results: Array<FindResultType>;
 	searchText: string;
 };
 
@@ -202,4 +202,4 @@ export type FindCallbackResultObject = {
  *
  * @deprecated Use `FindCallbackResultObject` instead.
  */
-export type FindCallbackResult = Array<ResultType>;
+export type FindCallbackResult = Array<FindResultType>;

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceui.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceui.ts
@@ -356,7 +356,7 @@ export class FindAndReplaceUI extends Plugin {
  *
  * @eventName ~FindAndReplaceUI#searchReseted
  */
-export type SearchResetedEvent = {
+export type FindResetedEvent = {
 	name: 'searchReseted';
 	args: [];
 };

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceutils.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceutils.ts
@@ -11,7 +11,7 @@ import type { Element, Item, Marker, Model, Range } from 'ckeditor5/src/engine.j
 import { Plugin } from 'ckeditor5/src/core.js';
 import { Collection, uid } from 'ckeditor5/src/utils.js';
 import { escapeRegExp } from 'es-toolkit/compat';
-import type { ResultType } from './findandreplace.js';
+import type { FindResultType } from './findandreplace.js';
 
 /**
  * A set of helpers related to find and replace.
@@ -54,9 +54,9 @@ export class FindAndReplaceUtils extends Plugin {
 	public updateFindResultFromRange(
 		range: Range,
 		model: Model,
-		findCallback: ( { item, text }: { item: Item; text: string } ) => Array<ResultType> | { results: Array<ResultType> },
-		startResults: Collection<ResultType> | null
-	): Collection<ResultType> {
+		findCallback: ( { item, text }: { item: Item; text: string } ) => Array<FindResultType> | { results: Array<FindResultType> },
+		startResults: Collection<FindResultType> | null
+	): Collection<FindResultType> {
 		const results = startResults || new Collection();
 
 		const checkIfResultAlreadyOnList = ( marker: Marker ) => results.find(
@@ -150,7 +150,7 @@ export class FindAndReplaceUtils extends Plugin {
 	public findByTextCallback(
 		searchTerm: string,
 		options: { matchCase?: boolean; wholeWords?: boolean }
-	): ( { item, text }: { item: Item; text: string } ) => Array<ResultType> {
+	): ( { item, text }: { item: Item; text: string } ) => Array<FindResultType> {
 		let flags = 'gu';
 
 		if ( !options.matchCase ) {
@@ -195,7 +195,7 @@ function findInsertIndex( resultsList: Collection<any>, markerToInsert: Marker )
 /**
  *  Maps RegExp match result to find result.
  */
-function regexpMatchToFindResult( matchResult: RegExpMatchArray ): ResultType {
+function regexpMatchToFindResult( matchResult: RegExpMatchArray ): FindResultType {
 	const lastGroupIndex = matchResult.length - 1;
 
 	let startOffset = matchResult.index!;

--- a/packages/ckeditor5-find-and-replace/src/findcommand.ts
+++ b/packages/ckeditor5-find-and-replace/src/findcommand.ts
@@ -11,7 +11,7 @@ import { Command, type Editor } from 'ckeditor5/src/core.js';
 import type { Collection } from 'ckeditor5/src/utils.js';
 
 import type { FindAndReplaceState, FindCallback } from './findandreplacestate.js';
-import type { ResultType } from './findandreplace.js';
+import type { FindResultType } from './findandreplace.js';
 import { type FindAndReplaceUtils } from './findandreplaceutils.js';
 
 /**
@@ -54,7 +54,7 @@ export class FindCommand extends Command {
 	public override execute(
 		callbackOrText: string | FindCallback,
 		{ matchCase, wholeWords }: FindAttributes = {}
-	): { results: Collection<ResultType>; findCallback: FindCallback } {
+	): { results: Collection<FindResultType>; findCallback: FindCallback } {
 		const { editor } = this;
 		const { model } = editor;
 		const findAndReplaceUtils: FindAndReplaceUtils = editor.plugins.get( 'FindAndReplaceUtils' );
@@ -87,7 +87,7 @@ export class FindCommand extends Command {
 
 		// Initial search is done on all nodes in all roots inside the content.
 		const results = model.document.getRootNames()
-			.reduce( ( ( currentResults: Collection<ResultType> | null, rootName ) => findAndReplaceUtils.updateFindResultFromRange(
+			.reduce( ( ( currentResults: Collection<FindResultType> | null, rootName ) => findAndReplaceUtils.updateFindResultFromRange(
 				model.createRangeIn( model.document.getRoot( rootName )! ),
 				model,
 				findCallback!,

--- a/packages/ckeditor5-find-and-replace/src/index.ts
+++ b/packages/ckeditor5-find-and-replace/src/index.ts
@@ -7,17 +7,35 @@
  * @module find-and-replace
  */
 
-export { FindAndReplace } from './findandreplace.js';
+export { FindAndReplace, type FindResultType } from './findandreplace.js';
 export { FindAndReplaceEditing } from './findandreplaceediting.js';
-export { FindAndReplaceUI } from './findandreplaceui.js';
+export { FindAndReplaceUI, type FindResetedEvent } from './findandreplaceui.js';
 export { FindAndReplaceUtils } from './findandreplaceutils.js';
-export { FindCommand } from './findcommand.js';
+export { FindCommand, type FindAttributes } from './findcommand.js';
 export { FindNextCommand } from './findnextcommand.js';
 export { FindPreviousCommand } from './findpreviouscommand.js';
 export { ReplaceCommand } from './replacecommand.js';
 export { ReplaceAllCommand } from './replaceallcommand.js';
+export { FindReplaceCommandBase } from './replacecommandbase.js';
 export type { FindAndReplaceConfig } from './findandreplaceconfig.js';
 
-export { sortSearchResultsByMarkerPositions as _sortFindResultsByMarkerPositions } from './findandreplacestate.js';
+export {
+	FindAndReplaceFormView,
+	type FindNextEvent,
+	type FindNextEventData,
+	type FindPreviousEvent,
+	type FindEventBaseData,
+	type ReplaceEvent,
+	type ReplaceEventData,
+	type ReplaceAllEvent
+} from './ui/findandreplaceformview.js';
+
+export {
+	FindAndReplaceState,
+	sortSearchResultsByMarkerPositions as _sortFindResultsByMarkerPositions,
+	type FindCallback,
+	type FindCallbackResultObject,
+	type FindCallbackResult
+} from './findandreplacestate.js';
 
 import './augmentation.js';

--- a/packages/ckeditor5-find-and-replace/src/replaceallcommand.ts
+++ b/packages/ckeditor5-find-and-replace/src/replaceallcommand.ts
@@ -8,14 +8,14 @@
  */
 
 import { Collection } from 'ckeditor5/src/utils.js';
-import type { ResultType } from './findandreplace.js';
+import type { FindResultType } from './findandreplace.js';
 import { type FindAndReplaceUtils } from './findandreplaceutils.js';
-import { ReplaceCommandBase } from './replacecommandbase.js';
+import { FindReplaceCommandBase } from './replacecommandbase.js';
 
 /**
  * The replace all command. It is used by the {@link module:find-and-replace/findandreplace~FindAndReplace find and replace feature}.
  */
-export class ReplaceAllCommand extends ReplaceCommandBase {
+export class ReplaceAllCommand extends FindReplaceCommandBase {
 	/**
 	 * Replaces all the occurrences of `textToReplace` with a given `newText` string.
 	 *
@@ -35,19 +35,19 @@ export class ReplaceAllCommand extends ReplaceCommandBase {
 	 *
 	 * @fires module:core/command~Command#event:execute
 	 */
-	public override execute( newText: string, textToReplace: string | Collection<ResultType> ): void {
+	public override execute( newText: string, textToReplace: string | Collection<FindResultType> ): void {
 		const { editor } = this;
 		const { model } = editor;
 		const findAndReplaceUtils: FindAndReplaceUtils = editor.plugins.get( 'FindAndReplaceUtils' );
 
 		const results = textToReplace instanceof Collection ?
 			textToReplace : model.document.getRootNames()
-				.reduce( ( ( currentResults: Collection<ResultType> | null, rootName ) => findAndReplaceUtils.updateFindResultFromRange(
+				.reduce( ( ( currentResults: Collection<FindResultType> | null, rootName ) => findAndReplaceUtils.updateFindResultFromRange(
 					model.createRangeIn( model.document.getRoot( rootName )! ),
 					model,
 					findAndReplaceUtils.findByTextCallback( textToReplace, this._state ),
 					currentResults
-				) ), null as Collection<ResultType> | null )!;
+				) ), null as Collection<FindResultType> | null )!;
 
 		if ( results.length ) {
 			// Wrapped in single change will batch it into one transaction.

--- a/packages/ckeditor5-find-and-replace/src/replacecommand.ts
+++ b/packages/ckeditor5-find-and-replace/src/replacecommand.ts
@@ -7,14 +7,14 @@
  * @module find-and-replace/replacecommand
 */
 
-import type { ResultType } from './findandreplace.js';
+import type { FindResultType } from './findandreplace.js';
 import { sortSearchResultsByMarkerPositions } from './findandreplacestate.js';
-import { ReplaceCommandBase } from './replacecommandbase.js';
+import { FindReplaceCommandBase } from './replacecommandbase.js';
 
 /**
  * The replace command. It is used by the {@link module:find-and-replace/findandreplace~FindAndReplace find and replace feature}.
  */
-export class ReplaceCommand extends ReplaceCommandBase {
+export class ReplaceCommand extends FindReplaceCommandBase {
 	/**
 	 * Replace a given find result by a string or a callback.
 	 *
@@ -22,7 +22,7 @@ export class ReplaceCommand extends ReplaceCommandBase {
 	 *
 	 * @fires execute
 	 */
-	public override execute( replacementText: string, result: ResultType ): void {
+	public override execute( replacementText: string, result: FindResultType ): void {
 		// We save highlight offset here, as the information about the highlighted result will be lost after the changes.
 		//
 		// It happens because result list is partially regenerated if the result is removed from the paragraph.

--- a/packages/ckeditor5-find-and-replace/src/replacecommandbase.ts
+++ b/packages/ckeditor5-find-and-replace/src/replacecommandbase.ts
@@ -8,10 +8,10 @@
 */
 
 import { Command, type Editor } from 'ckeditor5/src/core.js';
-import type { ResultType } from './findandreplace.js';
+import type { FindResultType } from './findandreplace.js';
 import { type FindAndReplaceState } from './findandreplacestate.js';
 
-export abstract class ReplaceCommandBase extends Command {
+export abstract class FindReplaceCommandBase extends Command {
 	/**
 	 * The find and replace state object used for command operations.
 	 */
@@ -43,7 +43,7 @@ export abstract class ReplaceCommandBase extends Command {
 	 *
 	 * @param result A single result from the find command.
 	 */
-	protected _replace( replacementText: string, result: ResultType ): void {
+	protected _replace( replacementText: string, result: FindResultType ): void {
 		const { model } = this.editor;
 
 		const range = result.marker!.getRange();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (find-and-replace): Added re-exports and aligned naming in the `ckeditor5-find-and-replace` package.

---

### Additional information

Part of ckeditor/ckeditor5#18590.
