### PR TITLE
Added re-exports and aligned naming in the `ckeditor5-font`, `ckeditor5-heading` and `ckeditor5-html-embed` packages

### DIFF
--- a/packages/ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorui.ts
+++ b/packages/ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorui.ts
@@ -8,14 +8,14 @@
  */
 
 import { IconFontBackground } from 'ckeditor5/src/icons.js';
-import { ColorUI } from '../ui/colorui.js';
+import { FontColorUIBase } from '../ui/colorui.js';
 import { FONT_BACKGROUND_COLOR } from '../utils.js';
 import type { Editor } from 'ckeditor5/src/core.js';
 
 /**
  * The font background color UI plugin. It introduces the `'fontBackgroundColor'` dropdown.
  */
-export class FontBackgroundColorUI extends ColorUI {
+export class FontBackgroundColorUI extends FontColorUIBase {
 	/**
 	 * @inheritDoc
 	 */

--- a/packages/ckeditor5-font/src/fontcolor/fontcolorui.ts
+++ b/packages/ckeditor5-font/src/fontcolor/fontcolorui.ts
@@ -8,14 +8,14 @@
  */
 
 import { IconFontColor } from 'ckeditor5/src/icons.js';
-import { ColorUI } from '../ui/colorui.js';
+import { FontColorUIBase } from '../ui/colorui.js';
 import { FONT_COLOR } from '../utils.js';
 import type { Editor } from 'ckeditor5/src/core.js';
 
 /**
  * The font color UI plugin. It introduces the `'fontColor'` dropdown.
  */
-export class FontColorUI extends ColorUI {
+export class FontColorUI extends FontColorUIBase {
 	/**
 	 * @inheritDoc
 	 */

--- a/packages/ckeditor5-font/src/index.ts
+++ b/packages/ckeditor5-font/src/index.ts
@@ -12,6 +12,7 @@ export { FontBackgroundColor } from './fontbackgroundcolor.js';
 export { FontColor } from './fontcolor.js';
 export { FontFamily } from './fontfamily.js';
 export { FontSize } from './fontsize.js';
+export { FontCommand } from './fontcommand.js';
 export { FontBackgroundColorEditing } from './fontbackgroundcolor/fontbackgroundcolorediting.js';
 export { FontBackgroundColorUI } from './fontbackgroundcolor/fontbackgroundcolorui.js';
 export { FontColorEditing } from './fontcolor/fontcolorediting.js';
@@ -24,6 +25,7 @@ export { FontBackgroundColorCommand } from './fontbackgroundcolor/fontbackground
 export { FontColorCommand } from './fontcolor/fontcolorcommand.js';
 export { FontFamilyCommand } from './fontfamily/fontfamilycommand.js';
 export { FontSizeCommand } from './fontsize/fontsizecommand.js';
+export { FontColorUIBase } from './ui/colorui.js';
 
 export {
 	buildDefinition as _buildFontDefinition,
@@ -35,13 +37,15 @@ export {
 	type FONT_COLOR,
 	type FONT_FAMILY,
 	type FONT_SIZE,
-	type ColorSelectorDropdownView
+	type FontColorSelectorDropdownView
 } from './utils.js';
 
 export type {
 	FontColorConfig,
 	FontFamilyConfig,
-	FontSizeConfig
+	FontFamilyOption,
+	FontSizeConfig,
+	FontSizeOption
 } from './fontconfig.js';
 
 export { normalizeOptions as _normalizeFontFamilyOptions } from './fontfamily/utils.js';

--- a/packages/ckeditor5-font/src/ui/colorui.ts
+++ b/packages/ckeditor5-font/src/ui/colorui.ts
@@ -23,7 +23,7 @@ import {
 
 import {
 	addColorSelectorToDropdown,
-	type ColorSelectorDropdownView,
+	type FontColorSelectorDropdownView,
 	type FONT_BACKGROUND_COLOR,
 	type FONT_COLOR
 } from '../utils.js';
@@ -37,7 +37,7 @@ import type { FontColorConfig } from '../fontconfig.js';
  * It is used to create the `'fontBackgroundColor'` and `'fontColor'` dropdowns, each hosting
  * a {@link module:ui/colorselector/colorselectorview~ColorSelectorView}.
  */
-export class ColorUI extends Plugin {
+export class FontColorUIBase extends Plugin {
 	/**
 	 * The name of the command which will be executed when a color tile is clicked.
 	 */
@@ -115,7 +115,7 @@ export class ColorUI extends Plugin {
 
 		// Register the UI component.
 		editor.ui.componentFactory.add( this.componentName, locale => {
-			const dropdownView: ColorSelectorDropdownView = createDropdown( locale );
+			const dropdownView: FontColorSelectorDropdownView = createDropdown( locale );
 			// Font color dropdown rendering is deferred once it gets open to improve performance (#6192).
 			let dropdownContentRendered = false;
 
@@ -176,7 +176,7 @@ export class ColorUI extends Plugin {
 			colorSelectorView.on<ColorSelectorColorPickerCancelEvent>( 'colorPicker:cancel', () => {
 				if ( this._undoStepBatch!.operations.length ) {
 					// We need to close the dropdown before the undo batch.
-					// Otherwise, ColorUI treats undo as a selected color change,
+					// Otherwise, FontColorUIBase treats undo as a selected color change,
 					// propagating the update to the whole selection.
 					// That's an issue if spans with various colors were selected.
 					dropdownView.isOpen = false;

--- a/packages/ckeditor5-font/src/utils.ts
+++ b/packages/ckeditor5-font/src/utils.ts
@@ -127,7 +127,7 @@ export function addColorSelectorToDropdown(
 		dropdownView, colors, columns, removeButtonLabel, colorPickerLabel,
 		documentColorsLabel, documentColorsCount, colorPickerViewConfig
 	}: {
-		dropdownView: ColorSelectorDropdownView;
+		dropdownView: FontColorSelectorDropdownView;
 		colors: Array<ColorDefinition>;
 		columns: number;
 		removeButtonLabel: string;
@@ -161,6 +161,6 @@ function normalizeColorCode( value: string ): string {
 	return value.replace( /\s/g, '' );
 }
 
-export type ColorSelectorDropdownView = DropdownView & {
+export type FontColorSelectorDropdownView = DropdownView & {
 	colorSelectorView?: ColorSelectorView;
 };

--- a/packages/ckeditor5-font/tests/_utils/testcolorplugin.js
+++ b/packages/ckeditor5-font/tests/_utils/testcolorplugin.js
@@ -3,10 +3,10 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import { ColorUI } from './../../src/ui/colorui.js';
+import { FontColorUIBase } from './../../src/ui/colorui.js';
 import { FontColorCommand } from './../../src/fontcolor/fontcolorcommand.js';
 
-export class TestColorPlugin extends ColorUI {
+export class TestColorPlugin extends FontColorUIBase {
 	constructor( editor ) {
 		super( editor, {
 			commandName: 'testColorCommand',

--- a/packages/ckeditor5-font/tests/fontbackgroundcolor/fontbackgroundcolorui.js
+++ b/packages/ckeditor5-font/tests/fontbackgroundcolor/fontbackgroundcolorui.js
@@ -6,7 +6,7 @@
 import { IconFontBackground } from 'ckeditor5/src/icons.js';
 import { FontBackgroundColorEditing } from './../../src/fontbackgroundcolor/fontbackgroundcolorediting.js';
 import { FontBackgroundColorUI } from './../../src/fontbackgroundcolor/fontbackgroundcolorui.js';
-import { ColorUI } from './../../src/ui/colorui.js';
+import { FontColorUIBase } from './../../src/ui/colorui.js';
 import { ClassicTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
 
 describe( 'FontBckgroundColorUI', () => {
@@ -31,8 +31,8 @@ describe( 'FontBckgroundColorUI', () => {
 		return editor.destroy();
 	} );
 
-	it( 'is ColorUI', () => {
-		expect( FontBackgroundColorUI.prototype ).to.be.instanceOf( ColorUI );
+	it( 'is FontColorUIBase', () => {
+		expect( FontBackgroundColorUI.prototype ).to.be.instanceOf( FontColorUIBase );
 	} );
 
 	it( 'has properly set initial values', () => {

--- a/packages/ckeditor5-font/tests/fontcolor/fontcolorui.js
+++ b/packages/ckeditor5-font/tests/fontcolor/fontcolorui.js
@@ -6,7 +6,7 @@
 import { IconFontColor } from 'ckeditor5/src/icons.js';
 import { FontColorEditing } from './../../src/fontcolor/fontcolorediting.js';
 import { FontColorUI } from './../../src/fontcolor/fontcolorui.js';
-import { ColorUI } from './../../src/ui/colorui.js';
+import { FontColorUIBase } from './../../src/ui/colorui.js';
 import { ClassicTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
 
 describe( 'FontColorUI', () => {
@@ -31,8 +31,8 @@ describe( 'FontColorUI', () => {
 		return editor.destroy();
 	} );
 
-	it( 'is ColorUI', () => {
-		expect( FontColorUI.prototype ).to.be.instanceOf( ColorUI );
+	it( 'is FontColorUIBase', () => {
+		expect( FontColorUI.prototype ).to.be.instanceOf( FontColorUIBase );
 	} );
 
 	it( 'has properly set initial values', () => {

--- a/packages/ckeditor5-font/tests/ui/colorui.js
+++ b/packages/ckeditor5-font/tests/ui/colorui.js
@@ -13,7 +13,7 @@ import { Undo } from '@ckeditor/ckeditor5-undo/src/undo.js';
 import { add as addTranslations, _clear as clearTranslations } from '@ckeditor/ckeditor5-utils/src/translation-service.js';
 import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
 
-describe( 'ColorUI', () => {
+describe( 'FontColorUIBase', () => {
 	const testColorConfig = {
 		colors: [
 			'yellow',

--- a/packages/ckeditor5-heading/docs/features/title.md
+++ b/packages/ckeditor5-heading/docs/features/title.md
@@ -54,7 +54,7 @@ ClassicEditor
 
 The title plugin is integrated with the {@link features/editor-placeholder placeholder} configuration. If you define it, the placeholder text will be used for the body element.
 
-To change the title placeholder, use the {@link module:heading/title~TitleConfig#placeholder `title.placeholder`} configuration option. For instance:
+To change the title placeholder, use the {@link module:heading/title~HeadingTitleConfig#placeholder `title.placeholder`} configuration option. For instance:
 
 ```js
 ClassicEditor

--- a/packages/ckeditor5-heading/src/augmentation.ts
+++ b/packages/ckeditor5-heading/src/augmentation.ts
@@ -8,9 +8,9 @@ import type {
 	HeadingCommand,
 	HeadingConfig,
 	HeadingEditing,
+	HeadingTitleConfig,
 	HeadingUI,
-	Title,
-	TitleConfig
+	Title
 } from './index.js';
 
 declare module '@ckeditor/ckeditor5-core' {
@@ -26,9 +26,9 @@ declare module '@ckeditor/ckeditor5-core' {
 		/**
 		 * The configuration of the {@link module:heading/title~Title title feature}.
 		 *
-		 * Read more in {@link module:heading/title~TitleConfig}.
+		 * Read more in {@link module:heading/title~HeadingTitleConfig}.
 		 */
-		title?: TitleConfig;
+		title?: HeadingTitleConfig;
 	}
 
 	interface PluginsMap {

--- a/packages/ckeditor5-heading/src/index.ts
+++ b/packages/ckeditor5-heading/src/index.ts
@@ -13,8 +13,8 @@ export { HeadingEditing } from './headingediting.js';
 export { HeadingUI } from './headingui.js';
 export { HeadingButtonsUI } from './headingbuttonsui.js';
 export { HeadingCommand } from './headingcommand.js';
-export { Title, type TitleConfig } from './title.js';
-export type { HeadingConfig } from './headingconfig.js';
+export { Title, type HeadingTitleConfig } from './title.js';
+export type { HeadingConfig, HeadingParagraphOption } from './headingconfig.js';
 
 export { getLocalizedOptions as _getLocalizedHeadingOptions } from './utils.js';
 

--- a/packages/ckeditor5-heading/src/title.ts
+++ b/packages/ckeditor5-heading/src/title.ts
@@ -614,12 +614,12 @@ function shouldRemoveLastParagraph( placeholder: Element, root: RootElement ) {
  *
  * See {@link module:core/editor/editorconfig~EditorConfig all editor configuration options}.
  */
-export interface TitleConfig {
+export interface HeadingTitleConfig {
 
 	/**
 	 * Defines a custom value of the placeholder for the title field.
 	 *
-	 * Read more in {@link module:heading/title~TitleConfig}.
+	 * Read more in {@link module:heading/title~HeadingTitleConfig}.
 	 */
 	placeholder?: string;
 }

--- a/packages/ckeditor5-html-embed/src/index.ts
+++ b/packages/ckeditor5-html-embed/src/index.ts
@@ -11,7 +11,7 @@ export { HtmlEmbed } from './htmlembed.js';
 export { HtmlEmbedEditing } from './htmlembedediting.js';
 export { HtmlEmbedUI } from './htmlembedui.js';
 export { HtmlEmbedCommand } from './htmlembedcommand.js';
-export type { HtmlEmbedConfig } from './htmlembedconfig.js';
+export type { HtmlEmbedConfig, HtmlEmbedSanitizeOutput } from './htmlembedconfig.js';
 
 export type { RawHtmlApi as _RawHtmlEmbedApi } from './htmlembedediting.js';
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (font): Added re-exports and aligned naming in the `ckeditor5-font` package.

Internal (heading): Added re-exports and aligned naming in the `ckeditor5-heading` package.

Internal (html-embed): Added re-exports in the `ckeditor5-html-embed` package.

---

### Additional information

Part of ckeditor/ckeditor5#18590.