### PR TITLE
Added re-exports and aligned naming in the `ckeditor5-markdown-gfm` package

### DIFF
--- a/packages/ckeditor5-code-block/tests/codeblock-integration.js
+++ b/packages/ckeditor5-code-block/tests/codeblock-integration.js
@@ -6,7 +6,7 @@
 import { ClassicTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
 import { Enter } from '@ckeditor/ckeditor5-enter/src/enter.js';
 import { Paragraph } from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
-import { GFMDataProcessor } from '@ckeditor/ckeditor5-markdown-gfm/src/gfmdataprocessor.js';
+import { MarkdownGfmDataProcessor } from '@ckeditor/ckeditor5-markdown-gfm/src/gfmdataprocessor.js';
 import { Plugin } from '@ckeditor/ckeditor5-core/src/plugin.js';
 import { ImageInlineEditing } from '@ckeditor/ckeditor5-image/src/image/imageinlineediting.js';
 import { ListEditing } from '@ckeditor/ckeditor5-list/src/list/listediting.js';
@@ -30,7 +30,7 @@ describe( 'CodeBlock - integration', () => {
 		class CodeBlockIntegration extends Plugin {
 			constructor( editor ) {
 				super( editor );
-				editor.data.processor = new GFMDataProcessor( editor.data.viewDocument );
+				editor.data.processor = new MarkdownGfmDataProcessor( editor.data.viewDocument );
 			}
 		}
 

--- a/packages/ckeditor5-markdown-gfm/docs/api/markdown-gfm.md
+++ b/packages/ckeditor5-markdown-gfm/docs/api/markdown-gfm.md
@@ -14,7 +14,7 @@ Check out the {@link features/markdown#demo demo in the Markdown output feature 
 
 ## Documentation
 
-See the {@link features/markdown Markdown output guide} and the {@link module:markdown-gfm/gfmdataprocessor~GFMDataProcessor} documentation. Read the {@link features/paste-markdown Paste Markdown feature guide} and the {@link module:markdown-gfm/pastefrommarkdownexperimental~PasteFromMarkdownExperimental} documentation.
+See the {@link features/markdown Markdown output guide} and the {@link module:markdown-gfm/gfmdataprocessor~MarkdownGfmDataProcessor} documentation. Read the {@link features/paste-markdown Paste Markdown feature guide} and the {@link module:markdown-gfm/pastefrommarkdownexperimental~PasteFromMarkdownExperimental} documentation.
 
 ## Installation
 

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -35,7 +35,7 @@ Please remember that Markdown syntax is really simple and it does not cover all 
 	Starting with {@link updating/update-to-42 version 42.0.0}, we changed the format of import paths. This guide uses the new, shorter format. Refer to the {@link getting-started/legacy-getting-started/legacy-imports Packages in the legacy setup} guide if you use an older version of CKEditor&nbsp;5.
 </info-box>
 
-After {@link getting-started/integrations-cdn/quick-start installing the editor}, add the {@link module:markdown-gfm/markdown~Markdown} plugin to the editor configuration. It will change the default {@link module:engine/dataprocessor/dataprocessor~DataProcessor data processor} to the {@link module:markdown-gfm/gfmdataprocessor~GFMDataProcessor}:
+After {@link getting-started/integrations-cdn/quick-start installing the editor}, add the {@link module:markdown-gfm/markdown~Markdown} plugin to the editor configuration. It will change the default {@link module:engine/dataprocessor/dataprocessor~DataProcessor data processor} to the {@link module:markdown-gfm/gfmdataprocessor~MarkdownGfmDataProcessor}:
 
 <code-switcher>
 ```js
@@ -63,7 +63,7 @@ If you need more extensive Markdown support for formatting elements (for example
 
 ## The Markdown data processor
 
-The Markdown plugin uses a {@link module:engine/dataprocessor/dataprocessor~DataProcessor data processor} (implemented by the {@link module:markdown-gfm/gfmdataprocessor~GFMDataProcessor} class) which changes the default output from HTML to Markdown. This means that you can {@link module:core/editor/editor~Editor#setData set} or {@link module:core/editor/editor~Editor#getData get} data from the editor in the Markdown format:
+The Markdown plugin uses a {@link module:engine/dataprocessor/dataprocessor~DataProcessor data processor} (implemented by the {@link module:markdown-gfm/gfmdataprocessor~MarkdownGfmDataProcessor} class) which changes the default output from HTML to Markdown. This means that you can {@link module:core/editor/editor~Editor#setData set} or {@link module:core/editor/editor~Editor#getData get} data from the editor in the Markdown format:
 
 ```js
 editor.getData(); // -> 'This is [CKEditor&nbsp;5](https://ckeditor.com).'

--- a/packages/ckeditor5-markdown-gfm/src/gfmdataprocessor.ts
+++ b/packages/ckeditor5-markdown-gfm/src/gfmdataprocessor.ts
@@ -15,15 +15,15 @@ import {
 	type MatcherPattern
 } from 'ckeditor5/src/engine.js';
 
-import { MarkdownToHtml } from './markdown2html/markdown2html.js';
-import { HtmlToMarkdown } from './html2markdown/html2markdown.js';
+import { MarkdownGfmMdToHtml } from './markdown2html/markdown2html.js';
+import { MarkdownGfmHtmlToMd } from './html2markdown/html2markdown.js';
 
 /**
  * This data processor implementation uses GitHub Flavored Markdown as input/output data.
  *
  * See the {@glink features/markdown Markdown output} guide to learn more on how to enable it.
  */
-export class GFMDataProcessor implements DataProcessor {
+export class MarkdownGfmDataProcessor implements DataProcessor {
 	/**
 	 * HTML data processor used to process HTML produced by the Markdown-to-HTML converter and the other way.
 	 */
@@ -32,20 +32,20 @@ export class GFMDataProcessor implements DataProcessor {
 	/**
 	 * Helper for converting Markdown to HTML.
 	 */
-	private _markdown2html: MarkdownToHtml;
+	private _markdown2html: MarkdownGfmMdToHtml;
 
 	/**
 	 * Helper for converting HTML to Markdown.
 	 */
-	private _html2markdown: HtmlToMarkdown;
+	private _html2markdown: MarkdownGfmHtmlToMd;
 
 	/**
 	 * Creates a new instance of the Markdown data processor class.
 	 */
 	constructor( document: ViewDocument ) {
 		this._htmlDP = new HtmlDataProcessor( document );
-		this._markdown2html = new MarkdownToHtml();
-		this._html2markdown = new HtmlToMarkdown();
+		this._markdown2html = new MarkdownGfmMdToHtml();
+		this._html2markdown = new MarkdownGfmHtmlToMd();
 	}
 
 	/**

--- a/packages/ckeditor5-markdown-gfm/src/html2markdown/html2markdown.ts
+++ b/packages/ckeditor5-markdown-gfm/src/html2markdown/html2markdown.ts
@@ -126,7 +126,7 @@ class UpdatedTurndown extends Turndown {
 /**
  * This is a helper class used by the {@link module:markdown-gfm/markdown Markdown feature} to convert HTML to Markdown.
  */
-export class HtmlToMarkdown {
+export class MarkdownGfmHtmlToMd {
 	private _parser: UpdatedTurndown;
 
 	constructor() {

--- a/packages/ckeditor5-markdown-gfm/src/index.ts
+++ b/packages/ckeditor5-markdown-gfm/src/index.ts
@@ -9,7 +9,8 @@
 
 export { Markdown } from './markdown.js';
 export { PasteFromMarkdownExperimental } from './pastefrommarkdownexperimental.js';
-export { GFMDataProcessor } from './gfmdataprocessor.js';
-export { MarkdownToHtml } from './markdown2html/markdown2html.js';
+export { MarkdownGfmDataProcessor } from './gfmdataprocessor.js';
+export { MarkdownGfmMdToHtml } from './markdown2html/markdown2html.js';
+export { MarkdownGfmHtmlToMd } from './html2markdown/html2markdown.js';
 
 import './augmentation.js';

--- a/packages/ckeditor5-markdown-gfm/src/markdown.ts
+++ b/packages/ckeditor5-markdown-gfm/src/markdown.ts
@@ -8,7 +8,7 @@
  */
 
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
-import { GFMDataProcessor } from './gfmdataprocessor.js';
+import { MarkdownGfmDataProcessor } from './gfmdataprocessor.js';
 
 /**
  * The GitHub Flavored Markdown (GFM) plugin.
@@ -22,7 +22,7 @@ export class Markdown extends Plugin {
 	constructor( editor: Editor ) {
 		super( editor );
 
-		editor.data.processor = new GFMDataProcessor( editor.data.viewDocument );
+		editor.data.processor = new MarkdownGfmDataProcessor( editor.data.viewDocument );
 	}
 
 	/**

--- a/packages/ckeditor5-markdown-gfm/src/markdown2html/markdown2html.ts
+++ b/packages/ckeditor5-markdown-gfm/src/markdown2html/markdown2html.ts
@@ -12,7 +12,7 @@ import { marked } from 'marked';
 /**
  * This is a helper class used by the {@link module:markdown-gfm/markdown Markdown feature} to convert Markdown to HTML.
  */
-export class MarkdownToHtml {
+export class MarkdownGfmMdToHtml {
 	private _parser: typeof marked;
 
 	private _options = {

--- a/packages/ckeditor5-markdown-gfm/src/pastefrommarkdownexperimental.ts
+++ b/packages/ckeditor5-markdown-gfm/src/pastefrommarkdownexperimental.ts
@@ -9,7 +9,7 @@
 
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
 import { ClipboardPipeline, type ClipboardInputTransformationEvent } from 'ckeditor5/src/clipboard.js';
-import { GFMDataProcessor } from './gfmdataprocessor.js';
+import { MarkdownGfmDataProcessor } from './gfmdataprocessor.js';
 import type { ViewDocumentKeyDownEvent } from 'ckeditor5/src/engine.js';
 
 const ALLOWED_MARKDOWN_FIRST_LEVEL_TAGS = [ 'SPAN', 'BR', 'PRE', 'CODE' ];
@@ -23,7 +23,7 @@ export class PasteFromMarkdownExperimental extends Plugin {
 	/**
 	 * @internal
 	 */
-	private _gfmDataProcessor: GFMDataProcessor;
+	private _gfmDataProcessor: MarkdownGfmDataProcessor;
 
 	/**
 	 * @inheritDoc
@@ -31,7 +31,7 @@ export class PasteFromMarkdownExperimental extends Plugin {
 	constructor( editor: Editor ) {
 		super( editor );
 
-		this._gfmDataProcessor = new GFMDataProcessor( editor.data.viewDocument );
+		this._gfmDataProcessor = new MarkdownGfmDataProcessor( editor.data.viewDocument );
 	}
 
 	/**

--- a/packages/ckeditor5-markdown-gfm/tests/_utils/utils.js
+++ b/packages/ckeditor5-markdown-gfm/tests/_utils/utils.js
@@ -3,13 +3,13 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import { GFMDataProcessor } from '../../src/gfmdataprocessor.js';
+import { MarkdownGfmDataProcessor } from '../../src/gfmdataprocessor.js';
 import { stringify } from '@ckeditor/ckeditor5-engine/src/dev-utils/view.js';
 import { ViewDocument } from '@ckeditor/ckeditor5-engine/src/view/document.js';
 import { StylesProcessor } from '@ckeditor/ckeditor5-engine/src/view/stylesmap.js';
 
 /**
- * Tests GFMDataProcessor.
+ * Tests MarkdownGfmDataProcessor.
  *
  * @param {String} markdown Markdown to be processed to view.
  * @param {String} viewString Expected view structure.
@@ -22,7 +22,7 @@ import { StylesProcessor } from '@ckeditor/ckeditor5-engine/src/view/stylesmap.j
 export function testDataProcessor( markdown, viewString, normalizedMarkdown, options ) {
 	const viewDocument = new ViewDocument( new StylesProcessor() );
 
-	const dataProcessor = new GFMDataProcessor( viewDocument );
+	const dataProcessor = new MarkdownGfmDataProcessor( viewDocument );
 
 	if ( options && options.setup ) {
 		options.setup( dataProcessor );

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/blockquotes.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/blockquotes.js
@@ -5,7 +5,7 @@
 
 import { testDataProcessor } from '../_utils/utils.js';
 
-describe( 'GFMDataProcessor', () => {
+describe( 'MarkdownGfmDataProcessor', () => {
 	describe( 'blockquotes', () => {
 		it( 'should process single blockquotes', () => {
 			testDataProcessor(

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/code.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/code.js
@@ -5,7 +5,7 @@
 
 import { testDataProcessor } from '../_utils/utils.js';
 
-describe( 'GFMDataProcessor', () => {
+describe( 'MarkdownGfmDataProcessor', () => {
 	describe( 'code', () => {
 		it( 'should process inline code', () => {
 			testDataProcessor(

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/escaping.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/escaping.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import { GFMDataProcessor } from '../../src/gfmdataprocessor.js';
+import { MarkdownGfmDataProcessor } from '../../src/gfmdataprocessor.js';
 import { stringify } from '@ckeditor/ckeditor5-engine/src/dev-utils/view.js';
 import { testDataProcessor } from '../../tests/_utils/utils.js';
 import { ViewDocument } from '@ckeditor/ckeditor5-engine/src/view/document.js';
@@ -26,14 +26,14 @@ const testCases = {
 	'minus': { test: '\\-', result: '-' }
 };
 
-describe( 'GFMDataProcessor', () => {
+describe( 'MarkdownGfmDataProcessor', () => {
 	describe( 'escaping', () => {
 		describe( 'toView', () => {
 			let dataProcessor;
 
 			beforeEach( () => {
 				const viewDocument = new ViewDocument( new StylesProcessor() );
-				dataProcessor = new GFMDataProcessor( viewDocument );
+				dataProcessor = new MarkdownGfmDataProcessor( viewDocument );
 			} );
 
 			for ( const key in testCases ) {

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/gfmdataprocessor.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/gfmdataprocessor.js
@@ -3,16 +3,16 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import { GFMDataProcessor } from '../../src/gfmdataprocessor.js';
+import { MarkdownGfmDataProcessor } from '../../src/gfmdataprocessor.js';
 import { ViewDocument } from '@ckeditor/ckeditor5-engine/src/view/document.js';
 import { StylesProcessor } from '@ckeditor/ckeditor5-engine/src/view/stylesmap.js';
 
-describe( 'GFMDataProcessor', () => {
+describe( 'MarkdownGfmDataProcessor', () => {
 	let dataProcessor, viewDocument;
 
 	beforeEach( () => {
 		viewDocument = new ViewDocument( new StylesProcessor() );
-		dataProcessor = new GFMDataProcessor( viewDocument );
+		dataProcessor = new MarkdownGfmDataProcessor( viewDocument );
 	} );
 
 	describe( 'useFillerType()', () => {

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/headers.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/headers.js
@@ -5,7 +5,7 @@
 
 import { testDataProcessor } from '../_utils/utils.js';
 
-describe( 'GFMDataProcessor', () => {
+describe( 'MarkdownGfmDataProcessor', () => {
 	describe( 'headers', () => {
 		it( 'should process level 1 header #1', () => {
 			testDataProcessor(

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/horizontal-rules.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/horizontal-rules.js
@@ -5,7 +5,7 @@
 
 import { testDataProcessor } from '../_utils/utils.js';
 
-describe( 'GFMDataProcessor', () => {
+describe( 'MarkdownGfmDataProcessor', () => {
 	// Horizontal rules are always rendered by GitHub as <hr> and normalized when converting
 	// back to ---.
 	describe( 'horizontal rules', () => {

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/html.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/html.js
@@ -5,7 +5,7 @@
 
 import { testDataProcessor } from '../_utils/utils.js';
 
-describe( 'GFMDataProcessor', () => {
+describe( 'MarkdownGfmDataProcessor', () => {
 	describe( 'html', () => {
 		it( 'should keep html', () => {
 			testDataProcessor(

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/images.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/images.js
@@ -5,7 +5,7 @@
 
 import { testDataProcessor } from '../_utils/utils.js';
 
-describe( 'GFMDataProcessor', () => {
+describe( 'MarkdownGfmDataProcessor', () => {
 	describe( 'images', () => {
 		it( 'should process images', () => {
 			testDataProcessor(

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/links.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/links.js
@@ -5,7 +5,7 @@
 
 import { testDataProcessor } from '../_utils/utils.js';
 
-describe( 'GFMDataProcessor', () => {
+describe( 'MarkdownGfmDataProcessor', () => {
 	describe( 'links', () => {
 		it( 'should not autolink', () => {
 			testDataProcessor(

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/lists.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/lists.js
@@ -4,12 +4,12 @@
  */
 
 import { testDataProcessor } from '../_utils/utils.js';
-import { GFMDataProcessor } from '../../src/gfmdataprocessor.js';
+import { MarkdownGfmDataProcessor } from '../../src/gfmdataprocessor.js';
 import { HtmlDataProcessor } from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor.js';
 import { ViewDocument } from '@ckeditor/ckeditor5-engine/src/view/document.js';
 import { StylesProcessor } from '@ckeditor/ckeditor5-engine/src/view/stylesmap.js';
 
-describe( 'GFMDataProcessor', () => {
+describe( 'MarkdownGfmDataProcessor', () => {
 	describe( 'lists', () => {
 		it( 'should process tight asterisks', () => {
 			testDataProcessor(
@@ -367,7 +367,7 @@ describe( 'GFMDataProcessor', () => {
 			const viewDocument = new ViewDocument( new StylesProcessor() );
 
 			const htmlDataProcessor = new HtmlDataProcessor( viewDocument );
-			const mdDataProcessor = new GFMDataProcessor( viewDocument );
+			const mdDataProcessor = new MarkdownGfmDataProcessor( viewDocument );
 
 			const viewFragment = htmlDataProcessor.toView(
 				'<ul class="todo-list">' +

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/paragraphs.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/paragraphs.js
@@ -5,7 +5,7 @@
 
 import { testDataProcessor } from '../_utils/utils.js';
 
-describe( 'GFMDataProcessor', () => {
+describe( 'MarkdownGfmDataProcessor', () => {
 	describe( 'paragraphs', () => {
 		it( 'single line', () => {
 			testDataProcessor(

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/strikethrough.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/strikethrough.js
@@ -5,7 +5,7 @@
 
 import { testDataProcessor } from '../_utils/utils.js';
 
-describe( 'GFMDataProcessor', () => {
+describe( 'MarkdownGfmDataProcessor', () => {
 	describe( 'Strikethrough', () => {
 		it( 'should process strikethrough text', () => {
 			testDataProcessor(

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/strong-emphasis.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/strong-emphasis.js
@@ -5,7 +5,7 @@
 
 import { testDataProcessor } from '../_utils/utils.js';
 
-describe( 'GFMDataProcessor', () => {
+describe( 'MarkdownGfmDataProcessor', () => {
 	describe( 'strong and emphasis', () => {
 		it( 'should process strong', () => {
 			testDataProcessor(

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/tables.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/tables.js
@@ -5,7 +5,7 @@
 
 import { testDataProcessor } from '../_utils/utils.js';
 
-describe( 'GFMDataProcessor', () => {
+describe( 'MarkdownGfmDataProcessor', () => {
 	describe( 'tables', () => {
 		it( 'should process tables', () => {
 			testDataProcessor(

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/tabs.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/tabs.js
@@ -5,7 +5,7 @@
 
 import { testDataProcessor } from '../_utils/utils.js';
 
-describe( 'GFMDataProcessor', () => {
+describe( 'MarkdownGfmDataProcessor', () => {
 	describe( 'tabs', () => {
 		it( 'should process list item with tabs', () => {
 			testDataProcessor(

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/text.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/text.js
@@ -5,7 +5,7 @@
 
 import { testDataProcessor } from '../_utils/utils.js';
 
-describe( 'GFMDataProcessor', () => {
+describe( 'MarkdownGfmDataProcessor', () => {
 	describe( 'text', () => {
 		describe( 'urls', () => {
 			it( 'should not escape urls', () => {

--- a/packages/ckeditor5-markdown-gfm/tests/manual/gfmdataprocessor/gfmdataprocessor.js
+++ b/packages/ckeditor5-markdown-gfm/tests/manual/gfmdataprocessor/gfmdataprocessor.js
@@ -7,11 +7,11 @@ import { Document } from '@ckeditor/ckeditor5-engine/src/view/document.js';
 import { StylesProcessor } from '@ckeditor/ckeditor5-engine/src/view/stylesmap.js';
 import { stringify, parse } from '@ckeditor/ckeditor5-engine/src/dev-utils/view.js';
 
-import { GFMDataProcessor } from '../../../src/gfmdataprocessor.js';
+import { MarkdownGfmDataProcessor } from '../../../src/gfmdataprocessor.js';
 
 const markdownTextArea = document.getElementById( 'markdown' );
 const viewTextArea = document.getElementById( 'view' );
-const dataProcessor = new GFMDataProcessor( new Document( new StylesProcessor() ) );
+const dataProcessor = new MarkdownGfmDataProcessor( new Document( new StylesProcessor() ) );
 
 document.getElementById( 'button_to_view' ).addEventListener( 'click', convertToView );
 document.getElementById( 'button_to_md' ).addEventListener( 'click', convertToMarkdown );

--- a/packages/ckeditor5-markdown-gfm/tests/markdown.js
+++ b/packages/ckeditor5-markdown-gfm/tests/markdown.js
@@ -4,7 +4,7 @@
  */
 
 import { Markdown } from '../src/markdown.js';
-import { GFMDataProcessor } from '../src/gfmdataprocessor.js';
+import { MarkdownGfmDataProcessor } from '../src/gfmdataprocessor.js';
 import { ClassicTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
 
 describe( 'Markdown', () => {
@@ -26,7 +26,7 @@ describe( 'Markdown', () => {
 				plugins: [ Markdown ]
 			} )
 			.then( editor => {
-				expect( editor.data.processor ).to.be.an.instanceof( GFMDataProcessor );
+				expect( editor.data.processor ).to.be.an.instanceof( MarkdownGfmDataProcessor );
 
 				return editor.destroy(); // Tests cleanup.
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (markdown-gfm): Added re-exports and aligned naming in the `ckeditor5-markdown-gfm` package.

Internal (code-block): Aligned to renames from the `ckeditor5-markdown-gfm` package.

---

### Additional information

Part of ckeditor/ckeditor5#18590.
