### PR TITLE
Improved rendering paragraph within the list and table cell element

### DIFF
--- a/packages/ckeditor5-list/theme/listformatting.css
+++ b/packages/ckeditor5-list/theme/listformatting.css
@@ -10,24 +10,22 @@
 }
 
 .ck-content li {
-	/* Our opiniotanted styling in the lists, it prevents
-	 * the shift of content when a list is turned into a multi-block one
-	 * (enter + backspace scenario).
+	/* Opinionated list content styling: prevents content shift
+	 * when a list becomes multi-block (Enter + Backspace scenario).
 	 * See: https://github.com/ckeditor/ckeditor5/pull/18801
 	 */
 	& > p:first-of-type {
-		margin-block-start: 0;
+		margin-top: 0;
 	}
 
-	/* Rule which prevents the margins to appear when a
-	 * bogus paragraph gets a line height or text alignment.
-	 * We use only-of-type as the cell may have a div with column resize.
-	 * to provide more consistent experience with the first one.
+	/* Prevents margins from appearing when a bogus paragraph
+	 * receives line height or text alignment.
+	 * Ensures a consistent experience with the first paragraph.
 	 * See: https://github.com/ckeditor/ckeditor5/pull/18801
 	 */
 	& > p:only-child {
-		margin-block-start: 0;
-		margin-block-end: 0;
+		margin-top: 0;
+		margin-bottom: 0;
 	}
 
 	&.ck-list-marker-bold::marker {

--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -54,31 +54,25 @@
 
 				& > td,
 				& > th {
-					/* Our opiniotanted styling in the tables, it prevents
-					 * the shift of content when the enter is pressed at the top.
+					/* Opinionated table content styling: prevents content from shifting
+					 * when Enter is pressed in the first cell.
 					 * See: https://github.com/ckeditor/ckeditor5/pull/18801
 					 */
 					& > p:first-of-type {
-						margin-block-start: 0;
+						margin-top: 0;
 					}
 
-					/* Symmetrical to the above rule which styles the last paragraph
-					 * to provide more consistent experience with the first one.
+					/* Mirrors the rule above for the last paragraph to keep the
+					 * experience consistent with the first paragraph.
+					 *
+					 * Together, these rules prevent margins from appearing when a
+					 * bogus paragraph becomes a real paragraph after it receives line
+					 * height, text alignment, or other block style.
+					 *
 					 * See: https://github.com/ckeditor/ckeditor5/pull/18801
 					 */
 					& > p:last-of-type {
-						margin-block-end: 0;
-					}
-
-					/* Rule which prevents the margins to appear when a
-					 * bogus paragraph gets a line height or text alingment.
-					 * We use only-of-type as the cell may have a div with column resize.
-					 * to provide more consistent experience with the first one.
-					 * See: https://github.com/ckeditor/ckeditor5/pull/18801
-					 */
-					& > p:only-of-type {
-						margin-block-start: 0;
-						margin-block-end: 0;
+						margin-bottom: 0;
 					}
 
 					min-width: 2em;


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Fix (list, table): Improved rendering of the `<p>` element when it is an only child of a list item (`<li>`) or a table cell (`<td>` or `<th>`). Closes #17440.

Fix: (list, table): Improve the paragraphs spacing in lists and tables. Closes: #11347. 

MAJOR BREAKING CHANGE (list): Removed vertical spacing in list items by resetting margins for `<p>` elements that are the child of a `<li>` element.

MAJOR BREAKING CHANGE (table): Removed vertical spacing in table cells by collapsing margins of `<p>` elements that are the only child of a `<td>` or `<th>` element.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes cksource/ckeditor5-commercial#7990.

---

### 💡 Additional information


This PR aligns the margin-reset rules for paragraphs inside <strong>table cells</strong> (<code inline="">td</code>, <code inline="">th</code>) and <strong>list items</strong>. The change prevents unexpected vertical spacing when editors insert or modify content at the beginning or end of a cell or list item

#### Motivation / Context


* Fixes unintended content shift when users press <strong>Enter</strong> at the top of a table cell or creates a multi-block list item.

* Ensures symmetrical behaviour between the first and last paragraphs in the table cells,

* Handles the presence of CKEditor’s internal elements (e.g. <code inline="">.ck-table-column-resizer</code>) by switching from <code inline="">:only-child</code> to <code inline="">:only-of-type</code>, so the rule is applied as long as the paragraph is the sole <strong>paragraph</strong>, even if other non-paragraph nodes exist.</p>

* We thought of `margin-block-start/end` usage, but it's not supported well in emails :/


### Table cells (td, th) - line height

**Before**

<img width="25%" alt="image" src="https://github.com/user-attachments/assets/1b4910bc-da24-4156-a0ba-03ca925b9c97" />

**After**

 <img width="25%" alt="image" src="https://github.com/user-attachments/assets/c3af95b1-cf11-4f47-b77a-a409fa719b0e" />

### Lists (li) - line height

**Before**

 <img width="25%" alt="image" src="https://github.com/user-attachments/assets/bc4e22bb-0d59-4abb-8218-5cf08a00e911" />

**After**

<img width="25%" alt="image" src="https://github.com/user-attachments/assets/8e9a61b4-b5c9-4431-b16d-924a103e44ac" />

### Table cells (td, th) - editing

**Pay attention to the top/bottom of the cell**

**Before**


https://github.com/user-attachments/assets/a0d1c6ae-18a6-4681-9e84-5b4e6b4f106e


**After**

https://github.com/user-attachments/assets/fedc6e55-aa8b-4c7c-92a3-66a9ea9ce2ea


### Lists (li) - editing 

**Before**

https://github.com/user-attachments/assets/9676643d-3eee-493a-98ec-fc96ae38fe20

**After**

https://github.com/user-attachments/assets/0b5fa244-e756-4ee3-98b6-2e3c5880b44e






