### PR TITLE
Added re-exports and aligned naming in the `ckeditor5-mention` package

### DIFF
--- a/packages/ckeditor5-emoji/src/emojimention.ts
+++ b/packages/ckeditor5-emoji/src/emojimention.ts
@@ -10,7 +10,7 @@
 import { logWarning, type LocaleTranslate } from 'ckeditor5/src/utils.js';
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
 import { Typing } from 'ckeditor5/src/typing.js';
-import type { MentionFeed, MentionFeedObjectItem, ItemRenderer } from '@ckeditor/ckeditor5-mention';
+import type { MentionFeed, MentionFeedObjectItem, MentionItemRenderer } from '@ckeditor/ckeditor5-mention';
 
 import { EmojiRepository } from './emojirepository.js';
 import { type EmojiPicker } from './emojipicker.js';
@@ -152,7 +152,7 @@ export class EmojiMention extends Plugin {
 	/**
 	 * Returns the `itemRenderer()` callback for mention config.
 	 */
-	private _customItemRendererFactory( t: LocaleTranslate ): ItemRenderer {
+	private _customItemRendererFactory( t: LocaleTranslate ): MentionItemRenderer {
 		return ( item: MentionFeedObjectItem ) => {
 			const itemElement = document.createElement( 'button' );
 

--- a/packages/ckeditor5-mention/src/index.ts
+++ b/packages/ckeditor5-mention/src/index.ts
@@ -7,15 +7,22 @@
  * @module mention
  */
 
-export { Mention } from './mention.js';
+export { Mention, type MentionAttribute } from './mention.js';
 export { MentionEditing } from './mentionediting.js';
 export { MentionUI } from './mentionui.js';
 export { MentionsView } from './ui/mentionsview.js';
 export { MentionListItemView } from './ui/mentionlistitemview.js';
-export { DomWrapperView } from './ui/domwrapperview.js';
+export { MentionDomWrapperView } from './ui/domwrapperview.js';
 export { MentionCommand } from './mentioncommand.js';
 
-export type { MentionConfig, MentionFeed, ItemRenderer, MentionFeedObjectItem } from './mentionconfig.js';
+export type {
+	MentionConfig,
+	MentionFeed,
+	MentionFeedItem,
+	MentionItemRenderer,
+	MentionFeedObjectItem,
+	MentionFeedbackCallback
+} from './mentionconfig.js';
 
 export { createRegExp as _createMentionMarkerRegExp } from './mentionui.js';
 export {

--- a/packages/ckeditor5-mention/src/mentionconfig.ts
+++ b/packages/ckeditor5-mention/src/mentionconfig.ts
@@ -180,7 +180,7 @@ export interface MentionFeed {
 	 * a static configuration (the mention feature will show matching items automatically) or a function which returns an array of
 	 * matching items (directly, or via a promise). If a function is passed, it is executed in the context of the editor instance.
 	 */
-	feed: Array<MentionFeedItem> | FeedCallback;
+	feed: Array<MentionFeedItem> | MentionFeedbackCallback;
 
 	/**
 	 * Specifies after how many characters the autocomplete panel should be shown.
@@ -193,7 +193,7 @@ export interface MentionFeed {
 	 * A function that renders a {@link module:mention/mentionconfig~MentionFeedItem}
 	 * to the autocomplete panel.
 	 */
-	itemRenderer?: ItemRenderer;
+	itemRenderer?: MentionItemRenderer;
 
 	/**
 	 * Specify how many available elements per feeds will the users be able to see in the dropdown list.
@@ -205,12 +205,12 @@ export interface MentionFeed {
 /**
  * Function that renders an array of {@link module:mention/mentionconfig~MentionFeedItem} based on string input.
  */
-export type FeedCallback = ( searchString: string ) => Array<MentionFeedItem> | Promise<Array<MentionFeedItem>>;
+export type MentionFeedbackCallback = ( searchString: string ) => Array<MentionFeedItem> | Promise<Array<MentionFeedItem>>;
 
 /**
  * Function that takes renders a {@link module:mention/mentionconfig~MentionFeedObjectItem} as HTMLElement.
  */
-export type ItemRenderer = ( item: MentionFeedObjectItem ) => HTMLElement | string;
+export type MentionItemRenderer = ( item: MentionFeedObjectItem ) => HTMLElement | string;
 
 /**
  * The mention feed item. It may be defined as a string or a plain object.

--- a/packages/ckeditor5-mention/src/mentionui.ts
+++ b/packages/ckeditor5-mention/src/mentionui.ts
@@ -39,14 +39,14 @@ import { TextWatcher, type TextWatcherMatchedEvent } from 'ckeditor5/src/typing.
 import { debounce } from 'es-toolkit/compat';
 
 import { MentionsView } from './ui/mentionsview.js';
-import { DomWrapperView } from './ui/domwrapperview.js';
+import { MentionDomWrapperView } from './ui/domwrapperview.js';
 import { MentionListItemView } from './ui/mentionlistitemview.js';
 
 import type {
-	FeedCallback,
+	MentionFeedbackCallback,
 	MentionFeed,
 	MentionFeedItem,
-	ItemRenderer,
+	MentionItemRenderer,
 	MentionFeedObjectItem
 } from './mentionconfig.js';
 
@@ -302,7 +302,7 @@ export class MentionUI extends Plugin {
 	/**
 	 * Returns item renderer for the marker.
 	 */
-	private _getItemRenderer( marker: string ): ItemRenderer | undefined {
+	private _getItemRenderer( marker: string ): MentionItemRenderer | undefined {
 		const { itemRenderer } = this._mentionsConfigurations.get( marker )!;
 
 		return itemRenderer;
@@ -508,7 +508,7 @@ export class MentionUI extends Plugin {
 	/**
 	 * Renders a single item in the autocomplete list.
 	 */
-	private _renderItem( item: MentionFeedObjectItem, marker: string ): DomWrapperView | ButtonView {
+	private _renderItem( item: MentionFeedObjectItem, marker: string ): MentionDomWrapperView | ButtonView {
 		const editor = this.editor;
 
 		let view;
@@ -520,7 +520,7 @@ export class MentionUI extends Plugin {
 			const renderResult = renderer( item );
 
 			if ( typeof renderResult != 'string' ) {
-				view = new DomWrapperView( editor.locale, renderResult );
+				view = new MentionDomWrapperView( editor.locale, renderResult );
 			} else {
 				label = renderResult;
 			}
@@ -892,8 +892,8 @@ type RequestFeedErrorEvent = {
 
 type Definition = {
 	marker: string;
-	feedCallback: FeedCallback;
-	itemRenderer?: ItemRenderer;
+	feedCallback: MentionFeedbackCallback;
+	itemRenderer?: MentionItemRenderer;
 	dropdownLimit?: number;
 };
 

--- a/packages/ckeditor5-mention/src/ui/domwrapperview.ts
+++ b/packages/ckeditor5-mention/src/ui/domwrapperview.ts
@@ -15,7 +15,7 @@ import type { Locale } from 'ckeditor5/src/utils.js';
  *
  * It allows to render any DOM element and use it in mentions list.
  */
-export class DomWrapperView extends View {
+export class MentionDomWrapperView extends View {
 	/**
 	 * The DOM element for which wrapper was created.
 	 */
@@ -30,7 +30,7 @@ export class DomWrapperView extends View {
 	declare public isOn: boolean;
 
 	/**
-	 * Creates an instance of {@link module:mention/ui/domwrapperview~DomWrapperView} class.
+	 * Creates an instance of {@link module:mention/ui/domwrapperview~MentionDomWrapperView} class.
 	 *
 	 * Also see {@link #render}.
 	 */

--- a/packages/ckeditor5-mention/src/ui/mentionlistitemview.ts
+++ b/packages/ckeditor5-mention/src/ui/mentionlistitemview.ts
@@ -11,7 +11,7 @@ import { ListItemView } from 'ckeditor5/src/ui.js';
 
 import type { MentionFeedItem } from '../mentionconfig.js';
 
-import { type DomWrapperView } from './domwrapperview.js';
+import { type MentionDomWrapperView } from './domwrapperview.js';
 
 export class MentionListItemView extends ListItemView {
 	public item!: MentionFeedItem;
@@ -19,13 +19,13 @@ export class MentionListItemView extends ListItemView {
 	public marker!: string;
 
 	public highlight(): void {
-		const child = this.children.first as DomWrapperView;
+		const child = this.children.first as MentionDomWrapperView;
 
 		child.isOn = true;
 	}
 
 	public removeHighlight(): void {
-		const child = this.children.first as DomWrapperView;
+		const child = this.children.first as MentionDomWrapperView;
 
 		child.isOn = false;
 	}

--- a/packages/ckeditor5-mention/tests/ui/domwrapperview.js
+++ b/packages/ckeditor5-mention/tests/ui/domwrapperview.js
@@ -4,14 +4,14 @@
  */
 
 import { Locale } from '@ckeditor/ckeditor5-utils';
-import { DomWrapperView } from '../../src/ui/domwrapperview.js';
+import { MentionDomWrapperView } from '../../src/ui/domwrapperview.js';
 
-describe( 'DomWrapperView', () => {
+describe( 'MentionDomWrapperView', () => {
 	let domElement, view;
 
 	beforeEach( () => {
 		domElement = document.createElement( 'div' );
-		view = new DomWrapperView( new Locale(), domElement );
+		view = new MentionDomWrapperView( new Locale(), domElement );
 	} );
 
 	afterEach( () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (mention): Added re-exports and aligned naming in the `ckeditor5-mention` package.

Internal (emoji): Aligned to renames from the `ckeditor5-mention` package.

---

### Additional information

Part of ckeditor/ckeditor5#18590.