### PR TITLE
Display errors when building the editor for docs

### DIFF
--- a/scripts/docs/build-ckeditor-packages.mjs
+++ b/scripts/docs/build-ckeditor-packages.mjs
@@ -13,7 +13,8 @@ import { CKEDITOR5_ROOT_PATH, CKEDITOR5_COMMERCIAL_PATH } from '../constants.mjs
 import generateCKEditor5DocsBuild from './generate-ckeditor5-docs-build.mjs';
 
 buildCKEditorPackages()
-	.catch( () => {
+	.catch( error => {
+		console.error( error );
 		process.exitCode = 1;
 	} );
 


### PR DESCRIPTION
### 🚀 Summary

Show the actual error that caused the docs build to fail instead of only showing a generic `error Command failed with exit code 1` message.

---

### 📌 Related issues

* Closes #18810

---

### 💡 Additional information

**Before:**
![Zrzut ekranu z 2025-07-04 14-56-09](https://github.com/user-attachments/assets/9188bc42-8bee-43c1-9b3e-cc0e5a473497)

**After:**
![Zrzut ekranu z 2025-07-04 14-55-47](https://github.com/user-attachments/assets/c273a4a7-e308-42e7-8db2-3467b02a555a)

