### PR TITLE
Added line height css variable

### DIFF
--- a/packages/ckeditor5-core/src/editor/editor.ts
+++ b/packages/ckeditor5-core/src/editor/editor.ts
@@ -46,6 +46,8 @@ import { getEditorUsageData, type EditorUsageData } from './utils/editorusagedat
 import type { LoadedPlugins, PluginConstructor } from '../plugin.js';
 import type { EditorConfig } from './editorconfig.js';
 
+import '../../theme/core.css';
+
 declare global {
 	// eslint-disable-next-line no-var
 	var CKEDITOR_GLOBAL_LICENSE_KEY: string | undefined;

--- a/packages/ckeditor5-core/theme/core.css
+++ b/packages/ckeditor5-core/theme/core.css
@@ -7,6 +7,6 @@
 	--ck-content-line-height: 1.5;
 }
 
-.ck.ck-content {
+.ck-content {
 	line-height: var(--ck-content-line-height);
 }

--- a/packages/ckeditor5-core/theme/core.css
+++ b/packages/ckeditor5-core/theme/core.css
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+:root {
+	--ck-content-line-height: 1.5;
+}
+
+.ck.ck-content {
+	line-height: var(--ck-content-line-height);
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (core): Added the `--ck-content-line-height` css variable. Closes #18634.

MAJOR BREAKING CHANGE: The editor now enforces a default line height of `1.5`, affecting both editing and rendered content. This may impact existing styling and layout, so custom line-height settings should be reviewed.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
