### PR TITLE
Config option to disable list item formatting integration

### DIFF
--- a/packages/ckeditor5-list/src/listconfig.ts
+++ b/packages/ckeditor5-list/src/listconfig.ts
@@ -46,6 +46,20 @@ export interface ListConfig {
 	 * @default true
 	 */
 	multiBlock?: boolean;
+
+	/**
+	 * Enables list item formatting. Current list of integrated formatting plugins includes:
+	 * * {@link module:list/listformatting/listitemfontfamilyintegration~ListItemFontFamilyIntegration Font family}
+	 * * {@link module:list/listformatting/listitemfontsizeintegration~ListItemFontSizeIntegration Font size}
+	 * * {@link module:list/listformatting/listitemfontcolorintegration~ListItemFontColorIntegration Font color}
+	 * * {@link module:list/listformatting/listitemboldintegration~ListItemBoldIntegration Bold}
+	 * * {@link module:list/listformatting/listitemitalicintegration~ListItemItalicIntegration Italic}
+	 *
+	 * **Note:** This is enabled by default.
+	 *
+	 * @default true
+	 */
+	enableListItemFormatting?: boolean;
 }
 
 /**

--- a/packages/ckeditor5-list/src/listformatting.ts
+++ b/packages/ckeditor5-list/src/listformatting.ts
@@ -7,8 +7,7 @@
  * @module list/listformatting
  */
 
-import { Plugin } from 'ckeditor5/src/core.js';
-
+import { type Editor, Plugin } from 'ckeditor5/src/core.js';
 import ListItemFontFamilyIntegration from './listformatting/listitemfontfamilyintegration.js';
 import type {
 	Element,
@@ -66,7 +65,20 @@ export default class ListFormatting extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
+	constructor( editor: Editor ) {
+		super( editor );
+
+		editor.config.define( 'list.enableListItemFormatting', true );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
 	public afterInit(): void {
+		if ( !this.editor.config.get( 'list.enableListItemFormatting' ) ) {
+			return;
+		}
+
 		this._registerPostfixerForListItemFormatting();
 	}
 
@@ -164,8 +176,14 @@ export default class ListFormatting extends Plugin {
 	 * to the list item element, based on whether there is a consistent default formatting attribute
 	 * applied within its content.
 	 */
-	public registerFormatAttribute( listItemFormatAttribute: string, formatAttribute: string ): void {
+	public registerFormatAttribute( listItemFormatAttribute: string, formatAttribute: string ): boolean {
+		if ( !this.editor.config.get( 'list.enableListItemFormatting' ) ) {
+			return false;
+		}
+
 		this._loadedFormattings[ listItemFormatAttribute ] = formatAttribute;
+
+		return true;
 	}
 }
 

--- a/packages/ckeditor5-list/src/listformatting/listitemfontfamilyintegration.ts
+++ b/packages/ckeditor5-list/src/listformatting/listitemfontfamilyintegration.ts
@@ -18,6 +18,11 @@ import type ListFormatting from '../listformatting.js';
  */
 export default class ListItemFontFamilyIntegration extends Plugin {
 	/**
+	 * Indicates whether the integration is enabled.
+	 */
+	private _integrationEnabled: boolean = false;
+
+	/**
 	 * @inheritDoc
 	 */
 	public static get pluginName() {
@@ -50,7 +55,11 @@ export default class ListItemFontFamilyIntegration extends Plugin {
 			return;
 		}
 
-		ListFormatting.registerFormatAttribute( 'listItemFontFamily', 'fontFamily' );
+		this._integrationEnabled = ListFormatting.registerFormatAttribute( 'listItemFontFamily', 'fontFamily' );
+
+		if ( !this._integrationEnabled ) {
+			return;
+		}
 
 		// Register the downcast strategy in init() so that the attribute name is registered  before the list editing
 		// registers its converters.
@@ -75,7 +84,7 @@ export default class ListItemFontFamilyIntegration extends Plugin {
 		const editor = this.editor;
 		const model = editor.model;
 
-		if ( !editor.plugins.has( 'FontFamilyEditing' ) ) {
+		if ( !editor.plugins.has( 'FontFamilyEditing' ) || !this._integrationEnabled ) {
 			return;
 		}
 

--- a/packages/ckeditor5-list/tests/list/listediting.js
+++ b/packages/ckeditor5-list/tests/list/listediting.js
@@ -103,7 +103,8 @@ describe( 'ListEditing', () => {
 
 	it( 'should define config', () => {
 		expect( editor.config.get( 'list' ) ).to.deep.equal( {
-			multiBlock: true
+			multiBlock: true,
+			enableListItemFormatting: true
 		} );
 	} );
 

--- a/packages/ckeditor5-list/tests/listformatting.js
+++ b/packages/ckeditor5-list/tests/listformatting.js
@@ -655,6 +655,48 @@ describe( 'ListFormatting', () => {
 		} );
 	} );
 
+	describe( 'enableListItemFormatting', () => {
+		it( 'should be enabled by default', () => {
+			expect( editor.config.get( 'list.enableListItemFormatting' ) ).to.be.true;
+		} );
+
+		describe( 'when enableListItemFormatting is false (postfixer should not run)', () => {
+			let editor, model, docSelection;
+
+			beforeEach( async () => {
+				editor = await VirtualTestEditor.create( {
+					plugins: [ ListFormatting, Paragraph, MyPlugin ],
+					list: {
+						enableListItemFormatting: false
+					}
+				} );
+
+				model = editor.model;
+				docSelection = model.document.selection;
+
+				model.schema.extend( '$text', { allowAttributes: [ 'inlineFormat', 'inlineFormat2' ] } );
+			} );
+
+			afterEach( async () => {
+				await editor.destroy();
+			} );
+
+			it( 'should not set attribute in li when adding formatting on the whole text', () => {
+				setModelData( model,
+					'<paragraph listIndent="0" listItemId="a">[<$text>foo</$text>]</paragraph>'
+				);
+
+				setAttribute( model, 'inlineFormat', 'foo', docSelection.getFirstRange() );
+
+				expect( getModelData( model, { withoutSelection: true } ) ).to.equalMarkup(
+					'<paragraph listIndent="0" listItemId="a">' +
+						'<$text inlineFormat="foo">foo</$text>' +
+					'</paragraph>'
+				);
+			} );
+		} );
+	} );
+
 	class MyPlugin extends Plugin {
 		init() {
 			const ListFormatting = this.editor.plugins.get( 'ListFormatting' );

--- a/packages/ckeditor5-list/tests/listformatting/listitemfontfamilyintegration.js
+++ b/packages/ckeditor5-list/tests/listformatting/listitemfontfamilyintegration.js
@@ -507,7 +507,7 @@ describe( 'ListItemFontFamilyIntegration', () => {
 		} );
 	} );
 
-	describe( 'when FontFamilyEditing is not loaded', () => {
+	describe( 'when enableListItemFormattin is false', () => {
 		let editor, model, view;
 
 		beforeEach( async () => {
@@ -554,6 +554,48 @@ describe( 'ListItemFontFamilyIntegration', () => {
 						'</p>' +
 					'</li>' +
 				'</ul>'
+			);
+		} );
+	} );
+
+	describe( 'when FontFamilyEditing is not loaded', () => {
+		let editor, model;
+
+		beforeEach( async () => {
+			editor = await VirtualTestEditor.create( {
+				plugins: [
+					ListItemFontFamilyIntegration,
+					FontFamilyEditing,
+					Paragraph
+				],
+				fontFamily: {
+					supportAllValues: true
+				},
+				list: {
+					enableListItemFormatting: false
+				}
+			} );
+
+			model = editor.model;
+		} );
+
+		afterEach( async () => {
+			await editor.destroy();
+		} );
+
+		it( 'should not upcast style in <li> to listItemFontFamily attribute', () => {
+			editor.setData(
+				'<ul>' +
+					'<li style="font-family:Arial;">' +
+						'<span style="font-family:Arial;">foo</span>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			expect( getModelData( model, { withoutSelection: true } ) ).to.equalMarkup(
+				'<paragraph listIndent="0" listItemId="a00" listType="bulleted">' +
+					'<$text fontFamily="Arial">foo</$text>' +
+				'</paragraph>'
 			);
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (list): Adds config option to disable list item formatting integration. Closes #18724 .

---

### Additional information

This covers Font family, but also other formats will have to be updated: Bold, Italic, Font size and Font color (when they are merged).
