### PR TITLE
Fixed missing reexport and rename for `WidgetResizeState`.

### DIFF
--- a/packages/ckeditor5-widget/src/index.ts
+++ b/packages/ckeditor5-widget/src/index.ts
@@ -28,6 +28,7 @@ export {
 
 export { WidgetHighlightStack, type WidgetHighlightStackChangeEvent, type WidgetHighlightStackChangeEventData } from './highlightstack.js';
 export { verticalWidgetNavigationHandler } from './verticalnavigation.js';
+export { WidgetResizeState } from './widgetresize/resizerstate.js';
 export {
 	WidgetResizer,
 	type WidgetResizerBeginEvent,

--- a/packages/ckeditor5-widget/src/widgetresize/resizer.ts
+++ b/packages/ckeditor5-widget/src/widgetresize/resizer.ts
@@ -16,7 +16,7 @@ import {
 	type DecoratedMethodEvent
 } from '@ckeditor/ckeditor5-utils';
 
-import { ResizeState } from './resizerstate.js';
+import { WidgetResizeState } from './resizerstate.js';
 import { SizeView } from './sizeview.js';
 
 import type { WidgetResizerOptions } from '../widgetresize.js';
@@ -53,7 +53,7 @@ export class WidgetResizer extends /* #__PURE__ */ ObservableMixin() {
 	 *
 	 * Note that a new state is created for each resize transaction.
 	 */
-	private _state!: ResizeState;
+	private _state!: WidgetResizeState;
 
 	/**
 	 * A view displaying the proposed new element size during the resizing.
@@ -108,7 +108,7 @@ export class WidgetResizer extends /* #__PURE__ */ ObservableMixin() {
 	 *
 	 * Note that a new state is created for each resize transaction.
 	 */
-	public get state(): ResizeState {
+	public get state(): WidgetResizeState {
 		return this._state;
 	}
 
@@ -185,7 +185,7 @@ export class WidgetResizer extends /* #__PURE__ */ ObservableMixin() {
 	 * @param domResizeHandle Clicked handle.
 	 */
 	public begin( domResizeHandle: HTMLElement ): void {
-		this._state = new ResizeState( this._options );
+		this._state = new WidgetResizeState( this._options );
 
 		this._sizeView._bindToState( this._options, this.state );
 

--- a/packages/ckeditor5-widget/src/widgetresize/resizerstate.ts
+++ b/packages/ckeditor5-widget/src/widgetresize/resizerstate.ts
@@ -15,7 +15,7 @@ import { calculateResizeHostPercentageWidth } from '../utils.js';
 /**
  * Stores the internal state of a single resizable object.
  */
-export class ResizeState extends /* #__PURE__ */ ObservableMixin() {
+export class WidgetResizeState extends /* #__PURE__ */ ObservableMixin() {
 	/**
 	 * The position of the handle that initiated the resizing. E.g. `"top-left"`, `"bottom-right"` etc. or `null`
 	 * if unknown.

--- a/packages/ckeditor5-widget/src/widgetresize/sizeview.ts
+++ b/packages/ckeditor5-widget/src/widgetresize/sizeview.ts
@@ -9,7 +9,7 @@
 
 import { View } from '@ckeditor/ckeditor5-ui';
 import type { WidgetResizerOptions } from '../widgetresize.js';
-import { type ResizeState } from './resizerstate.js';
+import { type WidgetResizeState } from './resizerstate.js';
 
 /**
  * A view displaying the proposed new element size during the resizing.
@@ -75,7 +75,7 @@ export class SizeView extends View {
 	 * @param options An object defining the resizer options, used for setting the proper size label.
 	 * @param resizeState The `ResizeState` class instance, used for keeping the `SizeView` state up to date.
 	 */
-	public _bindToState( options: WidgetResizerOptions, resizeState: ResizeState ): void {
+	public _bindToState( options: WidgetResizerOptions, resizeState: WidgetResizeState ): void {
 		this.bind( '_isVisible' ).to( resizeState, 'proposedWidth', resizeState, 'proposedHeight', ( width, height ) =>
 			width !== null && height !== null );
 

--- a/packages/ckeditor5-widget/tests/widgetresize/resizerstate.js
+++ b/packages/ckeditor5-widget/tests/widgetresize/resizerstate.js
@@ -3,12 +3,12 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import { ResizeState } from '../../src/widgetresize/resizerstate.js';
+import { WidgetResizeState } from '../../src/widgetresize/resizerstate.js';
 
 describe( 'ResizerState', () => {
 	describe( 'constructor', () => {
 		it( 'sets up proper default values', () => {
-			const state = new ResizeState();
+			const state = new WidgetResizeState();
 
 			expect( state.activeHandlePosition, 'activeHandlePosition' ).to.be.null;
 			expect( state.proposedWidthPercents, 'proposedWidthPercents' ).to.be.null;
@@ -19,7 +19,7 @@ describe( 'ResizerState', () => {
 		} );
 
 		it( 'sets up observable properties', () => {
-			const state = new ResizeState();
+			const state = new WidgetResizeState();
 
 			expect( isObservable( 'activeHandlePosition' ), 'activeHandlePosition' ).to.be.true;
 			expect( isObservable( 'proposedWidthPercents' ), 'proposedWidthPercents' ).to.be.true;
@@ -62,7 +62,7 @@ describe( 'ResizerState', () => {
 			const domHandleHost = domContentWrapper.querySelector( '.dom-element' );
 			const domResizeHost = domHandleHost;
 
-			const state = new ResizeState();
+			const state = new WidgetResizeState();
 			state.begin( domResizeHandle, domHandleHost, domResizeHost );
 
 			expect( state.activeHandlePosition, 'activeHandlePosition' ).to.equal( 'bottom-right' );
@@ -97,7 +97,7 @@ describe( 'ResizerState', () => {
 			const domHandleHost = domContentWrapper.querySelector( '.dom-element' );
 			const domResizeHost = domHandleHost;
 
-			const state = new ResizeState();
+			const state = new WidgetResizeState();
 			state.begin( domResizeHandle, domHandleHost, domResizeHost );
 
 			expect( state.originalWidthPercents, 'originalWidthPercents' ).to.not.be.NaN;
@@ -118,7 +118,7 @@ describe( 'ResizerState', () => {
 			const domHandleHost = domContentWrapper.querySelector( '.dom-element' );
 			const domResizeHost = domHandleHost;
 
-			const state = new ResizeState();
+			const state = new WidgetResizeState();
 			state.begin( domResizeHandle, domHandleHost, domResizeHost );
 
 			expect( state.originalWidthPercents, 'originalWidthPercents' ).to.not.be.NaN;
@@ -129,7 +129,7 @@ describe( 'ResizerState', () => {
 
 	describe( 'update()', () => {
 		it( 'changes the properties', () => {
-			const state = new ResizeState();
+			const state = new WidgetResizeState();
 
 			state.update( {
 				width: 100,

--- a/packages/ckeditor5-widget/tests/widgetresize/sizeview.js
+++ b/packages/ckeditor5-widget/tests/widgetresize/sizeview.js
@@ -4,14 +4,14 @@
  */
 
 import { SizeView } from '../../src/widgetresize/sizeview.js';
-import { ResizeState } from '../../src/widgetresize/resizerstate.js';
+import { WidgetResizeState } from '../../src/widgetresize/resizerstate.js';
 
 describe( 'SizeView', () => {
 	let sizeView, state;
 
 	beforeEach( () => {
 		sizeView = new SizeView();
-		state = new ResizeState();
+		state = new WidgetResizeState();
 
 		sizeView._bindToState( {}, state );
 		sizeView.render();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Fixed missing reexport and rename for `WidgetResizeState`.

Part of https://github.com/ckeditor/ckeditor5/issues/18590.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
