### PR TITLE
Introducing default content styles.

### DIFF
--- a/packages/ckeditor5-core/theme/core.css
+++ b/packages/ckeditor5-core/theme/core.css
@@ -4,9 +4,15 @@
  */
 
 :root {
+	--ck-content-font-family: Helvetica, Arial, Tahoma, Verdana, Sans-Serif;
+	--ck-content-font-size: medium;
+	--ck-content-font-color: hsl(0, 0%, 0%);
 	--ck-content-line-height: 1.5;
 }
 
 .ck-content {
+	font-family: var(--ck-content-font-family);
+	font-size: var(--ck-content-font-size);
+	color: var(--ck-content-font-color);
 	line-height: var(--ck-content-line-height);
 }

--- a/packages/ckeditor5-page-break/theme/pagebreak.css
+++ b/packages/ckeditor5-page-break/theme/pagebreak.css
@@ -27,7 +27,6 @@
 	text-transform: uppercase;
 	border: 1px solid hsl(0, 0%, 77%);
 	border-radius: 2px;
-	font-family: Helvetica, Arial, Tahoma, Verdana, Sans-Serif;
 	font-size: 0.75em;
 	font-weight: bold;
 	color: hsl(0, 0%, 20%);


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (core): Implemented the `--ck-content-font-family`, `--ck-content-font-size` and `--ck-content-font-color` CSS variables to standardize font family, size and color styling in CKEditor 5 content. Closes #18710.

MAJOR BREAKING CHANGE: The editor now enforces a default font family of `Helvetica, Arial, Tahoma, Verdana, Sans-Serif`, affecting both editing and rendered content. This may impact existing styling and layout, so custom `font-family` settings should be reviewed. See #18710.

MAJOR BREAKING CHANGE: The editor now enforces a default font size of `medium`, affecting both editing and rendered content. This may impact existing styling and layout, so custom `font-size` settings should be reviewed. See #18710.

MAJOR BREAKING CHANGE: The editor now enforces a default font color of `hsl(0, 0%, 0%)`, affecting both editing and rendered content. This may impact existing styling and layout, so custom `color` settings should be reviewed. See #18710.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
