### PR TITLE
Added re-exports and renamed package members for `ckeditor5-typing`.

### DIFF
--- a/packages/ckeditor5-typing/docs/features/text-transformation.md
+++ b/packages/ckeditor5-typing/docs/features/text-transformation.md
@@ -173,7 +173,7 @@ ClassicEditor
 	.catch( /* ... */ );
 ```
 
-You can read more about the format of transformation rules in {@link module:typing/typingconfig~TextTransformationDescription}.
+You can read more about the format of transformation rules in {@link module:typing/typingconfig~TextTypingTransformationDescription}.
 
 You can test these custom rules in the demo. Try typing `:)` or `:+1:` and see how the text gets transformed into emojis. You can also write some sentences to test how the editor capitalizes words after a period, a quotation mark, or an exclamation mark.
 

--- a/packages/ckeditor5-typing/src/deletecommand.ts
+++ b/packages/ckeditor5-typing/src/deletecommand.ts
@@ -11,7 +11,7 @@ import { Command, type Editor } from '@ckeditor/ckeditor5-core';
 import { count } from '@ckeditor/ckeditor5-utils';
 import type { DocumentSelection, Element, Selection, Writer } from '@ckeditor/ckeditor5-engine';
 
-import { ChangeBuffer } from './utils/changebuffer.js';
+import { TypingChangeBuffer } from './utils/changebuffer.js';
 
 // @if CK_DEBUG_TYPING // const { _buildLogMessage } = require( '@ckeditor/ckeditor5-engine/src/dev-utils/utils.js' );
 
@@ -29,7 +29,7 @@ export class DeleteCommand extends Command {
 	/**
 	 * Delete's change buffer used to group subsequent changes into batches.
 	 */
-	private readonly _buffer: ChangeBuffer;
+	private readonly _buffer: TypingChangeBuffer;
 
 	/**
 	 * Creates an instance of the command.
@@ -41,7 +41,7 @@ export class DeleteCommand extends Command {
 		super( editor );
 
 		this.direction = direction;
-		this._buffer = new ChangeBuffer( editor.model, editor.config.get( 'typing.undoStep' ) );
+		this._buffer = new TypingChangeBuffer( editor.model, editor.config.get( 'typing.undoStep' ) );
 
 		// Since this command may execute on different selectable than selection, it should be checked directly in execute block.
 		this._isEnabledBasedOnSelection = false;
@@ -50,7 +50,7 @@ export class DeleteCommand extends Command {
 	/**
 	 * The current change buffer.
 	 */
-	public get buffer(): ChangeBuffer {
+	public get buffer(): TypingChangeBuffer {
 		return this._buffer;
 	}
 

--- a/packages/ckeditor5-typing/src/index.ts
+++ b/packages/ckeditor5-typing/src/index.ts
@@ -19,16 +19,23 @@ export type { TextTransformationConfig } from './typingconfig.js';
 export { inlineHighlight } from './utils/inlinehighlight.js';
 export { findAttributeRange, findAttributeRangeBound } from './utils/findattributerange.js';
 export { getLastTextLine, type LastTextLineData } from './utils/getlasttextline.js';
+export { TypingChangeBuffer } from './utils/changebuffer.js';
 
-export { InsertTextCommand, type InsertTextCommandExecuteEvent } from './inserttextcommand.js';
+export { InsertTextCommand, type InsertTextCommandExecuteEvent, type InsertTextCommandOptions } from './inserttextcommand.js';
 export { DeleteCommand } from './deletecommand.js';
 
-export { DeleteObserver as _DeleteObserver } from './deleteobserver.js';
+export { DeleteObserver as _DeleteObserver, type DeleteEventData } from './deleteobserver.js';
 
-export type { TypingConfig } from './typingconfig.js';
+export type { TypingConfig, TextTypingTransformationDescription } from './typingconfig.js';
 export type { ViewDocumentDeleteEvent } from './deleteobserver.js';
-export type { ViewDocumentInsertTextEvent, InsertTextEventData } from './inserttextobserver.js';
-export type { TextWatcherMatchedEvent } from './textwatcher.js';
-export type { TextWatcherMatchedDataEvent } from './textwatcher.js';
+export type { ViewDocumentInsertTextEvent, InsertTextEventData, InsertTextObserver } from './inserttextobserver.js';
+export type {
+	TextWatcherMatchedEvent,
+	TextWatcherMatchedDataEvent,
+	TextWatcherMatchedTypingDataEventData,
+	TextWatcherMatchedTypingSelectionEvent,
+	TextWatcherMatchedTypingSelectionEventData,
+	TextWatcherUnmatchedTypingEvent
+} from './textwatcher.js';
 
 import './augmentation.js';

--- a/packages/ckeditor5-typing/src/inserttextcommand.ts
+++ b/packages/ckeditor5-typing/src/inserttextcommand.ts
@@ -9,7 +9,7 @@
 
 import { Command, type Editor } from '@ckeditor/ckeditor5-core';
 
-import { ChangeBuffer } from './utils/changebuffer.js';
+import { TypingChangeBuffer } from './utils/changebuffer.js';
 
 import type { DocumentSelection, Range, Selection } from '@ckeditor/ckeditor5-engine';
 
@@ -20,7 +20,7 @@ export class InsertTextCommand extends Command {
 	/**
 	 * Typing's change buffer used to group subsequent changes into batches.
 	 */
-	private readonly _buffer: ChangeBuffer;
+	private readonly _buffer: TypingChangeBuffer;
 
 	/**
 	 * Creates an instance of the command.
@@ -31,7 +31,7 @@ export class InsertTextCommand extends Command {
 	constructor( editor: Editor, undoStepSize: number ) {
 		super( editor );
 
-		this._buffer = new ChangeBuffer( editor.model, undoStepSize );
+		this._buffer = new TypingChangeBuffer( editor.model, undoStepSize );
 
 		// Since this command may execute on different selectable than selection, it should be checked directly in execute block.
 		this._isEnabledBasedOnSelection = false;
@@ -40,7 +40,7 @@ export class InsertTextCommand extends Command {
 	/**
 	 * The current change buffer.
 	 */
-	public get buffer(): ChangeBuffer {
+	public get buffer(): TypingChangeBuffer {
 		return this._buffer;
 	}
 

--- a/packages/ckeditor5-typing/src/texttransformation.ts
+++ b/packages/ckeditor5-typing/src/texttransformation.ts
@@ -15,13 +15,13 @@ import {
 import type { Position } from '@ckeditor/ckeditor5-engine';
 
 import { TextWatcher, type TextWatcherMatchedDataEvent } from './textwatcher.js';
-import type { TextTransformationConfig, TextTransformationDescription } from './typingconfig.js';
+import type { TextTransformationConfig, TextTypingTransformationDescription } from './typingconfig.js';
 import { type Delete } from './delete.js';
 
 import { escapeRegExp } from 'es-toolkit/compat';
 
 // All named transformations.
-const TRANSFORMATIONS: Record<string, TextTransformationDescription> = {
+const TRANSFORMATIONS: Record<string, TextTypingTransformationDescription> = {
 	// Common symbols:
 	copyright: { from: '(c)', to: '©' },
 	registeredTrademark: { from: '(r)', to: '®' },
@@ -217,7 +217,7 @@ function normalizeFrom( from: string | RegExp ): RegExp {
  * The normalized value for the `to` parameter is a function that takes an array and returns an array. See more in the
  * configuration description. If the passed `to` is already a function, it is returned unchanged.
  */
-function normalizeTo( to: TextTransformationDescription[ 'to' ] ) {
+function normalizeTo( to: TextTypingTransformationDescription[ 'to' ] ) {
 	if ( typeof to == 'string' ) {
 		return () => [ to ];
 	} else if ( to instanceof Array ) {
@@ -253,7 +253,7 @@ function buildQuotesRegExp( quoteCharacter: string ): RegExp {
 function normalizeTransformations( config: TextTransformationConfig ): Array<NormalizedTransformationConfig> {
 	const extra = config.extra || [];
 	const remove = config.remove || [];
-	const isNotRemoved = ( transformation: TextTransformationDescription | string ) => !remove.includes( transformation );
+	const isNotRemoved = ( transformation: TextTypingTransformationDescription | string ) => !remove.includes( transformation );
 
 	const configured = config.include.concat( extra ).filter( isNotRemoved );
 
@@ -263,7 +263,7 @@ function normalizeTransformations( config: TextTransformationConfig ): Array<Nor
 			typeof transformation == 'string' && TRANSFORMATIONS[ transformation ] ? TRANSFORMATIONS[ transformation ] : transformation )
 		)
 		// Filter out transformations set as string that has not been found.
-		.filter( ( transformation ): transformation is TextTransformationDescription => typeof transformation === 'object' )
+		.filter( ( transformation ): transformation is TextTypingTransformationDescription => typeof transformation === 'object' )
 		.map( transformation => ( {
 			from: normalizeFrom( transformation.from ),
 			to: normalizeTo( transformation.to )
@@ -275,10 +275,10 @@ function normalizeTransformations( config: TextTransformationConfig ): Array<Nor
  * This method also removes duplicated named transformations if any.
  */
 function expandGroupsAndRemoveDuplicates(
-	definitions: Array<TextTransformationDescription | string>
-): Array<TextTransformationDescription | string> {
+	definitions: Array<TextTypingTransformationDescription | string>
+): Array<TextTypingTransformationDescription | string> {
 	// Set is using to make sure that transformation names are not duplicated.
-	const definedTransformations = new Set<TextTransformationDescription | string>();
+	const definedTransformations = new Set<TextTypingTransformationDescription | string>();
 
 	for ( const transformationOrGroup of definitions ) {
 		if ( typeof transformationOrGroup == 'string' && TRANSFORMATION_GROUPS[ transformationOrGroup ] ) {

--- a/packages/ckeditor5-typing/src/textwatcher.ts
+++ b/packages/ckeditor5-typing/src/textwatcher.ts
@@ -153,7 +153,7 @@ export class TextWatcher extends /* #__PURE__ */ ObservableMixin() {
 		const testResult = this.testCallback( text );
 
 		if ( !testResult && this.hasMatch ) {
-			this.fire<TextWatcherUnmatchedEvent>( 'unmatched' );
+			this.fire<TextWatcherUnmatchedTypingEvent>( 'unmatched' );
 		}
 
 		this._hasMatch = !!testResult;
@@ -189,10 +189,10 @@ export type TextWatcherMatchedEvent<TCallbackResult extends Record<string, unkno
  */
 export type TextWatcherMatchedDataEvent<TCallbackResult extends Record<string, unknown>> = {
 	name: 'matched:data';
-	args: [ data: TextWatcherMatchedDataEventData & TCallbackResult ];
+	args: [ data: TextWatcherMatchedTypingDataEventData & TCallbackResult ];
 };
 
-export interface TextWatcherMatchedDataEventData {
+export interface TextWatcherMatchedTypingDataEventData {
 
 	/**
 	 * The full text before selection to which the regexp was applied.
@@ -214,12 +214,12 @@ export interface TextWatcherMatchedDataEventData {
  * @param data Event data.
  * @param data.testResult The additional data returned from the {@link module:typing/textwatcher~TextWatcher#testCallback}.
  */
-export type TextWatcherMatchedSelectionEvent<TCallbackResult extends Record<string, unknown>> = {
+export type TextWatcherMatchedTypingSelectionEvent<TCallbackResult extends Record<string, unknown>> = {
 	name: 'matched:selection';
-	args: [ data: TextWatcherMatchedSelectionEventData & TCallbackResult ];
+	args: [ data: TextWatcherMatchedTypingSelectionEventData & TCallbackResult ];
 };
 
-export interface TextWatcherMatchedSelectionEventData {
+export interface TextWatcherMatchedTypingSelectionEventData {
 
 	/**
 	 * The full text before selection.
@@ -237,7 +237,7 @@ export interface TextWatcherMatchedSelectionEventData {
  *
  * @eventName ~TextWatcher#unmatched
  */
-export type TextWatcherUnmatchedEvent = {
+export type TextWatcherUnmatchedTypingEvent = {
 	name: 'unmatched';
 	args: [];
 };

--- a/packages/ckeditor5-typing/src/typingconfig.ts
+++ b/packages/ckeditor5-typing/src/typingconfig.ts
@@ -123,7 +123,7 @@ export interface TextTransformationConfig {
 	 * ({@link module:typing/typingconfig~TextTransformationConfig#extra `transformations.extra`},
 	 * {@link module:typing/typingconfig~TextTransformationConfig#remove `transformations.remove`}) to fine-tune the default list.
 	 */
-	include: Array<TextTransformationDescription | string>;
+	include: Array<TextTypingTransformationDescription | string>;
 
 	/**
 	 * Additional text transformations that are added to the transformations defined in
@@ -137,7 +137,7 @@ export interface TextTransformationConfig {
 	 * };
 	 * ```
 	 */
-	extra?: Array<TextTransformationDescription | string>;
+	extra?: Array<TextTypingTransformationDescription | string>;
 
 	/**
 	 * The text transformation names that are removed from transformations defined in
@@ -153,7 +153,7 @@ export interface TextTransformationConfig {
 	 * }
 	 * ```
 	 */
-	remove?: Array<TextTransformationDescription | string>;
+	remove?: Array<TextTypingTransformationDescription | string>;
 }
 
 /**
@@ -201,7 +201,7 @@ export interface TextTransformationConfig {
  * }
  * ```
  */
-export interface TextTransformationDescription {
+export interface TextTypingTransformationDescription {
 
 	/**
 	 * The string or regular expression to transform.

--- a/packages/ckeditor5-typing/src/utils/changebuffer.ts
+++ b/packages/ckeditor5-typing/src/utils/changebuffer.ts
@@ -23,7 +23,7 @@ import type { EventInfo } from '@ckeditor/ckeditor5-utils';
  * Batches represent single undo steps, hence changes added to one single batch are undone together.
  *
  * The buffer has a configurable limit of atomic changes that it can accommodate. After the limit was
- * exceeded (see {@link ~ChangeBuffer#input}), a new batch is created in {@link ~ChangeBuffer#batch}.
+ * exceeded (see {@link ~TypingChangeBuffer#input}), a new batch is created in {@link ~TypingChangeBuffer#batch}.
  *
  * To use the change buffer you need to let it know about the number of changes that were added to the batch:
  *
@@ -35,7 +35,7 @@ import type { EventInfo } from '@ckeditor/ckeditor5-utils';
  * buffer.input( insertedCharacters.length );
  * ```
  */
-export class ChangeBuffer {
+export class TypingChangeBuffer {
 	/**
 	 * The model instance.
 	 */

--- a/packages/ckeditor5-typing/tests/deletecommand.js
+++ b/packages/ckeditor5-typing/tests/deletecommand.js
@@ -5,7 +5,7 @@
 
 import { DeleteCommand } from '../src/deletecommand.js';
 import { Delete } from '../src/delete.js';
-import { ChangeBuffer } from '../src/utils/changebuffer.js';
+import { TypingChangeBuffer } from '../src/utils/changebuffer.js';
 
 import { ParagraphCommand } from '@ckeditor/ckeditor5-paragraph/src/paragraphcommand.js';
 import { VirtualTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor.js';
@@ -48,7 +48,7 @@ describe( 'DeleteCommand', () => {
 
 	describe( 'buffer', () => {
 		it( 'has buffer getter', () => {
-			expect( editor.commands.get( 'delete' ).buffer ).to.be.an.instanceof( ChangeBuffer );
+			expect( editor.commands.get( 'delete' ).buffer ).to.be.an.instanceof( TypingChangeBuffer );
 		} );
 
 		it( 'has a buffer limit configured to default value of 20', () => {

--- a/packages/ckeditor5-typing/tests/inserttextcommand.js
+++ b/packages/ckeditor5-typing/tests/inserttextcommand.js
@@ -8,7 +8,7 @@ import { ModelTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/modeltest
 import { testUtils } from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
 import { InsertTextCommand } from '../src/inserttextcommand.js';
-import { ChangeBuffer } from '../src/utils/changebuffer.js';
+import { TypingChangeBuffer } from '../src/utils/changebuffer.js';
 import { Input } from '../src/input.js';
 
 describe( 'InsertTextCommand', () => {
@@ -41,7 +41,7 @@ describe( 'InsertTextCommand', () => {
 
 	describe( 'buffer', () => {
 		it( 'has buffer getter', () => {
-			expect( editor.commands.get( 'insertText' ).buffer ).to.be.an.instanceof( ChangeBuffer );
+			expect( editor.commands.get( 'insertText' ).buffer ).to.be.an.instanceof( TypingChangeBuffer );
 		} );
 
 		it( 'has a buffer limit configured to default value of 20', () => {

--- a/packages/ckeditor5-typing/tests/utils/changebuffer.js
+++ b/packages/ckeditor5-typing/tests/utils/changebuffer.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import { ChangeBuffer } from '../../src/utils/changebuffer.js';
+import { TypingChangeBuffer } from '../../src/utils/changebuffer.js';
 import { Model } from '@ckeditor/ckeditor5-engine/src/model/model.js';
 import { Batch } from '@ckeditor/ckeditor5-engine/src/model/batch.js';
 
@@ -15,7 +15,7 @@ describe( 'ChangeBuffer', () => {
 		model = new Model();
 		doc = model.document;
 		root = doc.createRoot();
-		buffer = new ChangeBuffer( model, CHANGE_LIMIT );
+		buffer = new TypingChangeBuffer( model, CHANGE_LIMIT );
 	} );
 
 	describe( 'constructor()', () => {
@@ -27,7 +27,7 @@ describe( 'ChangeBuffer', () => {
 		} );
 
 		it( 'sets limit property according to default value', () => {
-			buffer = new ChangeBuffer( model );
+			buffer = new TypingChangeBuffer( model );
 
 			expect( buffer ).to.have.property( 'limit', 20 );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Added re-exports and renamed package members for `ckeditor5-typing`.

Part of https://github.com/ckeditor/ckeditor5/issues/18590.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
