### PR TITLE
Added re-exports and aligned naming in the `ckeditor5-link` package

### DIFF
--- a/docs/umberto.json
+++ b/docs/umberto.json
@@ -47,7 +47,7 @@
 		"api/module_html-embed_inserthtmlembedcommand-InsertHtmlEmbedCommand.html": "api/module_html-embed_htmlembedcommand-HtmlEmbedCommand.html",
 		"api/module_html-embed_updatehtmlembedcommand.html": "api/module_html-embed_htmlembedcommand.html",
 		"api/module_html-embed_updatehtmlembedcommand-UpdateHtmlEmbedCommand.html": "api/module_html-embed_htmlembedcommand-HtmlEmbedCommand.html",
-		"api/module_link_utils-ManualDecorator.html": "api/module_link_utils_manualdecorator-ManualDecorator.html",
+		"api/module_link_utils-ManualDecorator.html": "api/module_link_utils_manualdecorator-LinkManualDecorator.html",
 		"api/module_link_utils-AutomaticDecorators.html": "api/module_link_utils_automaticdecorators-AutomaticDecorators.html",
 		"api/module_list_checktodolistcommand.html": "api/module_list_todolist_checktodolistcommand.html",
 		"api/module_list_checktodolistcommand-CheckTodoListCommand.html": "api/module_list_todolist_checktodolistcommand-CheckTodoListCommand.html",

--- a/packages/ckeditor5-link/src/index.ts
+++ b/packages/ckeditor5-link/src/index.ts
@@ -23,13 +23,13 @@ export { LinkPropertiesView } from './ui/linkpropertiesview.js';
 export { LinkProviderItemsView } from './ui/linkprovideritemsview.js';
 
 export type { LinkPreviewButtonNavigateEvent } from './ui/linkpreviewbuttonview.js';
-export type { BackEvent } from './ui/linkpropertiesview.js';
-export type { CancelEvent as LinkProviderItemsViewCancelEvent } from './ui/linkprovideritemsview.js';
+export type { LinkPropertiesBackEvent } from './ui/linkpropertiesview.js';
+export type { LinkProvidersCancelEvent as LinkProviderItemsViewCancelEvent } from './ui/linkprovideritemsview.js';
 
 export type {
 	LinkFormValidatorCallback,
-	SubmitEvent,
-	CancelEvent as LinkFormViewCancelEvent
+	LinkFormSubmitEvent,
+	LinkFormCancelEvent as LinkFormViewCancelEvent
 } from './ui/linkformview.js';
 
 export {
@@ -55,7 +55,7 @@ export type {
 } from './utils.js';
 
 export { AutomaticDecorators } from './utils/automaticdecorators.js';
-export { ManualDecorator } from './utils/manualdecorator.js';
+export { LinkManualDecorator } from './utils/manualdecorator.js';
 
 export type {
 	LinkConfig,

--- a/packages/ckeditor5-link/src/index.ts
+++ b/packages/ckeditor5-link/src/index.ts
@@ -24,12 +24,12 @@ export { LinkProviderItemsView } from './ui/linkprovideritemsview.js';
 
 export type { LinkPreviewButtonNavigateEvent } from './ui/linkpreviewbuttonview.js';
 export type { LinkPropertiesBackEvent } from './ui/linkpropertiesview.js';
-export type { LinkProvidersCancelEvent as LinkProviderItemsViewCancelEvent } from './ui/linkprovideritemsview.js';
+export type { LinkProvidersCancelEvent } from './ui/linkprovideritemsview.js';
 
 export type {
 	LinkFormValidatorCallback,
 	LinkFormSubmitEvent,
-	LinkFormCancelEvent as LinkFormViewCancelEvent
+	LinkFormCancelEvent
 } from './ui/linkformview.js';
 
 export {

--- a/packages/ckeditor5-link/src/linkcommand.ts
+++ b/packages/ckeditor5-link/src/linkcommand.ts
@@ -14,7 +14,7 @@ import { LivePosition, type Range, type Item } from 'ckeditor5/src/engine.js';
 
 import { AutomaticDecorators } from './utils/automaticdecorators.js';
 import { extractTextFromLinkRange, isLinkableElement } from './utils.js';
-import { type ManualDecorator } from './utils/manualdecorator.js';
+import { type LinkManualDecorator } from './utils/manualdecorator.js';
 
 /**
  * The link command. It is used by the {@link module:link/link~Link link feature}.
@@ -29,12 +29,12 @@ export class LinkCommand extends Command {
 	declare public value: string | undefined;
 
 	/**
-	 * A collection of {@link module:link/utils/manualdecorator~ManualDecorator manual decorators}
+	 * A collection of {@link module:link/utils/manualdecorator~LinkManualDecorator manual decorators}
 	 * corresponding to the {@link module:link/linkconfig~LinkConfig#decorators decorator configuration}.
 	 *
 	 * You can consider it a model with states of manual decorators added to the currently selected link.
 	 */
-	public readonly manualDecorators = new Collection<ManualDecorator>();
+	public readonly manualDecorators = new Collection<LinkManualDecorator>();
 
 	/**
 	 * An instance of the helper that ties together all {@link module:link/linkconfig~LinkDecoratorAutomaticDefinition}
@@ -91,7 +91,7 @@ export class LinkCommand extends Command {
 	 *
 	 * There is an optional argument to this command that applies or removes model
 	 * {@glink framework/architecture/editing-engine#text-attributes text attributes} brought by
-	 * {@link module:link/utils/manualdecorator~ManualDecorator manual link decorators}.
+	 * {@link module:link/utils/manualdecorator~LinkManualDecorator manual link decorators}.
 	 *
 	 * Text attribute names in the model correspond to the entries in the {@link module:link/linkconfig~LinkConfig#decorators
 	 * configuration}.

--- a/packages/ckeditor5-link/src/linkediting.ts
+++ b/packages/ckeditor5-link/src/linkediting.ts
@@ -32,7 +32,7 @@ import { keyCodes, env } from 'ckeditor5/src/utils.js';
 
 import { LinkCommand } from './linkcommand.js';
 import { UnlinkCommand } from './unlinkcommand.js';
-import { ManualDecorator } from './utils/manualdecorator.js';
+import { LinkManualDecorator } from './utils/manualdecorator.js';
 import {
 	createLinkElement,
 	ensureSafeUrl,
@@ -206,7 +206,7 @@ export class LinkEditing extends Plugin {
 
 	/**
 	 * Processes an array of configured {@link module:link/linkconfig~LinkDecoratorManualDefinition manual decorators},
-	 * transforms them into {@link module:link/utils/manualdecorator~ManualDecorator} instances and stores them in the
+	 * transforms them into {@link module:link/utils/manualdecorator~LinkManualDecorator} instances and stores them in the
 	 * {@link module:link/linkcommand~LinkCommand#manualDecorators} collection (a model for manual decorators state).
 	 *
 	 * Also registers an {@link module:engine/conversion/downcasthelpers~DowncastHelpers#attributeToElement attribute-to-element}
@@ -226,7 +226,7 @@ export class LinkEditing extends Plugin {
 			editor.model.schema.extend( '$text', { allowAttributes: decoratorDefinition.id } );
 
 			// Keeps reference to manual decorator to decode its name to attributes during downcast.
-			const decorator = new ManualDecorator( decoratorDefinition );
+			const decorator = new LinkManualDecorator( decoratorDefinition );
 
 			manualDecorators.add( decorator );
 

--- a/packages/ckeditor5-link/src/linkimageediting.ts
+++ b/packages/ckeditor5-link/src/linkimageediting.ts
@@ -24,7 +24,7 @@ import {
 import { toMap } from 'ckeditor5/src/utils.js';
 
 import { LinkEditing } from './linkediting.js';
-import { type ManualDecorator } from './utils/manualdecorator.js';
+import { type LinkManualDecorator } from './utils/manualdecorator.js';
 import { type LinkCommand } from './linkcommand.js';
 
 import type { ImageUtils } from '@ckeditor/ckeditor5-image';
@@ -91,7 +91,7 @@ export class LinkImageEditing extends Plugin {
 	}
 
 	/**
-	 * Processes transformed {@link module:link/utils/manualdecorator~ManualDecorator} instances and attaches proper converters
+	 * Processes transformed {@link module:link/utils/manualdecorator~LinkManualDecorator} instances and attaches proper converters
 	 * that will work when linking an image.
 	 */
 	private _enableManualDecorators(): void {
@@ -239,7 +239,7 @@ function downcastImageLink( editor: Editor ): ( dispatcher: DowncastDispatcher )
 /**
  * Returns a converter that decorates the `<a>` element when the image is the link label.
  */
-function downcastImageLinkManualDecorator( decorator: ManualDecorator ): ( dispatcher: DowncastDispatcher ) => void {
+function downcastImageLinkManualDecorator( decorator: LinkManualDecorator ): ( dispatcher: DowncastDispatcher ) => void {
 	return dispatcher => {
 		dispatcher.on<DowncastAttributeEvent<Element>>( `attribute:${ decorator.id }:imageBlock`, ( evt, data, conversionApi ) => {
 			const viewFigure = conversionApi.mapper.toViewElement( data.item )!;
@@ -289,7 +289,7 @@ function downcastImageLinkManualDecorator( decorator: ManualDecorator ): ( dispa
 /**
  * Returns a converter that checks whether manual decorators should be applied to the link.
  */
-function upcastImageLinkManualDecorator( editor: Editor, decorator: ManualDecorator ): ( dispatcher: UpcastDispatcher ) => void {
+function upcastImageLinkManualDecorator( editor: Editor, decorator: LinkManualDecorator ): ( dispatcher: UpcastDispatcher ) => void {
 	const isImageInlinePluginLoaded = editor.plugins.has( 'ImageInlineEditing' );
 	const imageUtils: ImageUtils = editor.plugins.get( 'ImageUtils' );
 

--- a/packages/ckeditor5-link/src/ui/linkformview.ts
+++ b/packages/ckeditor5-link/src/ui/linkformview.ts
@@ -407,7 +407,7 @@ export type LinkFormValidatorCallback = ( form: LinkFormView ) => string | undef
  *
  * @eventName ~LinkFormView#submit
  */
-export type SubmitEvent = {
+export type LinkFormSubmitEvent = {
 	name: 'submit';
 	args: [];
 };
@@ -417,7 +417,7 @@ export type SubmitEvent = {
  *
  * @eventName ~LinkFormView#cancel
  */
-export type CancelEvent = {
+export type LinkFormCancelEvent = {
 	name: 'cancel';
 	args: [];
 };

--- a/packages/ckeditor5-link/src/ui/linkpropertiesview.ts
+++ b/packages/ckeditor5-link/src/ui/linkpropertiesview.ts
@@ -119,7 +119,7 @@ export class LinkPropertiesView extends View {
 
 		// Close the panel on esc key press when the **form has focus**.
 		this.keystrokes.set( 'Esc', ( data, cancel ) => {
-			this.fire<BackEvent>( 'back' );
+			this.fire<LinkPropertiesBackEvent>( 'back' );
 			cancel();
 		} );
 	}
@@ -230,7 +230,7 @@ export class LinkPropertiesView extends View {
  *
  * @eventName ~LinkPropertiesView#back
  */
-export type BackEvent = {
+export type LinkPropertiesBackEvent = {
 	name: 'back';
 	args: [];
 };

--- a/packages/ckeditor5-link/src/ui/linkprovideritemsview.ts
+++ b/packages/ckeditor5-link/src/ui/linkprovideritemsview.ts
@@ -139,7 +139,7 @@ export class LinkProviderItemsView extends View {
 
 		// Close the panel on esc key press when the **form has focus**.
 		this.keystrokes.set( 'Esc', ( data, cancel ) => {
-			this.fire<CancelEvent>( 'cancel' );
+			this.fire<LinkProvidersCancelEvent>( 'cancel' );
 			cancel();
 		} );
 
@@ -296,7 +296,7 @@ export class LinkProviderItemsView extends View {
  *
  * @eventName ~LinkProviderItemsView#cancel
  */
-export type CancelEvent = {
+export type LinkProvidersCancelEvent = {
 	name: 'cancel';
 	args: [];
 };

--- a/packages/ckeditor5-link/src/utils/manualdecorator.ts
+++ b/packages/ckeditor5-link/src/utils/manualdecorator.ts
@@ -12,11 +12,11 @@ import type { MatcherObjectPattern } from 'ckeditor5/src/engine.js';
 import type { NormalizedLinkDecoratorManualDefinition } from '../utils.js';
 
 /**
- * Helper class that stores manual decorators with observable {@link module:link/utils/manualdecorator~ManualDecorator#value}
+ * Helper class that stores manual decorators with observable {@link module:link/utils/manualdecorator~LinkManualDecorator#value}
  * to support integration with the UI state. An instance of this class is a model with the state of individual manual decorators.
  * These decorators are kept as collections in {@link module:link/linkcommand~LinkCommand#manualDecorators}.
  */
-export class ManualDecorator extends /* #__PURE__ */ ObservableMixin() {
+export class LinkManualDecorator extends /* #__PURE__ */ ObservableMixin() {
 	/**
 	 * An ID of a manual decorator which is the name of the attribute in the model, for example: 'linkManualDecorator0'.
 	 */
@@ -58,7 +58,7 @@ export class ManualDecorator extends /* #__PURE__ */ ObservableMixin() {
 	public styles?: Record<string, string>;
 
 	/**
-	 * Creates a new instance of {@link module:link/utils/manualdecorator~ManualDecorator}.
+	 * Creates a new instance of {@link module:link/utils/manualdecorator~LinkManualDecorator}.
 	 *
 	 * @param options The configuration object.
 	 */

--- a/packages/ckeditor5-link/tests/linkcommand.js
+++ b/packages/ckeditor5-link/tests/linkcommand.js
@@ -5,7 +5,7 @@
 
 import { ModelTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor.js';
 import { LinkCommand } from '../src/linkcommand.js';
-import { ManualDecorator } from '../src/utils/manualdecorator.js';
+import { LinkManualDecorator } from '../src/utils/manualdecorator.js';
 import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
 import { AutomaticDecorators } from '../src/utils/automaticdecorators.js';
 import { LinkEditing } from '../src/linkediting.js';
@@ -996,21 +996,21 @@ describe( 'LinkCommand', () => {
 					model = newEditor.model;
 					command = new LinkCommand( newEditor );
 
-					command.manualDecorators.add( new ManualDecorator( {
+					command.manualDecorators.add( new LinkManualDecorator( {
 						id: 'linkIsFoo',
 						label: 'Foo',
 						attributes: {
 							class: 'Foo'
 						}
 					} ) );
-					command.manualDecorators.add( new ManualDecorator( {
+					command.manualDecorators.add( new LinkManualDecorator( {
 						id: 'linkIsBar',
 						label: 'Bar',
 						attributes: {
 							target: '_blank'
 						}
 					} ) );
-					command.manualDecorators.add( new ManualDecorator( {
+					command.manualDecorators.add( new LinkManualDecorator( {
 						id: 'linkIsSth',
 						label: 'Sth',
 						attributes: {

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -29,7 +29,7 @@ import { LinkUI } from '../src/linkui.js';
 import { LinkFormView } from '../src/ui/linkformview.js';
 import { LinkPreviewButtonView } from '../src/ui/linkpreviewbuttonview.js';
 import { LinkPropertiesView } from '../src/ui/linkpropertiesview.js';
-import { ManualDecorator } from '../src/utils/manualdecorator.js';
+import { LinkManualDecorator } from '../src/utils/manualdecorator.js';
 import { MenuBarMenuListItemButtonView, ToolbarView } from '@ckeditor/ckeditor5-ui';
 
 describe( 'LinkUI', () => {
@@ -348,7 +348,7 @@ describe( 'LinkUI', () => {
 
 			beforeEach( () => {
 				button = editor.ui.componentFactory.create( 'linkProperties' );
-				editor.commands.get( 'link' ).manualDecorators.add( new ManualDecorator( {
+				editor.commands.get( 'link' ).manualDecorators.add( new LinkManualDecorator( {
 					id: 'linkIsBar',
 					label: 'Bar',
 					attributes: {
@@ -1219,7 +1219,7 @@ describe( 'LinkUI', () => {
 	describe( '_addPropertiesView()', () => {
 		beforeEach( () => {
 			editor.editing.view.document.isFocused = true;
-			editor.commands.get( 'link' ).manualDecorators.add( new ManualDecorator( {
+			editor.commands.get( 'link' ).manualDecorators.add( new LinkManualDecorator( {
 				id: 'linkIsBar',
 				label: 'Bar',
 				attributes: {
@@ -2864,7 +2864,7 @@ describe( 'LinkUI', () => {
 
 	describe( 'properties view', () => {
 		beforeEach( () => {
-			editor.commands.get( 'link' ).manualDecorators.add( new ManualDecorator( {
+			editor.commands.get( 'link' ).manualDecorators.add( new LinkManualDecorator( {
 				id: 'linkIsBar',
 				label: 'Bar',
 				attributes: {

--- a/packages/ckeditor5-link/tests/ui/linkpropertiesview.js
+++ b/packages/ckeditor5-link/tests/ui/linkpropertiesview.js
@@ -17,7 +17,7 @@ import {
 } from '@ckeditor/ckeditor5-ui';
 import { testUtils } from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
 import { LinkPropertiesView } from '../../src/ui/linkpropertiesview.js';
-import { ManualDecorator } from '../../src/utils/manualdecorator.js';
+import { LinkManualDecorator } from '../../src/utils/manualdecorator.js';
 
 const mockLocale = { t: val => val };
 
@@ -29,7 +29,7 @@ describe( 'LinkPropertiesView', () => {
 	beforeEach( () => {
 		collection = new Collection();
 
-		decorator1 = new ManualDecorator( {
+		decorator1 = new LinkManualDecorator( {
 			id: 'decorator1',
 			label: 'Foo',
 			attributes: {
@@ -37,7 +37,7 @@ describe( 'LinkPropertiesView', () => {
 			}
 		} );
 
-		decorator2 = new ManualDecorator( {
+		decorator2 = new LinkManualDecorator( {
 			id: 'decorator2',
 			label: 'Download',
 			attributes: {
@@ -46,7 +46,7 @@ describe( 'LinkPropertiesView', () => {
 			defaultValue: true
 		} );
 
-		decorator3 = new ManualDecorator( {
+		decorator3 = new LinkManualDecorator( {
 			id: 'decorator3',
 			label: 'Multi',
 			attributes: {

--- a/packages/ckeditor5-link/tests/utils/manualdecorator.js
+++ b/packages/ckeditor5-link/tests/utils/manualdecorator.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import { ManualDecorator } from '../../src/utils/manualdecorator.js';
+import { LinkManualDecorator } from '../../src/utils/manualdecorator.js';
 import { testUtils } from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
 
 describe( 'Manual Decorator', () => {
@@ -11,7 +11,7 @@ describe( 'Manual Decorator', () => {
 	testUtils.createSinonSandbox();
 
 	beforeEach( () => {
-		manualDecorator = new ManualDecorator( {
+		manualDecorator = new LinkManualDecorator( {
 			id: 'foo',
 			label: 'bar',
 			attributes: {
@@ -28,7 +28,7 @@ describe( 'Manual Decorator', () => {
 	} );
 
 	it( 'constructor with defaultValue', () => {
-		manualDecorator = new ManualDecorator( {
+		manualDecorator = new LinkManualDecorator( {
 			id: 'foo',
 			label: 'bar',
 			attributes: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (link): Added re-exports and aligned naming in the `ckeditor5-link` package.

---

### Additional information

Part of ckeditor/ckeditor5#18590.
