### PR TITLE
List marker formatting should be restored when removed with remove-format feature.

### DIFF
--- a/packages/ckeditor5-list/src/listformatting.ts
+++ b/packages/ckeditor5-list/src/listformatting.ts
@@ -112,7 +112,8 @@ export class ListFormatting extends Plugin {
 					if (
 						entry.attributeKey == 'listItemId' ||
 						entry.attributeKey == 'listType' ||
-						this._isInlineOrSelectionFormatting( entry.attributeKey )
+						this._isInlineOrSelectionFormatting( entry.attributeKey ) ||
+						Object.values( this._loadedFormatting ).includes( entry.attributeKey )
 					) {
 						if ( isListItemBlock( entry.range.start.nodeAfter ) ) {
 							modifiedListItems.add( entry.range.start.nodeAfter );


### PR DESCRIPTION


### 🚀 Summary

List marker formatting should be restored when removed with remove-format feature.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #18796.

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
