### PR TITLE
Fix upcasting of `background-color` in tables. 

### DIFF
--- a/packages/ckeditor5-table/src/converters/tableproperties.ts
+++ b/packages/ckeditor5-table/src/converters/tableproperties.ts
@@ -32,6 +32,7 @@ export function upcastStyleToAttribute(
 		viewElement: string | RegExp;
 		defaultValue: string;
 		reduceBoxSides?: boolean;
+		shouldUpcast?: ( viewElement: ViewElement ) => boolean;
 	}
 ): void {
 	const {
@@ -41,6 +42,7 @@ export function upcastStyleToAttribute(
 		attributeType,
 		viewElement,
 		defaultValue,
+		shouldUpcast = () => true,
 		reduceBoxSides = false
 	} = options;
 
@@ -55,10 +57,7 @@ export function upcastStyleToAttribute(
 			key: modelAttribute,
 			value: ( viewElement: ViewElement, conversionApi: UpcastConversionApi, data: UpcastConversionData<ViewElement> ) => {
 				// Ignore table elements inside figures and figures without the table class.
-				if (
-					viewElement.name == 'table' && viewElement.parent!.name == 'figure' ||
-					viewElement.name == 'figure' && !viewElement.hasClass( 'table' )
-				) {
+				if ( !shouldUpcast( viewElement ) ) {
 					return;
 				}
 

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
@@ -363,6 +363,13 @@ function enableTableToFigureProperty(
 
 	schema.setAttributeProperties( modelAttribute, { isFormatting: true } );
 
-	upcastStyleToAttribute( conversion, { viewElement: /^(table|figure)$/, ...options } );
+	upcastStyleToAttribute( conversion, {
+		viewElement: /^(table|figure)$/,
+		shouldUpcast: ( viewElement: ViewElement ) =>
+			viewElement.name == 'table' && viewElement.parent!.name == 'figure' ||
+			viewElement.name == 'figure' && !viewElement.hasClass( 'table' ),
+		...options
+	} );
+
 	downcastAttributeToStyle( conversion, { modelElement: 'table', ...options } );
 }

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
@@ -365,9 +365,10 @@ function enableTableToFigureProperty(
 
 	upcastStyleToAttribute( conversion, {
 		viewElement: /^(table|figure)$/,
-		shouldUpcast: ( viewElement: ViewElement ) =>
+		shouldUpcast: ( viewElement: ViewElement ) => !(
 			viewElement.name == 'table' && viewElement.parent!.name == 'figure' ||
-			viewElement.name == 'figure' && !viewElement.hasClass( 'table' ),
+			viewElement.name == 'figure' && !viewElement.hasClass( 'table' )
+		),
 		...options
 	} );
 

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -1042,6 +1042,27 @@ describe( 'table properties', () => {
 					assertTableStyle( editor, 'background-color:#ba7;' );
 				} );
 			} );
+
+			it( 'data symmetry - should upcast downcasted tableBackgroundColor', () => {
+				editor.setData( '<table style="background-color:#f00"><tr><td>foo</td></tr></table>' );
+				const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+				expect( table.getAttribute( 'tableBackgroundColor' ) ).to.equal( '#f00' );
+
+				model.change( writer => writer.setAttribute( 'tableBackgroundColor', '#ba7', table ) );
+
+				expect( editor.getData() ).to.equalMarkup(
+					'<figure class="table">' +
+						'<table style="background-color:#ba7;">' +
+							'<tbody>' +
+								'<tr>' +
+									'<td>foo</td>' +
+								'</tr>' +
+							'</tbody>' +
+						'</table>' +
+					'</figure>'
+				);
+			} );
 		} );
 
 		describe( 'tableWidth', () => {

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -899,6 +899,24 @@ describe( 'table properties', () => {
 					expect( table.getAttribute( 'tableBackgroundColor' ) ).to.equal( '#f00' );
 				} );
 
+				it( 'should upcast background-color from table within <figure> with `.table` class', () => {
+					editor.setData(
+						'<figure class="table"><table style="background-color:#f00"><tr><td>foo</td></tr></table></figure>'
+					);
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableBackgroundColor' ) ).to.equal( '#f00' );
+				} );
+
+				it( 'should upcast background-color from table without <figure> without `.table` class', () => {
+					editor.setData(
+						'<figure><table style="background-color:#f00"><tr><td>foo</td></tr></table></figure>'
+					);
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableBackgroundColor' ) ).to.equal( '#f00' );
+				} );
+
 				it( 'should upcast from background shorthand', () => {
 					editor.setData( '<table style="background:#f00 center center"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );


### PR DESCRIPTION
### 🚀 Summary

Fix upcasting of `background-color` in tables. 

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5/issues/18803

---

### 💡 Additional information

Most likely related to https://github.com/ckeditor/ckeditor5/commit/71660f26fa2df1764edba36a3cd9ebdf2f278639#diff-251f3fa2633ce2469b2b3c1f3732db3b548eab2595295337591bc14c8caf3b15R57-R62