### PR TITLE
Added re-exports and aligned naming in the `ckeditor5-list` package

### DIFF
--- a/packages/ckeditor5-list/src/index.ts
+++ b/packages/ckeditor5-list/src/index.ts
@@ -9,7 +9,16 @@
 
 // List.
 export { List } from './list.js';
-export { ListEditing, type ListEditingPostFixerEvent, type ListType } from './list/listediting.js';
+
+export {
+	ListEditing,
+	type ListEditingPostFixerEvent,
+	type ListType,
+	type AttributeDowncastStrategy,
+	type ItemMarkerDowncastStrategy,
+	type DowncastStrategy
+} from './list/listediting.js';
+
 export { ListUtils } from './list/listutils.js';
 export { ListUI } from './list/listui.js';
 export { ListIndentCommand } from './list/listindentcommand.js';
@@ -120,6 +129,8 @@ export { listPropertiesUpcastConverter as _listPropertiesUpcastConverter } from 
 export type { AttributeStrategy as _ListAttributeConversionStrategy } from './listproperties/listpropertiesediting.js';
 export {
 	ListPropertiesView as _ListPropertiesView,
+	type ListPropertiesViewListStartEvent,
+	type ListPropertiesViewListReversedEvent,
 	type StylesView as _ListPropertiesStylesView
 } from './listproperties/ui/listpropertiesview.js';
 
@@ -138,6 +149,7 @@ export { TodoList } from './todolist.js';
 export { TodoListUI } from './todolist/todolistui.js';
 export { TodoListEditing } from './todolist/todolistediting.js';
 export { CheckTodoListCommand } from './todolist/checktodolistcommand.js';
+export type { ViewDocumentTodoCheckboxChangeEvent } from './todolist/todocheckboxchangeobserver.js';
 
 // Internal exports for 'todolist' submodule
 export { TodoCheckboxChangeObserver as _TodoCheckboxChangeObserver } from './todolist/todocheckboxchangeobserver.js';
@@ -162,7 +174,16 @@ export { LegacyTodoListEditing } from './legacytodolist/legacytodolistediting.js
 export { LegacyCheckTodoListCommand } from './legacytodolist/legacychecktodolistcommand.js';
 
 // Other.
-export type { ListConfig, ListPropertiesConfig } from './listconfig.js';
+export type {
+	ListConfig,
+	ListPropertiesConfig,
+	ListPropertiesStyleConfig,
+	ListPropertiesStyleListType,
+	ListStyleTypesConfig,
+	NumberedListStyleType,
+	BulletedListStyleType
+} from './listconfig.js';
+
 export { AdjacentListsSupport } from './list/adjacentlistssupport.js';
 
 import './augmentation.js';

--- a/packages/ckeditor5-list/src/legacylist/legacyconverters.ts
+++ b/packages/ckeditor5-list/src/legacylist/legacyconverters.ts
@@ -47,6 +47,7 @@ import {
  * It creates a `<ul><li></li><ul>` (or `<ol>`) view structure out of a `listItem` model element, inserts it at the correct
  * position, and merges the list with surrounding lists (if available).
  *
+ * @internal
  * @see module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:insert
  * @param model Model instance.
  */
@@ -75,6 +76,7 @@ export function modelViewInsertion( model: Model ): GetCallback<DowncastInsertEv
 /**
  * A model-to-view converter for the `listItem` model element removal.
  *
+ * @internal
  * @see module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:remove
  * @param model Model instance.
  * @returns Returns a conversion callback.
@@ -133,6 +135,7 @@ export function modelViewRemove( model: Model ): GetCallback<DowncastRemoveEvent
  * Splitting this conversion into 2 steps makes it possible to add an additional conversion in the middle.
  * Check {@link module:list/legacytodolist/legacytodolistconverters~modelViewChangeType} to see an example of it.
  *
+ * @internal
  * @see module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:attribute
  */
 export const modelViewChangeType: GetCallback<DowncastAttributeEvent<Element>> = ( evt, data, conversionApi ) => {
@@ -159,6 +162,7 @@ export const modelViewChangeType: GetCallback<DowncastAttributeEvent<Element>> =
 /**
  * A model-to-view converter that attempts to merge nodes split by {@link module:list/legacylist/legacyconverters~modelViewChangeType}.
  *
+ * @internal
  * @see module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:attribute
  */
 export const modelViewMergeAfterChangeType: GetCallback<DowncastAttributeEvent<Element>> = ( evt, data, conversionApi ) => {
@@ -176,6 +180,7 @@ export const modelViewMergeAfterChangeType: GetCallback<DowncastAttributeEvent<E
 /**
  * A model-to-view converter for the `listIndent` attribute change on the `listItem` model element.
  *
+ * @internal
  * @see module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:attribute
  * @param model Model instance.
  * @returns Returns a conversion callback.
@@ -245,6 +250,7 @@ export function modelViewChangeIndent( model: Model ): GetCallback<DowncastAttri
  * <listItem>bar</listItem>         <ul><li>foo</li><p>xxx</p><li>bar</li></ul>
  * ```
  *
+ * @internal
  * @see module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:insert
  */
 export const modelViewSplitOnInsert: GetCallback<DowncastInsertEvent<Element>> = ( evt, data, conversionApi ) => {
@@ -369,6 +375,7 @@ export const modelViewSplitOnInsert: GetCallback<DowncastInsertEvent<Element>> =
  *                                  </ul>
  * ```
  *
+ * @internal
  * @see module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:remove
  */
 export const modelViewMergeAfter: GetCallback<DowncastRemoveEvent> = ( evt, data, conversionApi ) => {
@@ -389,6 +396,7 @@ export const modelViewMergeAfter: GetCallback<DowncastRemoveEvent> = ( evt, data
  * * checks `<li>`'s parent,
  * * stores and increases the `conversionApi.store.indent` value when `<li>`'s sub-items are converted.
  *
+ * @internal
  * @see module:engine/conversion/upcastdispatcher~UpcastDispatcher#event:element
  */
 export const viewModelConverter: GetCallback<UpcastElementEvent> = ( evt, data, conversionApi ) => {
@@ -425,6 +433,7 @@ export const viewModelConverter: GetCallback<UpcastElementEvent> = ( evt, data, 
  * This is mostly to clean whitespaces from between the `<li>` view elements inside the view list element, however, also
  * incorrect data can be cleared if the view was incorrect.
  *
+ * @internal
  * @see module:engine/conversion/upcastdispatcher~UpcastDispatcher#event:element
  */
 export const cleanList: GetCallback<UpcastElementEvent> = ( evt, data, conversionApi ) => {
@@ -445,6 +454,7 @@ export const cleanList: GetCallback<UpcastElementEvent> = ( evt, data, conversio
 /**
  * A view-to-model converter for the `<li>` elements that cleans whitespace formatting from the input view.
  *
+ * @internal
  * @see module:engine/conversion/upcastdispatcher~UpcastDispatcher#event:element
  */
 export const cleanListItem: GetCallback<UpcastElementEvent> = ( evt, data, conversionApi ) => {
@@ -474,6 +484,8 @@ export const cleanListItem: GetCallback<UpcastElementEvent> = ( evt, data, conve
  * Returns a callback for model position to view position mapping for {@link module:engine/conversion/mapper~Mapper}. The callback fixes
  * positions between the `listItem` elements that would be incorrectly mapped because of how list items are represented in the model
  * and in the view.
+ *
+ * @internal
  */
 export function modelToViewPosition( view: EditingView ): GetCallback<MapperModelToViewPositionEvent> {
 	return ( evt, data ) => {
@@ -508,6 +520,7 @@ export function modelToViewPosition( view: EditingView ): GetCallback<MapperMode
  * positions between the `<li>` elements that would be incorrectly mapped because of how list items are represented in the model
  * and in the view.
  *
+ * @internal
  * @see module:engine/conversion/mapper~Mapper#event:viewToModelPosition
  * @param model Model instance.
  * @returns Returns a conversion callback.
@@ -592,6 +605,7 @@ export function viewToModelPosition( model: Model ): GetCallback<MapperViewToMod
  * <listItem listType="bulleted" listIndent=1>Item 3</listItem>   <--- note that indent got post-fixed.
  * ```
  *
+ * @internal
  * @param model The data model.
  * @param writer The writer to do changes with.
  * @returns `true` if any change has been applied, `false` otherwise.
@@ -784,6 +798,8 @@ export function modelChangePostFixer( model: Model, writer: Writer ): boolean {
  * <listItem listType="bulleted" listIndent=2>Y/listItem>
  * <listItem listType="bulleted" listIndent=2>C</listItem>
  * ```
+ *
+ * @internal
  */
 export const modelIndentPasteFixer: GetCallback<ModelInsertContentEvent> = function( evt, [ content, selectable ] ) {
 	const model = this as Model;

--- a/packages/ckeditor5-list/src/legacylist/legacyutils.ts
+++ b/packages/ckeditor5-list/src/legacylist/legacyutils.ts
@@ -25,6 +25,7 @@ import {
 /**
  * Creates a list item {@link module:engine/view/containerelement~ContainerElement}.
  *
+ * @internal
  * @param writer The writer instance.
  */
 export function createViewListItemElement( writer: DowncastWriter ): ViewContainerElement {
@@ -40,6 +41,7 @@ export function createViewListItemElement( writer: DowncastWriter ): ViewContain
  * Then, it binds the created view list item (`<li>`) with the model `listItem` element.
  * The function then returns the created view list item (`<li>`).
  *
+ * @internal
  * @param modelItem Model list item.
  * @param conversionApi Conversion interface.
  * @returns View list element.
@@ -65,6 +67,7 @@ export function generateLiInUl( modelItem: Item, conversionApi: DowncastConversi
  * should be in a view list element (`<ul>` or `<ol>`) and should be its only child.
  * See comments below to better understand the algorithm.
  *
+ * @internal
  * @param modelItem Model list item.
  * @param injectedItem
  * @param conversionApi Conversion interface.
@@ -187,6 +190,7 @@ export function injectViewList(
  * Helper function that takes two parameters that are expected to be view list elements, and merges them.
  * The merge happens only if both parameters are list elements of the same type (the same element name and the same class attributes).
  *
+ * @internal
  * @param viewWriter The writer instance.
  * @param firstList The first element to compare.
  * @param secondList The second element to compare.
@@ -224,6 +228,7 @@ export function mergeViewLists(
  * `<container:p>foo^<ui:span></ui:span><ui:span></ui:span>bar</container:p>`
  * For position ^, the position before "bar" will be returned.
  *
+ * @internal
  */
 export function positionAfterUiElements( viewPosition: ViewPosition ): ViewPosition {
 	return viewPosition.getLastMatchingPosition( value => value.item.is( 'uiElement' ) );
@@ -233,6 +238,7 @@ export function positionAfterUiElements( viewPosition: ViewPosition ): ViewPosit
  * Helper function that searches for a previous list item sibling of a given model item that meets the given criteria
  * passed by the options object.
  *
+ * @internal
  * @param options Search criteria.
  * @param options.sameIndent Whether the sought sibling should have the same indentation.
  * @param options.smallerIndent Whether the sought sibling should have a smaller indentation.
@@ -273,6 +279,8 @@ export function getSiblingListItem(
 
 /**
  * Returns a first list view element that is direct child of the given view element.
+ *
+ * @internal
  */
 export function findNestedList( viewElement: ViewElement ): ViewElement | null {
 	for ( const node of ( viewElement.getChildren() as Iterable<ViewElement> ) ) {
@@ -291,6 +299,7 @@ export function findNestedList( viewElement: ViewElement ): ViewElement | null {
  *
  * Additionally, if the `position` is inside a list item, that list item will be returned as well.
  *
+ * @internal
  * @param position Starting position.
  * @param direction Walking direction.
  */
@@ -424,6 +433,8 @@ const NUMBERED_LIST_STYLE_TYPES = [
 
 /**
  * Checks whether the given list-style-type is supported by numbered or bulleted list.
+ *
+ * @internal
  */
 export function getListTypeFromListStyleType( listStyleType: string ): 'bulleted' | 'numbered' | null {
 	if ( BULLETED_LIST_STYLE_TYPES.includes( listStyleType ) ) {

--- a/packages/ckeditor5-list/src/legacytodolist/legacytodolistconverters.ts
+++ b/packages/ckeditor5-list/src/legacytodolist/legacytodolistconverters.ts
@@ -31,6 +31,7 @@ import { generateLiInUl, injectViewList, positionAfterUiElements, findNestedList
  *
  * It is used by {@link module:engine/controller/editingcontroller~EditingController}.
  *
+ * @internal
  * @see module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:insert
  * @param model Model instance.
  * @param onCheckboxChecked Callback function.
@@ -84,6 +85,7 @@ export function modelViewInsertion(
  *
  * It is used by {@link module:engine/controller/datacontroller~DataController}.
  *
+ * @internal
  * @see module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:insert
  * @param model Model instance.
  * @returns Returns a conversion callback.
@@ -148,6 +150,7 @@ export function dataModelViewInsertion( model: Model ): GetCallback<DowncastInse
  *
  * It is used by {@link module:engine/controller/datacontroller~DataController}.
  *
+ * @internal
  * @see module:engine/conversion/upcastdispatcher~UpcastDispatcher#event:element
  */
 export const dataViewModelCheckmarkInsertion: GetCallback<UpcastElementEvent> = ( evt, data, conversionApi ) => {
@@ -187,6 +190,7 @@ export const dataViewModelCheckmarkInsertion: GetCallback<UpcastElementEvent> = 
  *
  * It is used by {@link module:engine/controller/editingcontroller~EditingController}.
  *
+ * @internal
  * @see module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:attribute
  * @param onCheckedChange Callback fired after clicking the checkbox UI element.
  * @param view Editing view controller.
@@ -243,6 +247,7 @@ export function modelViewChangeType(
  *
  * It is used by {@link module:engine/controller/editingcontroller~EditingController}.
  *
+ * @internal
  * @see module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:attribute
  * @param onCheckedChange Callback fired after clicking the checkbox UI element.
  * @returns Returns a conversion callback.
@@ -279,6 +284,8 @@ export function modelViewChangeChecked(
  * This helper ensures that position inside todo-list in the view is mapped after the checkbox.
  *
  * It only handles the position at the beginning of a list item as other positions are properly mapped be the default mapper.
+ *
+ * @internal
  */
 export function mapModelToViewPosition( view: EditingView ): GetCallback<MapperModelToViewPositionEvent> {
 	return ( evt, data ) => {

--- a/packages/ckeditor5-list/src/list/listediting.ts
+++ b/packages/ckeditor5-list/src/list/listediting.ts
@@ -968,7 +968,6 @@ function shouldMergeOnBlocksContentLevel( model: Model, direction: 'backward' | 
  *
  * It allows triggering a re-wrapping of a list item.
  *
- * @internal
  * @eventName ~ListEditing#postFixer
  * @param listHead The head element of a list.
  * @param writer The writer to do changes with.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (list): Added re-exports and aligned naming in the `ckeditor5-list` package.

---

### Additional information

Part of ckeditor/ckeditor5#18590.