### PR TITLE
[Hotfix] Editor should not crash when balloon toolbar is attached to removed DOM text node

### DIFF
--- a/packages/ckeditor5-engine/src/view/domconverter.ts
+++ b/packages/ckeditor5-engine/src/view/domconverter.ts
@@ -651,7 +651,9 @@ export default class DomConverter {
 
 			// In case someone uses outdated view position, but DOM text node was already changed while typing.
 			// See: https://github.com/ckeditor/ckeditor5/issues/18648.
-			if ( offset > domParent.data.length ) {
+			// Note that when checking Renderer#_isSelectionInInlineFiller() this might be other element
+			// than a text node as it is triggered before applying view changes to the DOM.
+			if ( domParent.data && offset > domParent.data.length ) {
 				offset = domParent.data.length;
 			}
 

--- a/packages/ckeditor5-engine/tests/view/domconverter/view-to-dom.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/view-to-dom.js
@@ -1487,6 +1487,26 @@ describe( 'DomConverter', () => {
 			expect( domPosition.parent ).to.equal( domFoo );
 		} );
 
+		it( 'should not crash for position in text on not yet updated DOM tree', () => {
+			// Note this is a case when renderer is verifying whether the selection is inside an inline filler,
+			// so the DOM tree is not yet updated.
+			const domFiller = document.createTextNode( INLINE_FILLER );
+			const domFoo = document.createTextNode( 'foo' );
+			const domSpan = createElement( document, 'span', null, domFoo );
+			const domStrong = createElement( document, 'strong', null, [ domFiller, domSpan ] );
+			const domP = createElement( document, 'p', null, domStrong );
+			const { view: viewP } = parse( '<container:p>{}foo</container:p>' );
+
+			converter.bindElements( domP, viewP );
+
+			const viewPosition = new ViewPosition( viewP.getChild( 0 ), 0 );
+			const domPosition = converter.viewPositionToDom( viewPosition );
+
+			expect( domPosition.offset ).to.equal( 0 );
+			expect( domPosition.parent ).to.equal( domStrong );
+			// This should be in a text node but since DOM is not yet updated, it is in the strong element.
+		} );
+
 		it( 'should move the position to the text node if the position is where inline filler is', () => {
 			const domFiller = document.createTextNode( INLINE_FILLER );
 			const domP = createElement( document, 'p', null, domFiller );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (engine): The editor should not crash when typing over a table content with the balloon toolbar enabled. Closes #18648.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
