### PR TITLE
Added re-exports and aligned naming in the `ckeditor5-html-support` package

### DIFF
--- a/packages/ckeditor5-html-support/docs/features/full-page-html.md
+++ b/packages/ckeditor5-html-support/docs/features/full-page-html.md
@@ -49,11 +49,11 @@ ClassicEditor
 
 ### Render styles
 
-By default, the full page HTML feature does not render the CSS from `<style>` that may be located in the `<head>` section edited content. To enable that possibility, set the {@link module:html-support/generalhtmlsupportconfig~FullPageConfig#allowRenderStylesFromHead `config.htmlSupport.fullPage.allowRenderStylesFromHead`} option to `true`.
+By default, the full page HTML feature does not render the CSS from `<style>` that may be located in the `<head>` section edited content. To enable that possibility, set the {@link module:html-support/generalhtmlsupportconfig~GHSFullPageConfig#allowRenderStylesFromHead `config.htmlSupport.fullPage.allowRenderStylesFromHead`} option to `true`.
 
 Plugin extracts `<style>` elements from the edited content moves them to the main document `<head>`, and renders them. When CSS in `<style>` tag is changed using, for example, the {@link features/source-editing-enhanced Enhanced source code editing} feature, previously added `<style>` elements to the main document `<head>` will be replaced by the new ones.
 
-However, by enabling the ability to render CSS from `<style>` elements located in the `<head>` section of the edited content, you expose the users of your system to the **risk of executing malicious code inside the editor**. Therefore, we highly recommend sanitizing your CSS using some library that will strip the malicious code from the styles before rendering them. You can plug in the sanitizer by defining the {@link module:html-support/generalhtmlsupportconfig~FullPageConfig#sanitizeCss `config.htmlSupport.fullPage.sanitizeCss`} option.
+However, by enabling the ability to render CSS from `<style>` elements located in the `<head>` section of the edited content, you expose the users of your system to the **risk of executing malicious code inside the editor**. Therefore, we highly recommend sanitizing your CSS using some library that will strip the malicious code from the styles before rendering them. You can plug in the sanitizer by defining the {@link module:html-support/generalhtmlsupportconfig~GHSFullPageConfig#sanitizeCss `config.htmlSupport.fullPage.sanitizeCss`} option.
 
 ```js
 ClassicEditor
@@ -90,7 +90,7 @@ You can instruct some advanced users to never paste CSS code from untrusted sour
 
 #### Sanitizer
 
-The {@link module:html-support/generalhtmlsupportconfig~FullPageConfig#sanitizeCss `config.htmlSupport.fullPage.sanitizeCss`} option allows plugging an external sanitizer.
+The {@link module:html-support/generalhtmlsupportconfig~GHSFullPageConfig#sanitizeCss `config.htmlSupport.fullPage.sanitizeCss`} option allows plugging an external sanitizer.
 
 #### CSP
 

--- a/packages/ckeditor5-html-support/docs/features/general-html-support.md
+++ b/packages/ckeditor5-html-support/docs/features/general-html-support.md
@@ -288,7 +288,7 @@ ClassicEditor
 ```
 </code-switcher>
 
-You can treat both inline and block elements as object elements. To make it possible, it is necessary to set the {@link module:html-support/dataschema~DataSchemaDefinition#isObject isObject} property to `true`.
+You can treat both inline and block elements as object elements. To make it possible, it is necessary to set the {@link module:html-support/dataschema~HtmlSupportDataSchemaDefinition#isObject isObject} property to `true`.
 
 ```js
 // Inline object element.

--- a/packages/ckeditor5-html-support/src/converters.ts
+++ b/packages/ckeditor5-html-support/src/converters.ts
@@ -31,7 +31,11 @@ import {
 	type GHSViewAttributes
 } from './utils.js';
 import { type DataFilter } from './datafilter.js';
-import type { DataSchemaBlockElementDefinition, DataSchemaDefinition, DataSchemaInlineElementDefinition } from './dataschema.js';
+import type {
+	HtmlSupportDataSchemaBlockElementDefinition,
+	HtmlSupportDataSchemaDefinition,
+	HtmlSupportDataSchemaInlineElementDefinition
+} from './dataschema.js';
 
 /**
  * View-to-model conversion helper for object elements.
@@ -41,7 +45,7 @@ import type { DataSchemaBlockElementDefinition, DataSchemaDefinition, DataSchema
  * @returns Returns a conversion callback.
  * @internal
 */
-export function viewToModelObjectConverter( { model: modelName }: DataSchemaDefinition ) {
+export function viewToModelObjectConverter( { model: modelName }: HtmlSupportDataSchemaDefinition ) {
 	return ( viewElement: ViewElement, conversionApi: UpcastConversionApi ): Element => {
 		// Let's keep element HTML and its attributes, so we can rebuild element in downcast conversions.
 		return conversionApi.writer.createElement( modelName, {
@@ -58,7 +62,7 @@ export function viewToModelObjectConverter( { model: modelName }: DataSchemaDefi
 */
 export function toObjectWidgetConverter(
 	editor: Editor,
-	{ view: viewName, isInline }: DataSchemaInlineElementDefinition
+	{ view: viewName, isInline }: HtmlSupportDataSchemaInlineElementDefinition
 ): ElementCreatorFunction {
 	const t = editor.t;
 
@@ -106,7 +110,7 @@ export function createObjectView( viewName: string, modelElement: Element, write
  * @internal
 */
 export function viewToAttributeInlineConverter(
-	{ view: viewName, model: attributeKey, allowEmpty }: DataSchemaInlineElementDefinition,
+	{ view: viewName, model: attributeKey, allowEmpty }: HtmlSupportDataSchemaInlineElementDefinition,
 	dataFilter: DataFilter
 ): ( dispatcher: UpcastDispatcher ) => void {
 	return dispatcher => {
@@ -177,7 +181,7 @@ export function viewToAttributeInlineConverter(
  * @internal
  */
 export function emptyInlineModelElementToViewConverter(
-	{ model: attributeKey, view: viewName }: DataSchemaInlineElementDefinition,
+	{ model: attributeKey, view: viewName }: HtmlSupportDataSchemaInlineElementDefinition,
 	asWidget?: boolean
 ): ElementCreatorFunction {
 	return ( item, { writer, consumable } ) => {
@@ -203,7 +207,7 @@ export function emptyInlineModelElementToViewConverter(
  * @returns Returns a conversion callback.
  * @internal
 */
-export function attributeToViewInlineConverter( { priority, view: viewName }: DataSchemaInlineElementDefinition ) {
+export function attributeToViewInlineConverter( { priority, view: viewName }: HtmlSupportDataSchemaInlineElementDefinition ) {
 	return ( attributeValue: any, conversionApi: DowncastConversionApi ): AttributeElement | undefined => {
 		if ( !attributeValue ) {
 			return;
@@ -226,7 +230,10 @@ export function attributeToViewInlineConverter( { priority, view: viewName }: Da
  * @returns Returns a conversion callback.
  * @internal
 */
-export function viewToModelBlockAttributeConverter( { view: viewName }: DataSchemaBlockElementDefinition, dataFilter: DataFilter ) {
+export function viewToModelBlockAttributeConverter(
+	{ view: viewName }: HtmlSupportDataSchemaBlockElementDefinition,
+	dataFilter: DataFilter
+) {
 	return ( dispatcher: UpcastDispatcher ): void => {
 		dispatcher.on<UpcastElementEvent>( `element:${ viewName }`, ( evt, data, conversionApi ) => {
 			// Converting an attribute of an element that has not been converted to anything does not make sense
@@ -259,7 +266,7 @@ export function viewToModelBlockAttributeConverter( { view: viewName }: DataSche
  * @returns Returns a conversion callback.
  * @internal
 */
-export function modelToViewBlockAttributeConverter( { view: viewName, model: modelName }: DataSchemaBlockElementDefinition ) {
+export function modelToViewBlockAttributeConverter( { view: viewName, model: modelName }: HtmlSupportDataSchemaBlockElementDefinition ) {
 	return ( dispatcher: DowncastDispatcher ): void => {
 		dispatcher.on<DowncastAttributeEvent>(
 			`attribute:${ getHtmlAttributeName( viewName! ) }:${ modelName }`,

--- a/packages/ckeditor5-html-support/src/datafilter.ts
+++ b/packages/ckeditor5-html-support/src/datafilter.ts
@@ -45,9 +45,9 @@ import {
 
 import {
 	DataSchema,
-	type DataSchemaBlockElementDefinition,
-	type DataSchemaDefinition,
-	type DataSchemaInlineElementDefinition
+	type HtmlSupportDataSchemaBlockElementDefinition,
+	type HtmlSupportDataSchemaDefinition,
+	type HtmlSupportDataSchemaInlineElementDefinition
 } from './dataschema.js';
 
 import {
@@ -112,7 +112,7 @@ export class DataFilter extends Plugin {
 	/**
 	 * Allowed element definitions by {@link module:html-support/datafilter~DataFilter#allowElement} method.
 	*/
-	private readonly _allowedElements: Set<DataSchemaDefinition & { coupledAttribute?: string }>;
+	private readonly _allowedElements: Set<HtmlSupportDataSchemaDefinition & { coupledAttribute?: string }>;
 
 	/**
 	 * Disallowed element names by {@link module:html-support/datafilter~DataFilter#disallowElement} method.
@@ -332,7 +332,7 @@ export class DataFilter extends Plugin {
 	/**
 	 * Adds allowed element definition and fires registration event.
 	 */
-	private _addAllowedElement( definition: DataSchemaDefinition ): void {
+	private _addAllowedElement( definition: HtmlSupportDataSchemaDefinition ): void {
 		if ( this._allowedElements.has( definition ) ) {
 			return;
 		}
@@ -392,7 +392,7 @@ export class DataFilter extends Plugin {
 	 * Registers default element handlers.
 	 */
 	private _registerElementHandlers() {
-		this.on<DataFilterRegisterEvent>( 'register', ( evt, definition ) => {
+		this.on<HtmlSupportDataFilterRegisterEvent>( 'register', ( evt, definition ) => {
 			const schema = this.editor.model.schema;
 
 			// Object element should be only registered for new features.
@@ -401,9 +401,9 @@ export class DataFilter extends Plugin {
 			if ( definition.isObject && !schema.isRegistered( definition.model ) ) {
 				this._registerObjectElement( definition );
 			} else if ( definition.isBlock ) {
-				this._registerBlockElement( definition as DataSchemaBlockElementDefinition );
+				this._registerBlockElement( definition as HtmlSupportDataSchemaBlockElementDefinition );
 			} else if ( definition.isInline ) {
-				this._registerInlineElement( definition as DataSchemaInlineElementDefinition );
+				this._registerInlineElement( definition as HtmlSupportDataSchemaInlineElementDefinition );
 			} else {
 				/**
 				 * The definition cannot be handled by the data filter.
@@ -607,18 +607,18 @@ export class DataFilter extends Plugin {
 	/**
 	 * Fires `register` event for the given element definition.
 	 */
-	private _fireRegisterEvent( definition: DataSchemaDefinition ) {
+	private _fireRegisterEvent( definition: HtmlSupportDataSchemaDefinition ) {
 		if ( definition.view && this._disallowedElements.has( definition.view ) ) {
 			return;
 		}
 
-		this.fire<DataFilterRegisterEvent>( definition.view ? `register:${ definition.view }` : 'register', definition );
+		this.fire<HtmlSupportDataFilterRegisterEvent>( definition.view ? `register:${ definition.view }` : 'register', definition );
 	}
 
 	/**
 	 * Registers object element and attribute converters for the given data schema definition.
 	 */
-	private _registerObjectElement( definition: DataSchemaDefinition ) {
+	private _registerObjectElement( definition: HtmlSupportDataSchemaDefinition ) {
 		const editor = this.editor;
 		const schema = editor.model.schema;
 		const conversion = editor.conversion;
@@ -649,14 +649,15 @@ export class DataFilter extends Plugin {
 			// `+ 2` is used to take priority over `_addDefaultH1Conversion` in the Heading plugin.
 			converterPriority: priorities.low + 2
 		} );
-		conversion.for( 'upcast' ).add( viewToModelBlockAttributeConverter( definition as DataSchemaBlockElementDefinition, this ) );
+		conversion.for( 'upcast' )
+			.add( viewToModelBlockAttributeConverter( definition as HtmlSupportDataSchemaBlockElementDefinition, this ) );
 
 		conversion.for( 'editingDowncast' ).elementToStructure( {
 			model: {
 				name: modelName,
 				attributes: [ getHtmlAttributeName( viewName ) ]
 			},
-			view: toObjectWidgetConverter( editor, definition as DataSchemaInlineElementDefinition )
+			view: toObjectWidgetConverter( editor, definition as HtmlSupportDataSchemaInlineElementDefinition )
 		} );
 
 		conversion.for( 'dataDowncast' ).elementToElement( {
@@ -665,13 +666,14 @@ export class DataFilter extends Plugin {
 				return createObjectView( viewName, modelElement, writer );
 			}
 		} );
-		conversion.for( 'dataDowncast' ).add( modelToViewBlockAttributeConverter( definition as DataSchemaBlockElementDefinition ) );
+		conversion.for( 'dataDowncast' )
+			.add( modelToViewBlockAttributeConverter( definition as HtmlSupportDataSchemaBlockElementDefinition ) );
 	}
 
 	/**
 	 * Registers block element and attribute converters for the given data schema definition.
 	 */
-	private _registerBlockElement( definition: DataSchemaBlockElementDefinition ) {
+	private _registerBlockElement( definition: HtmlSupportDataSchemaBlockElementDefinition ) {
 		const editor = this.editor;
 		const schema = editor.model.schema;
 		const conversion = editor.conversion;
@@ -724,7 +726,7 @@ export class DataFilter extends Plugin {
 	 *
 	 * Extends `$text` model schema to allow the given definition model attribute and its properties.
 	 */
-	private _registerInlineElement( definition: DataSchemaInlineElementDefinition ) {
+	private _registerInlineElement( definition: HtmlSupportDataSchemaInlineElementDefinition ) {
 		const editor = this.editor;
 		const schema = editor.model.schema;
 		const conversion = editor.conversion;
@@ -839,9 +841,9 @@ export class DataFilter extends Plugin {
 
 /**
  * Fired when {@link module:html-support/datafilter~DataFilter} is registering element and attribute
- * converters for the {@link module:html-support/dataschema~DataSchemaDefinition element definition}.
+ * converters for the {@link module:html-support/dataschema~HtmlSupportDataSchemaDefinition element definition}.
  *
- * The event also accepts {@link module:html-support/dataschema~DataSchemaDefinition#view} value
+ * The event also accepts {@link module:html-support/dataschema~HtmlSupportDataSchemaDefinition#view} value
  * as an event namespace, e.g. `register:span`.
  *
  * ```ts
@@ -864,9 +866,9 @@ export class DataFilter extends Plugin {
  *
  * @eventName ~DataFilter#register
  */
-export interface DataFilterRegisterEvent {
+export interface HtmlSupportDataFilterRegisterEvent {
 	name: 'register' | `register:${ string }`;
-	args: [ data: DataSchemaDefinition ];
+	args: [ data: HtmlSupportDataSchemaDefinition ];
 }
 
 /**

--- a/packages/ckeditor5-html-support/src/dataschema.ts
+++ b/packages/ckeditor5-html-support/src/dataschema.ts
@@ -49,7 +49,7 @@ export class DataSchema extends Plugin {
 	/**
 	 * A map of registered data schema definitions.
 	 */
-	private readonly _definitions: Array<DataSchemaDefinition> = [];
+	private readonly _definitions: Array<HtmlSupportDataSchemaDefinition> = [];
 
 	/**
 	 * @inheritDoc
@@ -81,14 +81,14 @@ export class DataSchema extends Plugin {
 	/**
 	 * Add new data schema definition describing block element.
 	 */
-	public registerBlockElement( definition: DataSchemaBlockElementDefinition ): void {
+	public registerBlockElement( definition: HtmlSupportDataSchemaBlockElementDefinition ): void {
 		this._definitions.push( { ...definition, isBlock: true } );
 	}
 
 	/**
 	 * Add new data schema definition describing inline element.
 	 */
-	public registerInlineElement( definition: DataSchemaInlineElementDefinition ): void {
+	public registerInlineElement( definition: HtmlSupportDataSchemaInlineElementDefinition ): void {
 		this._definitions.push( { ...definition, isInline: true } );
 	}
 
@@ -100,7 +100,7 @@ export class DataSchema extends Plugin {
 	 *
 	 * @param definition Definition update.
 	 */
-	public extendBlockElement( definition: DataSchemaBlockElementDefinition ): void {
+	public extendBlockElement( definition: HtmlSupportDataSchemaBlockElementDefinition ): void {
 		this._extendDefinition( { ...definition, isBlock: true } );
 	}
 
@@ -112,7 +112,7 @@ export class DataSchema extends Plugin {
 	 *
 	 * @param definition Definition update.
 	 */
-	public extendInlineElement( definition: DataSchemaInlineElementDefinition ): void {
+	public extendInlineElement( definition: HtmlSupportDataSchemaInlineElementDefinition ): void {
 		this._extendDefinition( { ...definition, isInline: true } );
 	}
 
@@ -121,8 +121,8 @@ export class DataSchema extends Plugin {
 	 *
 	 * @param includeReferences Indicates if this method should also include definitions of referenced models.
 	 */
-	public getDefinitionsForView( viewName: string | RegExp, includeReferences: boolean = false ): Set<DataSchemaDefinition> {
-		const definitions = new Set<DataSchemaDefinition>();
+	public getDefinitionsForView( viewName: string | RegExp, includeReferences: boolean = false ): Set<HtmlSupportDataSchemaDefinition> {
+		const definitions = new Set<HtmlSupportDataSchemaDefinition>();
 
 		for ( const definition of this._getMatchingViewDefinitions( viewName ) ) {
 			if ( includeReferences ) {
@@ -140,14 +140,14 @@ export class DataSchema extends Plugin {
 	/**
 	 * Returns definitions matching the given model name.
 	 */
-	public getDefinitionsForModel( modelName: string ): Array<DataSchemaDefinition> {
+	public getDefinitionsForModel( modelName: string ): Array<HtmlSupportDataSchemaDefinition> {
 		return this._definitions.filter( definition => definition.model == modelName );
 	}
 
 	/**
 	 * Returns definitions matching the given view name.
 	 */
-	private _getMatchingViewDefinitions( viewName: string | RegExp ): Array<DataSchemaDefinition> {
+	private _getMatchingViewDefinitions( viewName: string | RegExp ): Array<HtmlSupportDataSchemaDefinition> {
 		return this._definitions.filter( def => def.view && testViewName( viewName, def.view ) );
 	}
 
@@ -156,7 +156,7 @@ export class DataSchema extends Plugin {
 	 *
 	 * @param modelName Data schema model name.
 	 */
-	private* _getReferences( modelName: string ): Iterable<DataSchemaDefinition> {
+	private* _getReferences( modelName: string ): Iterable<HtmlSupportDataSchemaDefinition> {
 		const inheritProperties = [
 			'inheritAllFrom',
 			'inheritTypesFrom',
@@ -195,7 +195,7 @@ export class DataSchema extends Plugin {
 	 *
 	 * @param definition Definition update.
 	 */
-	private _extendDefinition( definition: DataSchemaDefinition ): void {
+	private _extendDefinition( definition: HtmlSupportDataSchemaDefinition ): void {
 		const currentDefinitions = Array.from( this._definitions.entries() )
 			.filter( ( [ , currentDefinition ] ) => currentDefinition.model == definition.model );
 
@@ -231,7 +231,7 @@ function testViewName( pattern: string | RegExp, viewName: string ): boolean {
 /**
  * A base definition of {@link module:html-support/dataschema~DataSchema data schema}.
  */
-export interface DataSchemaDefinition {
+export interface HtmlSupportDataSchemaDefinition {
 
 	/**
 	 * Name of the model.
@@ -273,7 +273,7 @@ export interface DataSchemaDefinition {
 /**
  * A definition of {@link module:html-support/dataschema~DataSchema data schema} for block elements.
  */
-export interface DataSchemaBlockElementDefinition extends DataSchemaDefinition {
+export interface HtmlSupportDataSchemaBlockElementDefinition extends HtmlSupportDataSchemaDefinition {
 
 	/**
 	 * Should be used when an element can behave both as a sectioning element (e.g. article) and
@@ -286,7 +286,7 @@ export interface DataSchemaBlockElementDefinition extends DataSchemaDefinition {
 /**
  * A definition of {@link module:html-support/dataschema~DataSchema data schema} for inline elements.
  */
-export interface DataSchemaInlineElementDefinition extends DataSchemaDefinition {
+export interface HtmlSupportDataSchemaInlineElementDefinition extends HtmlSupportDataSchemaDefinition {
 
 	/**
 	 *  Additional metadata describing the model attribute.

--- a/packages/ckeditor5-html-support/src/generalhtmlsupport.ts
+++ b/packages/ckeditor5-html-support/src/generalhtmlsupport.ts
@@ -23,7 +23,7 @@ import { StyleElementSupport } from './integrations/style.js';
 import { ListElementSupport } from './integrations/list.js';
 import { HorizontalLineElementSupport } from './integrations/horizontalline.js';
 import { CustomElementSupport } from './integrations/customelement.js';
-import type { DataSchemaInlineElementDefinition } from './dataschema.js';
+import type { HtmlSupportDataSchemaInlineElementDefinition } from './dataschema.js';
 import type { DocumentSelection, Item, Model, Range, Selectable } from 'ckeditor5/src/engine.js';
 import { getHtmlAttributeName, modifyGhsAttribute, removeFormatting } from './utils.js';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -109,7 +109,7 @@ export class GeneralHtmlSupport extends Plugin {
 		const definitions = Array.from( dataSchema.getDefinitionsForView( viewElementName, false ) );
 
 		const inlineDefinition = definitions.find( definition => (
-			( definition as DataSchemaInlineElementDefinition ).isInline && !definitions[ 0 ].isObject
+			( definition as HtmlSupportDataSchemaInlineElementDefinition ).isInline && !definitions[ 0 ].isObject
 		) );
 
 		if ( inlineDefinition ) {

--- a/packages/ckeditor5-html-support/src/generalhtmlsupportconfig.ts
+++ b/packages/ckeditor5-html-support/src/generalhtmlsupportconfig.ts
@@ -109,13 +109,13 @@ export interface GeneralHtmlSupportConfig {
 	 * 	.catch( ... );
 	 * ```
 	 */
-	fullPage?: FullPageConfig;
+	fullPage?: GHSFullPageConfig;
 }
 
 /**
  * The configuration of the Full page editing feature.
  */
-export interface FullPageConfig {
+export interface GHSFullPageConfig {
 
 	/**
 	 * Whether the feature should allow the editor to render styles from the `<head>` section of editor data content.
@@ -146,7 +146,7 @@ export interface FullPageConfig {
 	 * We strongly recommend overwriting the default function to avoid XSS vulnerabilities.
 	 *
 	 * The function receives the CSS (as a string), and should return an object
-	 * that matches the {@link module:html-support/generalhtmlsupportconfig~CssSanitizeOutput} interface.
+	 * that matches the {@link module:html-support/generalhtmlsupportconfig~GHSCssSanitizeOutput} interface.
 	 *
 	 * ```ts
 	 * ClassicEditor
@@ -172,10 +172,10 @@ export interface FullPageConfig {
 	 * ```
 	 *
 	 */
-	sanitizeCss?: ( css: string ) => CssSanitizeOutput;
+	sanitizeCss?: ( css: string ) => GHSCssSanitizeOutput;
 }
 
-export interface CssSanitizeOutput {
+export interface GHSCssSanitizeOutput {
 
 	/**
 	 * An output (safe) CSS that will be inserted into the document.

--- a/packages/ckeditor5-html-support/src/index.ts
+++ b/packages/ckeditor5-html-support/src/index.ts
@@ -8,13 +8,20 @@
  */
 
 export { GeneralHtmlSupport } from './generalhtmlsupport.js';
-export { DataFilter, type DataFilterRegisterEvent } from './datafilter.js';
-export { DataSchema, type DataSchemaBlockElementDefinition } from './dataschema.js';
-export { HtmlComment } from './htmlcomment.js';
+export { DataFilter, type HtmlSupportDataFilterRegisterEvent } from './datafilter.js';
+
+export {
+	DataSchema,
+	type HtmlSupportDataSchemaBlockElementDefinition,
+	type HtmlSupportDataSchemaDefinition,
+	type HtmlSupportDataSchemaInlineElementDefinition
+} from './dataschema.js';
+
+export { HtmlComment, type HtmlCommentData } from './htmlcomment.js';
 export { FullPage } from './fullpage.js';
 export { HtmlPageDataProcessor } from './htmlpagedataprocessor.js';
 export { EmptyBlock } from './emptyblock.js';
-export type { GeneralHtmlSupportConfig } from './generalhtmlsupportconfig.js';
+export type { GeneralHtmlSupportConfig, GHSFullPageConfig, GHSCssSanitizeOutput } from './generalhtmlsupportconfig.js';
 export type { CodeBlockElementSupport } from './integrations/codeblock.js';
 export type { CustomElementSupport } from './integrations/customelement.js';
 export type { ListElementSupport } from './integrations/list.js';
@@ -48,7 +55,8 @@ export {
 	mergeViewElementAttributes as _mergeHtmlSupportViewElementAttributes,
 	modifyGhsAttribute as _modifyHtmlSupportGhsAttribute,
 	toPascalCase as _toHtmlSupportPascalCase,
-	getHtmlAttributeName as _getHtmlSupportAttributeName
+	getHtmlAttributeName as _getHtmlSupportAttributeName,
+	type GHSViewAttributes
 } from './utils.js';
 
 import './augmentation.js';

--- a/packages/ckeditor5-html-support/src/integrations/codeblock.ts
+++ b/packages/ckeditor5-html-support/src/integrations/codeblock.ts
@@ -21,7 +21,7 @@ import {
 	updateViewAttributes,
 	type GHSViewAttributes
 } from '../utils.js';
-import { DataFilter, type DataFilterRegisterEvent } from '../datafilter.js';
+import { DataFilter, type HtmlSupportDataFilterRegisterEvent } from '../datafilter.js';
 
 /**
  * Provides the General HTML Support integration with {@link module:code-block/codeblock~CodeBlock Code Block} feature.
@@ -58,7 +58,7 @@ export class CodeBlockElementSupport extends Plugin {
 
 		const dataFilter = this.editor.plugins.get( DataFilter );
 
-		dataFilter.on<DataFilterRegisterEvent>( 'register:pre', ( evt, definition ) => {
+		dataFilter.on<HtmlSupportDataFilterRegisterEvent>( 'register:pre', ( evt, definition ) => {
 			if ( definition.model !== 'codeBlock' ) {
 				return;
 			}

--- a/packages/ckeditor5-html-support/src/integrations/customelement.ts
+++ b/packages/ckeditor5-html-support/src/integrations/customelement.ts
@@ -11,7 +11,7 @@ import { Plugin } from 'ckeditor5/src/core.js';
 import { UpcastWriter, type ViewDocumentFragment, type ViewNode } from 'ckeditor5/src/engine.js';
 
 import { DataSchema } from '../dataschema.js';
-import { DataFilter, type DataFilterRegisterEvent } from '../datafilter.js';
+import { DataFilter, type HtmlSupportDataFilterRegisterEvent } from '../datafilter.js';
 import { type GHSViewAttributes, setViewAttributes } from '../utils.js';
 
 /**
@@ -46,7 +46,7 @@ export class CustomElementSupport extends Plugin {
 		const dataFilter = this.editor.plugins.get( DataFilter );
 		const dataSchema = this.editor.plugins.get( DataSchema );
 
-		dataFilter.on<DataFilterRegisterEvent>( 'register:$customElement', ( evt, definition ) => {
+		dataFilter.on<HtmlSupportDataFilterRegisterEvent>( 'register:$customElement', ( evt, definition ) => {
 			evt.stop();
 
 			const editor = this.editor;

--- a/packages/ckeditor5-html-support/src/integrations/dualcontent.ts
+++ b/packages/ckeditor5-html-support/src/integrations/dualcontent.ts
@@ -15,8 +15,8 @@ import {
 	modelToViewBlockAttributeConverter,
 	viewToModelBlockAttributeConverter
 } from '../converters.js';
-import { DataFilter, type DataFilterRegisterEvent } from '../datafilter.js';
-import type { DataSchemaBlockElementDefinition } from '../dataschema.js';
+import { DataFilter, type HtmlSupportDataFilterRegisterEvent } from '../datafilter.js';
+import type { HtmlSupportDataSchemaBlockElementDefinition } from '../dataschema.js';
 import { getHtmlAttributeName } from '../utils.js';
 
 /**
@@ -31,9 +31,10 @@ import { getHtmlAttributeName } from '../utils.js';
  * * model element HTML is semantically correct and easier to work with.
  *
  * If element contains any block element, it will be treated as a sectioning element and registered using
- * {@link module:html-support/dataschema~DataSchemaDefinition#model} and
- * {@link module:html-support/dataschema~DataSchemaDefinition#modelSchema} in editor schema.
- * Otherwise, it will be registered under {@link module:html-support/dataschema~DataSchemaBlockElementDefinition#paragraphLikeModel} model
+ * {@link module:html-support/dataschema~HtmlSupportDataSchemaDefinition#model} and
+ * {@link module:html-support/dataschema~HtmlSupportDataSchemaDefinition#modelSchema} in editor schema.
+ * Otherwise, it will be registered under
+ * {@link module:html-support/dataschema~HtmlSupportDataSchemaBlockElementDefinition#paragraphLikeModel} model
  * name with model schema accepting only inline content (inheriting from `$block`).
  */
 export class DualContentModelElementSupport extends Plugin {
@@ -64,8 +65,8 @@ export class DualContentModelElementSupport extends Plugin {
 	public init(): void {
 		const dataFilter = this.editor.plugins.get( DataFilter );
 
-		dataFilter.on<DataFilterRegisterEvent>( 'register', ( evt, definition ) => {
-			const blockDefinition = definition as DataSchemaBlockElementDefinition;
+		dataFilter.on<HtmlSupportDataFilterRegisterEvent>( 'register', ( evt, definition ) => {
+			const blockDefinition = definition as HtmlSupportDataSchemaBlockElementDefinition;
 			const editor = this.editor;
 			const schema = editor.model.schema;
 			const conversion = editor.conversion;
@@ -79,7 +80,7 @@ export class DualContentModelElementSupport extends Plugin {
 				return;
 			}
 
-			const paragraphLikeModelDefinition: DataSchemaBlockElementDefinition = {
+			const paragraphLikeModelDefinition: HtmlSupportDataSchemaBlockElementDefinition = {
 				model: blockDefinition.paragraphLikeModel,
 				view: blockDefinition.view
 			};
@@ -141,7 +142,7 @@ export class DualContentModelElementSupport extends Plugin {
 	/**
 	 * Adds attribute filtering conversion for the given data schema.
 	 */
-	private _addAttributeConversion( definition: DataSchemaBlockElementDefinition ) {
+	private _addAttributeConversion( definition: HtmlSupportDataSchemaBlockElementDefinition ) {
 		const editor = this.editor;
 		const conversion = editor.conversion;
 		const dataFilter = editor.plugins.get( DataFilter );

--- a/packages/ckeditor5-html-support/src/integrations/horizontalline.ts
+++ b/packages/ckeditor5-html-support/src/integrations/horizontalline.ts
@@ -14,7 +14,7 @@ import type {
 	Element
 } from 'ckeditor5/src/engine.js';
 
-import { DataFilter, type DataFilterRegisterEvent } from '../datafilter.js';
+import { DataFilter, type HtmlSupportDataFilterRegisterEvent } from '../datafilter.js';
 import { type GHSViewAttributes, updateViewAttributes } from '../utils.js';
 import { getDescendantElement } from './integrationutils.js';
 import { viewToModelBlockAttributeConverter } from '../converters.js';
@@ -58,7 +58,7 @@ export class HorizontalLineElementSupport extends Plugin {
 		const conversion = editor.conversion;
 		const dataFilter = editor.plugins.get( DataFilter );
 
-		dataFilter.on<DataFilterRegisterEvent>( 'register:hr', ( evt, definition ) => {
+		dataFilter.on<HtmlSupportDataFilterRegisterEvent>( 'register:hr', ( evt, definition ) => {
 			if ( definition.model !== 'horizontalLine' ) {
 				return;
 			}

--- a/packages/ckeditor5-html-support/src/integrations/image.ts
+++ b/packages/ckeditor5-html-support/src/integrations/image.ts
@@ -17,7 +17,7 @@ import type {
 } from 'ckeditor5/src/engine.js';
 import type { ImageUtils } from '@ckeditor/ckeditor5-image';
 
-import { DataFilter, type DataFilterRegisterEvent } from '../datafilter.js';
+import { DataFilter, type HtmlSupportDataFilterRegisterEvent } from '../datafilter.js';
 import { type GHSViewAttributes, setViewAttributes, updateViewAttributes } from '../utils.js';
 import { getDescendantElement } from './integrationutils.js';
 
@@ -61,11 +61,11 @@ export class ImageElementSupport extends Plugin {
 		const conversion = editor.conversion;
 		const dataFilter = editor.plugins.get( DataFilter );
 
-		dataFilter.on<DataFilterRegisterEvent>( 'register:figure', () => {
+		dataFilter.on<HtmlSupportDataFilterRegisterEvent>( 'register:figure', () => {
 			conversion.for( 'upcast' ).add( viewToModelFigureAttributeConverter( dataFilter ) );
 		} );
 
-		dataFilter.on<DataFilterRegisterEvent>( 'register:img', ( evt, definition ) => {
+		dataFilter.on<HtmlSupportDataFilterRegisterEvent>( 'register:img', ( evt, definition ) => {
 			if ( definition.model !== 'imageBlock' && definition.model !== 'imageInline' ) {
 				return;
 			}

--- a/packages/ckeditor5-html-support/src/integrations/list.ts
+++ b/packages/ckeditor5-html-support/src/integrations/list.ts
@@ -21,7 +21,7 @@ import type {
 } from '@ckeditor/ckeditor5-list';
 
 import { getHtmlAttributeName, setViewAttributes } from '../utils.js';
-import { DataFilter, type DataFilterRegisterEvent } from '../datafilter.js';
+import { DataFilter, type HtmlSupportDataFilterRegisterEvent } from '../datafilter.js';
 
 /**
  * Provides the General HTML Support integration with the {@link module:list/list~List List} feature.
@@ -85,7 +85,7 @@ export class ListElementSupport extends Plugin {
 			setAttributeOnDowncast: setViewAttributes
 		} );
 
-		dataFilter.on<DataFilterRegisterEvent>( 'register', ( evt, definition ) => {
+		dataFilter.on<HtmlSupportDataFilterRegisterEvent>( 'register', ( evt, definition ) => {
 			if ( !viewElements.includes( definition.view! ) ) {
 				return;
 			}

--- a/packages/ckeditor5-html-support/src/integrations/mediaembed.ts
+++ b/packages/ckeditor5-html-support/src/integrations/mediaembed.ts
@@ -9,7 +9,7 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 
-import { DataFilter, type DataFilterRegisterEvent } from '../datafilter.js';
+import { DataFilter, type HtmlSupportDataFilterRegisterEvent } from '../datafilter.js';
 import { DataSchema } from '../dataschema.js';
 import { updateViewAttributes, type GHSViewAttributes, getHtmlAttributeName } from '../utils.js';
 import type {
@@ -71,11 +71,11 @@ export class MediaEmbedElementSupport extends Plugin {
 			view: mediaElementName
 		} );
 
-		dataFilter.on<DataFilterRegisterEvent>( 'register:figure', ( ) => {
+		dataFilter.on<HtmlSupportDataFilterRegisterEvent>( 'register:figure', ( ) => {
 			conversion.for( 'upcast' ).add( viewToModelFigureAttributesConverter( dataFilter ) );
 		} );
 
-		dataFilter.on<DataFilterRegisterEvent>( `register:${ mediaElementName }`, ( evt, definition ) => {
+		dataFilter.on<HtmlSupportDataFilterRegisterEvent>( `register:${ mediaElementName }`, ( evt, definition ) => {
 			if ( definition.model !== 'media' ) {
 				return;
 			}

--- a/packages/ckeditor5-html-support/src/integrations/script.ts
+++ b/packages/ckeditor5-html-support/src/integrations/script.ts
@@ -14,8 +14,8 @@ import {
 	viewToModelBlockAttributeConverter,
 	viewToModelObjectConverter
 } from '../converters.js';
-import { DataFilter, type DataFilterRegisterEvent } from '../datafilter.js';
-import type { DataSchemaBlockElementDefinition } from '../dataschema.js';
+import { DataFilter, type HtmlSupportDataFilterRegisterEvent } from '../datafilter.js';
+import type { HtmlSupportDataSchemaBlockElementDefinition } from '../dataschema.js';
 
 /**
  * Provides the General HTML Support for `script` elements.
@@ -48,7 +48,7 @@ export class ScriptElementSupport extends Plugin {
 	public init(): void {
 		const dataFilter = this.editor.plugins.get( DataFilter );
 
-		dataFilter.on<DataFilterRegisterEvent>( 'register:script', ( evt, definition ) => {
+		dataFilter.on<HtmlSupportDataFilterRegisterEvent>( 'register:script', ( evt, definition ) => {
 			const editor = this.editor;
 			const schema = editor.model.schema;
 			const conversion = editor.conversion;
@@ -70,7 +70,7 @@ export class ScriptElementSupport extends Plugin {
 			} );
 
 			conversion.for( 'upcast' ).add( viewToModelBlockAttributeConverter(
-				definition as DataSchemaBlockElementDefinition,
+				definition as HtmlSupportDataSchemaBlockElementDefinition,
 				dataFilter
 			) );
 
@@ -81,7 +81,8 @@ export class ScriptElementSupport extends Plugin {
 				}
 			} );
 
-			conversion.for( 'downcast' ).add( modelToViewBlockAttributeConverter( definition as DataSchemaBlockElementDefinition ) );
+			conversion.for( 'downcast' )
+				.add( modelToViewBlockAttributeConverter( definition as HtmlSupportDataSchemaBlockElementDefinition ) );
 
 			evt.stop();
 		} );

--- a/packages/ckeditor5-html-support/src/integrations/style.ts
+++ b/packages/ckeditor5-html-support/src/integrations/style.ts
@@ -15,8 +15,8 @@ import {
 	viewToModelBlockAttributeConverter,
 	viewToModelObjectConverter
 } from '../converters.js';
-import { DataFilter, type DataFilterRegisterEvent } from '../datafilter.js';
-import type { DataSchemaBlockElementDefinition } from '../dataschema.js';
+import { DataFilter, type HtmlSupportDataFilterRegisterEvent } from '../datafilter.js';
+import type { HtmlSupportDataSchemaBlockElementDefinition } from '../dataschema.js';
 
 /**
  * Provides the General HTML Support for `style` elements.
@@ -49,7 +49,7 @@ export class StyleElementSupport extends Plugin {
 	public init(): void {
 		const dataFilter = this.editor.plugins.get( DataFilter );
 
-		dataFilter.on<DataFilterRegisterEvent>( 'register:style', ( evt, definition ) => {
+		dataFilter.on<HtmlSupportDataFilterRegisterEvent>( 'register:style', ( evt, definition ) => {
 			const editor = this.editor;
 			const schema = editor.model.schema;
 			const conversion = editor.conversion;
@@ -71,7 +71,7 @@ export class StyleElementSupport extends Plugin {
 			} );
 
 			conversion.for( 'upcast' ).add( viewToModelBlockAttributeConverter(
-				definition as DataSchemaBlockElementDefinition, dataFilter
+				definition as HtmlSupportDataSchemaBlockElementDefinition, dataFilter
 			) );
 
 			conversion.for( 'downcast' ).elementToElement( {
@@ -81,7 +81,8 @@ export class StyleElementSupport extends Plugin {
 				}
 			} );
 
-			conversion.for( 'downcast' ).add( modelToViewBlockAttributeConverter( definition as DataSchemaBlockElementDefinition ) );
+			conversion.for( 'downcast' )
+				.add( modelToViewBlockAttributeConverter( definition as HtmlSupportDataSchemaBlockElementDefinition ) );
 
 			evt.stop();
 		} );

--- a/packages/ckeditor5-html-support/src/integrations/table.ts
+++ b/packages/ckeditor5-html-support/src/integrations/table.ts
@@ -22,7 +22,7 @@ import { Plugin } from 'ckeditor5/src/core.js';
 import type { TableUtils } from '@ckeditor/ckeditor5-table';
 
 import { updateViewAttributes, type GHSViewAttributes } from '../utils.js';
-import { DataFilter, type DataFilterRegisterEvent } from '../datafilter.js';
+import { DataFilter, type HtmlSupportDataFilterRegisterEvent } from '../datafilter.js';
 import { getDescendantElement } from './integrationutils.js';
 
 const STYLE_ATTRIBUTES_TO_PROPAGATE = [
@@ -74,11 +74,11 @@ export class TableElementSupport extends Plugin {
 		const dataFilter = editor.plugins.get( DataFilter );
 		const tableUtils: TableUtils = editor.plugins.get( 'TableUtils' );
 
-		dataFilter.on<DataFilterRegisterEvent>( 'register:figure', ( ) => {
+		dataFilter.on<HtmlSupportDataFilterRegisterEvent>( 'register:figure', ( ) => {
 			conversion.for( 'upcast' ).add( viewToModelFigureAttributeConverter( dataFilter ) );
 		} );
 
-		dataFilter.on<DataFilterRegisterEvent>( 'register:table', ( evt, definition ) => {
+		dataFilter.on<HtmlSupportDataFilterRegisterEvent>( 'register:table', ( evt, definition ) => {
 			if ( definition.model !== 'table' ) {
 				return;
 			}

--- a/packages/ckeditor5-html-support/src/schemadefinitions.ts
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import type { DataSchemaBlockElementDefinition, DataSchemaInlineElementDefinition } from './dataschema.js';
+import type { HtmlSupportDataSchemaBlockElementDefinition, HtmlSupportDataSchemaInlineElementDefinition } from './dataschema.js';
 
 /**
  * @module html-support/schemadefinitions
@@ -538,7 +538,7 @@ export const defaultConfig = {
 				inheritAllFrom: '$blockObject'
 			}
 		}
-	] as Array<DataSchemaBlockElementDefinition>,
+	] as Array<HtmlSupportDataSchemaBlockElementDefinition>,
 
 	inline: [
 		// Existing features (attribute set on an existing model element).
@@ -986,5 +986,5 @@ export const defaultConfig = {
 				isInline: true
 			}
 		}
-	] as Array<DataSchemaInlineElementDefinition>
+	] as Array<HtmlSupportDataSchemaInlineElementDefinition>
 };

--- a/packages/ckeditor5-style/src/styleutils.ts
+++ b/packages/ckeditor5-style/src/styleutils.ts
@@ -12,7 +12,12 @@ import type { Element, MatcherObjectPattern, DocumentSelection, Selectable } fro
 import type { DecoratedMethodEvent } from 'ckeditor5/src/utils.js';
 import type { TemplateDefinition } from 'ckeditor5/src/ui.js';
 
-import type { DataFilter, DataSchema, GeneralHtmlSupport, DataSchemaBlockElementDefinition } from '@ckeditor/ckeditor5-html-support';
+import type {
+	DataFilter,
+	DataSchema,
+	GeneralHtmlSupport,
+	HtmlSupportDataSchemaBlockElementDefinition
+} from '@ckeditor/ckeditor5-html-support';
 
 import type { StyleDefinition } from './styleconfig.js';
 import { isObject } from 'es-toolkit/compat';
@@ -106,7 +111,7 @@ export class StyleUtils extends Plugin {
 					if ( typeof appliesToBlock == 'string' ) {
 						modelElements.push( appliesToBlock );
 					} else if ( ghsDefinition.isBlock ) {
-						const ghsBlockDefinition: DataSchemaBlockElementDefinition = ghsDefinition;
+						const ghsBlockDefinition: HtmlSupportDataSchemaBlockElementDefinition = ghsDefinition;
 
 						modelElements.push( ghsDefinition.model );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (html-support): Added re-exports and aligned naming in the `ckeditor5-html-support` package.

Internal (style): Aligned to renames from the `ckeditor5-html-support` package.

---

### Additional information

Part of ckeditor/ckeditor5#18590.
Commercial PR: https://github.com/cksource/ckeditor5-commercial/pull/7925.
