### PR TITLE
Fixed typing over multiple blocks selected.

### DIFF
--- a/packages/ckeditor5-typing/src/input.ts
+++ b/packages/ckeditor5-typing/src/input.ts
@@ -114,6 +114,11 @@ export default class Input extends Plugin {
 				modelRanges = Array.from( modelSelection.getRanges() );
 			}
 
+			// Browser must not modify multiple blocks selected as the result is unpredictable.
+			if ( modelRanges.some( range => range.start.parent !== range.end.parent ) ) {
+				data.preventDefault();
+			}
+
 			let insertText = text;
 
 			// Typing in English on Android is firing composition events for the whole typed word.

--- a/packages/ckeditor5-typing/tests/input.js
+++ b/packages/ckeditor5-typing/tests/input.js
@@ -145,16 +145,68 @@ describe( 'Input', () => {
 			it( 'should preventDefault() the original beforeinput event if target ranges match fake selection', () => {
 				setModelData( editor.model, '[<widget></widget>]' );
 
-				const spy = sinon.spy();
-
-				viewDocument.fire( 'insertText', {
-					preventDefault: spy,
+				const eventData = {
+					preventDefault: sinon.spy(),
 					selection: viewDocument.selection,
-					text: 'bar',
-					domEvent: {}
-				} );
+					text: 'bar'
+				};
 
-				sinon.assert.calledOnce( spy );
+				eventData.domEvent = {
+					get defaultPrevented() {
+						return eventData.preventDefault.called;
+					}
+				};
+
+				viewDocument.fire( 'insertText', eventData );
+
+				sinon.assert.calledOnce( eventData.preventDefault );
+				sinon.assert.calledOnce( insertTextCommandSpy );
+			} );
+
+			it( 'should preventDefault() the original beforeinput event if target ranges span across different blocks', () => {
+				setModelData( editor.model,
+					'<paragraph>[foo</paragraph>' +
+					'<paragraph>]bar</paragraph>'
+				);
+
+				const eventData = {
+					preventDefault: sinon.spy(),
+					selection: viewDocument.selection,
+					text: 'abc',
+					domEvent: {}
+				};
+
+				eventData.domEvent = {
+					get defaultPrevented() {
+						return eventData.preventDefault.called;
+					}
+				};
+
+				viewDocument.fire( 'insertText', eventData );
+
+				sinon.assert.calledOnce( eventData.preventDefault );
+				sinon.assert.calledOnce( insertTextCommandSpy );
+			} );
+
+			it( 'should not preventDefault() the original beforeinput event if target ranges span a single block', () => {
+				setModelData( editor.model, '<paragraph>[foo]</paragraph>' );
+
+				const eventData = {
+					preventDefault: sinon.spy(),
+					selection: viewDocument.selection,
+					text: 'abc',
+					domEvent: {}
+				};
+
+				eventData.domEvent = {
+					get defaultPrevented() {
+						return eventData.preventDefault.called;
+					}
+				};
+
+				viewDocument.fire( 'insertText', eventData );
+
+				sinon.assert.notCalled( eventData.preventDefault );
 				sinon.assert.notCalled( insertTextCommandSpy );
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (typing): Typing over multiple selected blocks next to a code block or a block quote should not crash the editor. Closes #18722.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
