### PR TITLE
Fixed remaining packages export names to pass export validation.

### DIFF
--- a/packages/ckeditor5-code-block/src/codeblockediting.ts
+++ b/packages/ckeditor5-code-block/src/codeblockediting.ts
@@ -20,7 +20,7 @@ import {
 	type UpcastElementEvent,
 	type UpcastTextEvent,
 	type ModelElement,
-	type SelectionChangeRangeEvent
+	type ModelSelectionChangeRangeEvent
 } from 'ckeditor5/src/engine.js';
 import { ClipboardPipeline, type ClipboardContentInsertionEvent } from 'ckeditor5/src/clipboard.js';
 
@@ -318,7 +318,7 @@ export class CodeBlockEditing extends Plugin {
 
 		let lastFocusedCodeBlock: ModelElement | null = null;
 
-		model.document.selection.on<SelectionChangeRangeEvent>( 'change:range', () => {
+		model.document.selection.on<ModelSelectionChangeRangeEvent>( 'change:range', () => {
 			const focusParent = model.document.selection.focus!.parent;
 
 			if ( !ui || lastFocusedCodeBlock === focusParent || !focusParent.is( 'element' ) ) {

--- a/packages/ckeditor5-engine/src/controller/editingcontroller.ts
+++ b/packages/ckeditor5-engine/src/controller/editingcontroller.ts
@@ -40,7 +40,7 @@ import { type ModelTextProxy } from '../model/textproxy.js';
 import type { ModelDocumentChangeEvent } from '../model/document.js';
 import type { Marker } from '../model/markercollection.js';
 import type { StylesProcessor } from '../view/stylesmap.js';
-import type { ViewDocumentSelectionChangeEvent } from '../view/observer/selectionobserver.js';
+import type { ViewDocumentObserverSelectionChangeEvent } from '../view/observer/selectionobserver.js';
 
 // @if CK_DEBUG_ENGINE // const { dumpTrees, initDocumentDumping } = require( '../dev-utils/utils' );
 
@@ -116,7 +116,7 @@ export class EditingController extends /* #__PURE__ */ ObservableMixin() {
 		}, { priority: 'low' } );
 
 		// Convert selection from the view to the model when it changes in the view.
-		this.listenTo<ViewDocumentSelectionChangeEvent>( this.view.document, 'selectionChange',
+		this.listenTo<ViewDocumentObserverSelectionChangeEvent>( this.view.document, 'selectionChange',
 			convertSelectionChange( this.model, this.mapper )
 		);
 

--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -69,7 +69,8 @@ export {
 	type DowncastAddHighlightCallback,
 	type DowncastHighlightDescriptorCreatorFunction,
 	type DowncastRemoveHighlightCallback,
-	type DowncastMarkerDataCreatorFunction
+	type DowncastMarkerDataCreatorFunction,
+	type DowncastAttributeCreatorFunction
 } from './conversion/downcasthelpers.js';
 
 export type {
@@ -213,7 +214,6 @@ export type {
 	ModelModifySelectionEvent,
 	ModelCanEditAtEvent
 } from './model/model.js';
-export type { ModelSelectionChangeRangeEvent as SelectionChangeRangeEvent } from './model/selection.js';
 
 // View.
 export { ViewDataTransfer, type ViewDropEffect, type ViewEffectAllowed } from './view/datatransfer.js';
@@ -247,7 +247,7 @@ export { ViewRawElement } from './view/rawelement.js';
 export { ViewUIElement } from './view/uielement.js';
 export { ViewDocumentFragment } from './view/documentfragment.js';
 export type { ViewElementDefinition, ViewElementObjectDefinition } from './view/elementdefinition.js';
-export { ViewDocumentSelection } from './view/documentselection.js';
+export { ViewDocumentSelection, type ViewDocumentSelectionChangeEvent } from './view/documentselection.js';
 export type { ViewItem } from './view/item.js';
 export { ViewNode, type ViewNodeChangeEvent } from './view/node.js';
 export {
@@ -298,7 +298,7 @@ export {
 
 export {
 	SelectionObserver,
-	type ViewDocumentSelectionEventData
+	type ViewDocumentObserverSelectionEventData
 } from './view/observer/selectionobserver.js';
 
 export { CompositionObserver, type ViewDocumentCompositionEventData } from './view/observer/compositionobserver.js';
@@ -366,7 +366,10 @@ export type {
 } from './view/observer/touchobserver.js';
 export type { ViewDocumentTabEvent } from './view/observer/tabobserver.js';
 export type { ViewDocumentClickEvent } from './view/observer/clickobserver.js';
-export type { ViewDocumentSelectionChangeEvent, ViewDocumentSelectionChangeDoneEvent } from './view/observer/selectionobserver.js';
+export type {
+	ViewDocumentObserverSelectionChangeEvent,
+	ViewDocumentObserverSelectionChangeDoneEvent
+} from './view/observer/selectionobserver.js';
 
 // View / Styles.
 export {

--- a/packages/ckeditor5-engine/src/view/observer/fakeselectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/fakeselectionobserver.ts
@@ -12,9 +12,9 @@ import type { ViewDocumentArrowKeyEvent } from './arrowkeysobserver.js';
 import { ViewSelection } from '../selection.js';
 import { type EditingView } from '../view.js';
 import type {
-	ViewDocumentSelectionChangeEvent,
-	ViewDocumentSelectionChangeDoneEvent,
-	ViewDocumentSelectionEventData
+	ViewDocumentObserverSelectionChangeEvent,
+	ViewDocumentObserverSelectionChangeDoneEvent,
+	ViewDocumentObserverSelectionEventData
 } from './selectionobserver.js';
 import { keyCodes } from '@ckeditor/ckeditor5-utils';
 import { debounce, type DebouncedFunction } from 'es-toolkit/compat';
@@ -30,7 +30,7 @@ export class FakeSelectionObserver extends Observer {
 	/**
 	 * Fires debounced event `selectionChangeDone`. It uses `es-toolkit#debounce` method to delay function call.
 	 */
-	private readonly _fireSelectionChangeDoneDebounced: DebouncedFunction<( data: ViewDocumentSelectionEventData ) => void>;
+	private readonly _fireSelectionChangeDoneDebounced: DebouncedFunction<( data: ViewDocumentObserverSelectionEventData ) => void>;
 
 	/**
 	 * Creates new FakeSelectionObserver instance.
@@ -39,7 +39,7 @@ export class FakeSelectionObserver extends Observer {
 		super( view );
 
 		this._fireSelectionChangeDoneDebounced = debounce( data => {
-			this.document.fire<ViewDocumentSelectionChangeDoneEvent>( 'selectionChangeDone', data );
+			this.document.fire<ViewDocumentObserverSelectionChangeDoneEvent>( 'selectionChangeDone', data );
 		}, 200 );
 	}
 
@@ -110,7 +110,7 @@ export class FakeSelectionObserver extends Observer {
 		};
 
 		// Fire dummy selection change event.
-		this.document.fire<ViewDocumentSelectionChangeEvent>( 'selectionChange', data );
+		this.document.fire<ViewDocumentObserverSelectionChangeEvent>( 'selectionChange', data );
 
 		// Call` #_fireSelectionChangeDoneDebounced` every time when `selectionChange` event is fired.
 		// This function is debounced what means that `selectionChangeDone` event will be fired only when

--- a/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
@@ -67,7 +67,7 @@ export class SelectionObserver extends Observer {
 	/**
 	 * Fires debounced event `selectionChangeDone`. It uses `es-toolkit#debounce` method to delay function call.
 	 */
-	private readonly _fireSelectionChangeDoneDebounced: DebouncedFunction<( data: ViewDocumentSelectionEventData ) => void>;
+	private readonly _fireSelectionChangeDoneDebounced: DebouncedFunction<( data: ViewDocumentObserverSelectionEventData ) => void>;
 
 	/**
 	 * When called, starts clearing the {@link #_loopbackCounter} counter in time intervals. When the number of selection
@@ -103,7 +103,7 @@ export class SelectionObserver extends Observer {
 		this.domConverter = view.domConverter;
 
 		this._fireSelectionChangeDoneDebounced = debounce( data => {
-			this.document.fire<ViewDocumentSelectionChangeDoneEvent>( 'selectionChangeDone', data );
+			this.document.fire<ViewDocumentObserverSelectionChangeDoneEvent>( 'selectionChangeDone', data );
 		}, 200 );
 
 		this._clearInfiniteLoopInterval = setInterval( () => this._clearInfiniteLoop(), 1000 );
@@ -339,7 +339,7 @@ export class SelectionObserver extends Observer {
 			// Just re-render it, no need to fire any events, etc.
 			this.view.forceRender();
 		} else {
-			const data: ViewDocumentSelectionEventData = {
+			const data: ViewDocumentObserverSelectionEventData = {
 				oldSelection: this.selection,
 				newSelection: newViewSelection,
 				domSelection
@@ -353,7 +353,7 @@ export class SelectionObserver extends Observer {
 			// @if CK_DEBUG_TYPING // }
 
 			// Prepare data for new selection and fire appropriate events.
-			this.document.fire<ViewDocumentSelectionChangeEvent>( 'selectionChange', data );
+			this.document.fire<ViewDocumentObserverSelectionChangeEvent>( 'selectionChange', data );
 
 			// Call `#_fireSelectionChangeDoneDebounced` every time when `selectionChange` event is fired.
 			// This function is debounced what means that `selectionChangeDone` event will be fired only when
@@ -372,9 +372,9 @@ export class SelectionObserver extends Observer {
 }
 
 /**
- * The value of {@link ~ViewDocumentSelectionChangeEvent} and {@link ~ViewDocumentSelectionChangeDoneEvent} events.
+ * The value of {@link ~ViewDocumentObserverSelectionChangeEvent} and {@link ~ViewDocumentObserverSelectionChangeDoneEvent} events.
  */
-export type ViewDocumentSelectionEventData = {
+export type ViewDocumentObserverSelectionEventData = {
 
 	/**
 	 * Old View selection which is {@link module:engine/view/document~ViewDocument#selection}.
@@ -404,9 +404,9 @@ export type ViewDocumentSelectionEventData = {
  * @see module:engine/view/observer/selectionobserver~SelectionObserver
  * @eventName module:engine/view/document~ViewDocument#selectionChange
  */
-export type ViewDocumentSelectionChangeEvent = {
+export type ViewDocumentObserverSelectionChangeEvent = {
 	name: 'selectionChange';
-	args: [ ViewDocumentSelectionEventData ];
+	args: [ ViewDocumentObserverSelectionEventData ];
 };
 
 /**
@@ -420,7 +420,7 @@ export type ViewDocumentSelectionChangeEvent = {
  * @see module:engine/view/observer/selectionobserver~SelectionObserver
  * @eventName module:engine/view/document~ViewDocument#selectionChangeDone
  */
-export type ViewDocumentSelectionChangeDoneEvent = {
+export type ViewDocumentObserverSelectionChangeDoneEvent = {
 	name: 'selectionChangeDone';
-	args: [ ViewDocumentSelectionEventData ];
+	args: [ ViewDocumentObserverSelectionEventData ];
 };

--- a/packages/ckeditor5-engine/src/view/view.ts
+++ b/packages/ckeditor5-engine/src/view/view.ts
@@ -42,14 +42,15 @@ import {
 	env,
 	ObservableMixin,
 	scrollViewportToShowTarget,
-	type ObservableChangeEvent
+	type ObservableChangeEvent,
+	type IfTrue
 } from '@ckeditor/ckeditor5-utils';
 import { injectUiElementHandling } from './uielement.js';
 import { injectQuirksHandling } from './filler.js';
 
 import { cloneDeep } from 'es-toolkit/compat';
 
-type IfTrue<T> = T extends true ? true : never;
+// type IfTrue<T> = T extends true ? true : never;
 type DomRange = globalThis.Range;
 
 /**

--- a/packages/ckeditor5-fullscreen/src/fullscreencommand.ts
+++ b/packages/ckeditor5-fullscreen/src/fullscreencommand.ts
@@ -11,9 +11,9 @@ import { Command, type Editor } from 'ckeditor5/src/core.js';
 import type { ClassicEditor } from '@ckeditor/ckeditor5-editor-classic';
 import type { DecoupledEditor } from '@ckeditor/ckeditor5-editor-decoupled';
 
-import { AbstractEditorHandler } from './handlers/abstracteditorhandler.js';
-import { ClassicEditorHandler } from './handlers/classiceditorhandler.js';
-import { DecoupledEditorHandler } from './handlers/decouplededitorhandler.js';
+import { FullscreenAbstractEditorHandler } from './handlers/abstracteditorhandler.js';
+import { FullscreenClassicEditorHandler } from './handlers/classiceditorhandler.js';
+import { FullscreenDecoupledEditorHandler } from './handlers/decouplededitorhandler.js';
 
 /**
  * A command toggling the fullscreen mode.
@@ -43,7 +43,7 @@ export class FullscreenCommand extends Command {
 	 * 	} );
 	 * ```
 	 */
-	public fullscreenHandler: AbstractEditorHandler;
+	public fullscreenHandler: FullscreenAbstractEditorHandler;
 
 	/**
 	 * @inheritDoc
@@ -59,11 +59,11 @@ export class FullscreenCommand extends Command {
 		// Currently only `ClassicEditor` and `DecoupledEditor` are supported. For other editor types, you should create a custom handler
 		// that extends `AbstractEditorHandler` and replace `fullscreenHandler` with it.
 		if ( isClassicEditor( editor ) ) {
-			this.fullscreenHandler = new ClassicEditorHandler( editor );
+			this.fullscreenHandler = new FullscreenClassicEditorHandler( editor );
 		} else if ( isDecoupledEditor( editor ) ) {
-			this.fullscreenHandler = new DecoupledEditorHandler( editor );
+			this.fullscreenHandler = new FullscreenDecoupledEditorHandler( editor );
 		} else {
-			this.fullscreenHandler = new AbstractEditorHandler( editor );
+			this.fullscreenHandler = new FullscreenAbstractEditorHandler( editor );
 		}
 	}
 

--- a/packages/ckeditor5-fullscreen/src/handlers/abstracteditorhandler.ts
+++ b/packages/ckeditor5-fullscreen/src/handlers/abstracteditorhandler.ts
@@ -73,7 +73,7 @@ const DIALOG_OFFSET = 28;
  *
  * This class is exported to allow for custom extensions.
  */
-export class AbstractEditorHandler {
+export class FullscreenAbstractEditorHandler {
 	/**
 	 * Maps placeholder names to placeholder elements and moved elements.
 	 */

--- a/packages/ckeditor5-fullscreen/src/handlers/classiceditorhandler.ts
+++ b/packages/ckeditor5-fullscreen/src/handlers/classiceditorhandler.ts
@@ -10,12 +10,12 @@
 import { MenuBarView } from 'ckeditor5/src/ui.js';
 import type { ClassicEditor } from '@ckeditor/ckeditor5-editor-classic';
 
-import { AbstractEditorHandler } from './abstracteditorhandler.js';
+import { FullscreenAbstractEditorHandler } from './abstracteditorhandler.js';
 
 /**
  * The classic editor fullscreen mode handler.
  */
-export class ClassicEditorHandler extends AbstractEditorHandler {
+export class FullscreenClassicEditorHandler extends FullscreenAbstractEditorHandler {
 	/**
 	 * An editor instance.
 	 */

--- a/packages/ckeditor5-fullscreen/src/handlers/decouplededitorhandler.ts
+++ b/packages/ckeditor5-fullscreen/src/handlers/decouplededitorhandler.ts
@@ -9,12 +9,12 @@
 
 import type { DecoupledEditor } from '@ckeditor/ckeditor5-editor-decoupled';
 
-import { AbstractEditorHandler } from './abstracteditorhandler.js';
+import { FullscreenAbstractEditorHandler } from './abstracteditorhandler.js';
 
 /**
  * The decoupled editor fullscreen mode handler.
  */
-export class DecoupledEditorHandler extends AbstractEditorHandler {
+export class FullscreenDecoupledEditorHandler extends FullscreenAbstractEditorHandler {
 	/**
 	 * An editor instance.
 	 */

--- a/packages/ckeditor5-fullscreen/src/index.ts
+++ b/packages/ckeditor5-fullscreen/src/index.ts
@@ -12,9 +12,9 @@ export { FullscreenEditing } from './fullscreenediting.js';
 export { FullscreenUI } from './fullscreenui.js';
 export { FullscreenCommand } from './fullscreencommand.js';
 
-export { AbstractEditorHandler as FullscreenAbstractEditorHandler } from './handlers/abstracteditorhandler.js';
-export { ClassicEditorHandler as FullscreenClassicEditorHandler } from './handlers/classiceditorhandler.js';
-export { DecoupledEditorHandler as FullscreenDecoupledEditorHandler } from './handlers/decouplededitorhandler.js';
+export { FullscreenAbstractEditorHandler } from './handlers/abstracteditorhandler.js';
+export { FullscreenClassicEditorHandler } from './handlers/classiceditorhandler.js';
+export { FullscreenDecoupledEditorHandler } from './handlers/decouplededitorhandler.js';
 
 export type { FullscreenConfig } from './fullscreenconfig.js';
 

--- a/packages/ckeditor5-fullscreen/tests/fullscreencommand.js
+++ b/packages/ckeditor5-fullscreen/tests/fullscreencommand.js
@@ -14,9 +14,9 @@ import { MultiRootEditor } from '@ckeditor/ckeditor5-editor-multi-root';
 import { removeEditorBodyOrphans } from '@ckeditor/ckeditor5-core/tests/_utils/cleanup.js';
 
 import { FullscreenCommand } from '../src/fullscreencommand.js';
-import { ClassicEditorHandler } from '../src/handlers/classiceditorhandler.js';
-import { DecoupledEditorHandler } from '../src/handlers/decouplededitorhandler.js';
-import { AbstractEditorHandler } from '../src/handlers/abstracteditorhandler.js';
+import { FullscreenClassicEditorHandler } from '../src/handlers/classiceditorhandler.js';
+import { FullscreenDecoupledEditorHandler } from '../src/handlers/decouplededitorhandler.js';
+import { FullscreenAbstractEditorHandler } from '../src/handlers/abstracteditorhandler.js';
 
 const basicConfig = {
 	plugins: [
@@ -68,23 +68,23 @@ describe( 'FullscreenCommand', () => {
 		} );
 
 		it( 'for Classic editor', async () => {
-			testEditorTypeHandler( tempElement, ClassicEditor, ClassicEditorHandler );
+			testEditorTypeHandler( tempElement, ClassicEditor, FullscreenClassicEditorHandler );
 		} );
 
 		it( 'for Decoupled editor', async () => {
-			testEditorTypeHandler( tempElement, DecoupledEditor, DecoupledEditorHandler );
+			testEditorTypeHandler( tempElement, DecoupledEditor, FullscreenDecoupledEditorHandler );
 		} );
 
 		it( 'for Inline editor', async () => {
-			testEditorTypeHandler( tempElement, InlineEditor, AbstractEditorHandler );
+			testEditorTypeHandler( tempElement, InlineEditor, FullscreenAbstractEditorHandler );
 		} );
 
 		it( 'for Balloon editor', async () => {
-			testEditorTypeHandler( tempElement, BalloonEditor, AbstractEditorHandler );
+			testEditorTypeHandler( tempElement, BalloonEditor, FullscreenAbstractEditorHandler );
 		} );
 
 		it( 'for Multiroot editor', async () => {
-			testEditorTypeHandler( tempElement, MultiRootEditor, AbstractEditorHandler );
+			testEditorTypeHandler( tempElement, MultiRootEditor, FullscreenAbstractEditorHandler );
 		} );
 
 		async function testEditorTypeHandler( element, editorConstructor, editorHandler ) {

--- a/packages/ckeditor5-fullscreen/tests/handlers/abstracteditorhandler.js
+++ b/packages/ckeditor5-fullscreen/tests/handlers/abstracteditorhandler.js
@@ -13,7 +13,7 @@ import { SourceEditing } from '@ckeditor/ckeditor5-source-editing';
 import { Plugin } from '@ckeditor/ckeditor5-core';
 
 import { RevisionHistoryMock } from '../_utils/revisionhistorymock.js';
-import { AbstractEditorHandler } from '../../src/handlers/abstracteditorhandler.js';
+import { FullscreenAbstractEditorHandler } from '../../src/handlers/abstracteditorhandler.js';
 import { Fullscreen } from '../../src/fullscreen.js';
 
 describe( 'AbstractHandler', () => {
@@ -31,7 +31,7 @@ describe( 'AbstractHandler', () => {
 			]
 		} );
 
-		abstractHandler = new AbstractEditorHandler( editor );
+		abstractHandler = new FullscreenAbstractEditorHandler( editor );
 	} );
 
 	afterEach( () => {
@@ -272,7 +272,7 @@ describe( 'AbstractHandler', () => {
 				}
 			} );
 
-			const tempAbstractHandlerDynamicToolbar = new AbstractEditorHandler( tempEditorDynamicToolbar );
+			const tempAbstractHandlerDynamicToolbar = new FullscreenAbstractEditorHandler( tempEditorDynamicToolbar );
 
 			tempAbstractHandlerDynamicToolbar.enable();
 			tempAbstractHandlerDynamicToolbar.disable();
@@ -300,7 +300,7 @@ describe( 'AbstractHandler', () => {
 				}
 			} );
 
-			const tempAbstractHandlerStaticToolbar = new AbstractEditorHandler( tempEditorStaticToolbar );
+			const tempAbstractHandlerStaticToolbar = new FullscreenAbstractEditorHandler( tempEditorStaticToolbar );
 
 			tempAbstractHandlerStaticToolbar.enable();
 			tempAbstractHandlerStaticToolbar.disable();
@@ -381,7 +381,7 @@ describe( 'AbstractHandler', () => {
 				]
 			} );
 
-			abstractEditorHandler = new AbstractEditorHandler( editorWithRevisionHistory );
+			abstractEditorHandler = new FullscreenAbstractEditorHandler( editorWithRevisionHistory );
 		} );
 
 		afterEach( async () => {
@@ -447,7 +447,7 @@ describe( 'AbstractHandler', () => {
 				]
 			} );
 
-			abstractEditorHandler = new AbstractEditorHandler( editorWithSourceEditing );
+			abstractEditorHandler = new FullscreenAbstractEditorHandler( editorWithSourceEditing );
 			sinon.stub( abstractEditorHandler, '_generateDocumentOutlineContainer' );
 		} );
 

--- a/packages/ckeditor5-fullscreen/tests/handlers/classiceditorhandler.js
+++ b/packages/ckeditor5-fullscreen/tests/handlers/classiceditorhandler.js
@@ -8,7 +8,7 @@ import { Paragraph } from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
 import { ClassicEditor } from '@ckeditor/ckeditor5-editor-classic/src/classiceditor.js';
 import { global } from '@ckeditor/ckeditor5-utils/src/dom/global.js';
 
-import { ClassicEditorHandler } from '../../src/handlers/classiceditorhandler.js';
+import { FullscreenClassicEditorHandler } from '../../src/handlers/classiceditorhandler.js';
 import { FullscreenEditing } from '../../src/fullscreenediting.js';
 
 describe( 'ClassicEditorHandler', () => {
@@ -25,7 +25,7 @@ describe( 'ClassicEditorHandler', () => {
 			]
 		} );
 
-		classicEditorHandler = new ClassicEditorHandler( editor );
+		classicEditorHandler = new FullscreenClassicEditorHandler( editor );
 	} );
 
 	afterEach( () => {
@@ -82,7 +82,7 @@ describe( 'ClassicEditorHandler', () => {
 				}
 			} );
 
-			const tempClassicEditorHandler = new ClassicEditorHandler( tempEditor );
+			const tempClassicEditorHandler = new FullscreenClassicEditorHandler( tempEditor );
 
 			tempClassicEditorHandler.enable();
 

--- a/packages/ckeditor5-fullscreen/tests/handlers/decouplededitorhandler.js
+++ b/packages/ckeditor5-fullscreen/tests/handlers/decouplededitorhandler.js
@@ -8,7 +8,7 @@ import { Paragraph } from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
 import { DecoupledEditor } from '@ckeditor/ckeditor5-editor-decoupled';
 import { global } from '@ckeditor/ckeditor5-utils/src/dom/global.js';
 
-import { DecoupledEditorHandler } from '../../src/handlers/decouplededitorhandler.js';
+import { FullscreenDecoupledEditorHandler } from '../../src/handlers/decouplededitorhandler.js';
 import { FullscreenEditing } from '../../src/fullscreenediting.js';
 
 describe( 'DecoupledEditorHandler', () => {
@@ -30,7 +30,7 @@ describe( 'DecoupledEditorHandler', () => {
 			}
 		} );
 
-		decoupledEditorHandler = new DecoupledEditorHandler( editor );
+		decoupledEditorHandler = new FullscreenDecoupledEditorHandler( editor );
 	} );
 
 	afterEach( () => {

--- a/packages/ckeditor5-list/src/legacytodolist/legacytodolistediting.ts
+++ b/packages/ckeditor5-list/src/legacytodolist/legacytodolistediting.ts
@@ -20,7 +20,7 @@ import type {
 	ViewDocumentKeyDownEvent,
 	AttributeOperation,
 	RenameOperation,
-	SelectionChangeRangeEvent,
+	ModelSelectionChangeRangeEvent,
 	ModelDocumentFragment
 } from 'ckeditor5/src/engine.js';
 
@@ -235,7 +235,7 @@ export class LegacyTodoListEditing extends Plugin {
 			return;
 		}
 
-		model.document.selection.on<SelectionChangeRangeEvent>( 'change:range', () => {
+		model.document.selection.on<ModelSelectionChangeRangeEvent>( 'change:range', () => {
 			const focusParent = model.document.selection.focus!.parent;
 			const lastElementIsTodoList = isLegacyTodoListItemElement( lastFocusedCodeBlock );
 			const currentElementIsTodoList = isLegacyTodoListItemElement( focusParent );

--- a/packages/ckeditor5-list/src/todolist/todolistediting.ts
+++ b/packages/ckeditor5-list/src/todolist/todolistediting.ts
@@ -17,7 +17,7 @@ import {
 	type ViewDocumentArrowKeyEvent,
 	type MapperViewToModelPositionEvent,
 	type ViewDocumentFragment,
-	type SelectionChangeRangeEvent,
+	type ModelSelectionChangeRangeEvent,
 	type ModelDocumentFragment,
 	type ModelElement
 } from 'ckeditor5/src/engine.js';
@@ -387,7 +387,7 @@ export class TodoListEditing extends Plugin {
 			return;
 		}
 
-		model.document.selection.on<SelectionChangeRangeEvent>( 'change:range', () => {
+		model.document.selection.on<ModelSelectionChangeRangeEvent>( 'change:range', () => {
 			const focusParent = model.document.selection.focus!.parent;
 			const lastElementIsTodoList = isTodoListItemElement( lastFocusedCodeBlock );
 			const currentElementIsTodoList = isTodoListItemElement( focusParent );

--- a/packages/ckeditor5-typing/src/twostepcaretmovement.ts
+++ b/packages/ckeditor5-typing/src/twostepcaretmovement.ts
@@ -21,7 +21,7 @@ import {
 	type ModelPosition,
 	type ViewDocumentArrowKeyEvent,
 	type ViewDocumentMouseDownEvent,
-	type ViewDocumentSelectionChangeEvent,
+	type ViewDocumentObserverSelectionChangeEvent,
 	type ViewDocumentTouchStartEvent,
 	type ModelInsertContentEvent,
 	type ModelDeleteContentEvent
@@ -520,7 +520,7 @@ export class TwoStepCaretMovement extends Plugin {
 		} );
 
 		// When the selection has changed...
-		this.listenTo<ViewDocumentSelectionChangeEvent>( document, 'selectionChange', () => {
+		this.listenTo<ViewDocumentObserverSelectionChangeEvent>( document, 'selectionChange', () => {
 			const attributes = this.attributes;
 
 			if ( !clicked && !touched ) {

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -269,6 +269,7 @@ export {
 	type MenuBarConfig,
 	type MenuBarConfigObject,
 	type NormalizedMenuBarConfigObject,
+	type MenuBarMenuEvent,
 	type MenuBarMenuGroupDefinition,
 	type MenuBarMenuDefinition,
 	type MenuBarConfigAddedPosition,

--- a/packages/ckeditor5-ui/src/menubar/menubarview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarview.ts
@@ -430,7 +430,7 @@ export type MenuBarConfigAddedMenu = {
  * Any namespaced event fired by menu a {@link module:ui/menubar/menubarview~MenuBarView#menus menu view instance} of the
  * {@link module:ui/menubar/menubarview~MenuBarView menu bar}.
  */
-interface MenuBarMenuEvent extends BaseEvent {
+export interface MenuBarMenuEvent extends BaseEvent {
 	name: `menu:${ string }` | `menu:change:${ string }`;
 }
 

--- a/packages/ckeditor5-widget/src/widgettypearound/widgettypearound.ts
+++ b/packages/ckeditor5-widget/src/widgettypearound/widgettypearound.ts
@@ -42,7 +42,7 @@ import type {
 	ViewDowncastWriter,
 	ModelElement,
 	ModelSchema,
-	SelectionChangeRangeEvent,
+	ModelSelectionChangeRangeEvent,
 	ViewDocumentArrowKeyEvent,
 	ViewDocumentCompositionStartEvent,
 	ViewDocumentKeyDownEvent,
@@ -321,7 +321,7 @@ export class WidgetTypeAround extends Plugin {
 		// selection as soon as the model range changes. This attribute only makes sense when a widget is selected
 		// (and the "fake horizontal caret" is visible) so whenever the range changes (e.g. selection moved somewhere else),
 		// let's get rid of the attribute so that the selection downcast dispatcher isn't even bothered.
-		this._listenToIfEnabled<SelectionChangeRangeEvent>( modelSelection, 'change:range', ( evt, data ) => {
+		this._listenToIfEnabled<ModelSelectionChangeRangeEvent>( modelSelection, 'change:range', ( evt, data ) => {
 			// Do not reset the selection attribute when the change was indirect.
 			if ( !data.directChange ) {
 				return;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (code-block): Fixed missing reexport and rename for `ckeditor5-code-block`.
Internal (engine): Fixed missing reexport and rename for `ckeditor5-engine`.
Internal (fullscreen): Fixed missing reexport and rename for `ckeditor5-fullscreen`.
Internal (list): Fixed missing reexport and rename for `ckeditor5-list`.
Internal (typing): Fixed missing reexport and rename for `ckeditor5-typing`.
Internal (ui): Fixed missing reexport and rename for `ckeditor5-ui`.
Internal (widget): Fixed missing reexport and rename for `ckeditor5-widget`.

Part of https://github.com/ckeditor/ckeditor5/issues/18590.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
