### PR TITLE
Modified export validator to ensure command is exported as value instead of type.

### DIFF
--- a/scripts/ci/check-manual-tests-directory-structure.mjs
+++ b/scripts/ci/check-manual-tests-directory-structure.mjs
@@ -8,6 +8,7 @@
 import { globSync } from 'glob';
 import chalk from 'chalk';
 import { CKEDITOR5_ROOT_PATH } from '../constants.mjs';
+import upath from 'upath';
 
 // This script ensures that the "manual/" test directories are only located in the root
 // of the "tests" directories. Previously, they have been nested deeper, which prevents
@@ -19,7 +20,8 @@ const globPatterns = [
 	'tests/*/**/manual/**/*.@(js|ts|html|md)'
 ];
 
-const manualDirectoriesNotInTestsRoot = globPatterns.flatMap( pattern => globSync( pattern, { cwd: CKEDITOR5_ROOT_PATH } ) );
+const manualDirectoriesNotInTestsRoot = globPatterns
+	.flatMap( pattern => globSync( pattern, { cwd: CKEDITOR5_ROOT_PATH } ).map( upath.normalize ) );
 
 if ( manualDirectoriesNotInTestsRoot.length ) {
 	console.log( chalk.red( 'The "manual/" directory should be stored directly in the "tests/" directory.' ) );

--- a/scripts/ci/exports/policy/validate-command-exports.mjs
+++ b/scripts/ci/exports/policy/validate-command-exports.mjs
@@ -1,0 +1,62 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+import { mapper } from '../utils/logger.mjs';
+
+/**
+ * Validates that command classes are exported as values, not types.
+ * This prevents regressions related to #18583 where command classes were exported as types.
+ */
+export function validateCommandExports( library ) {
+	const errors = [];
+
+	for ( const pkg of library.packages.values() ) {
+		// Only check the index module!
+		const module = pkg.index;
+
+		if ( !module ) {
+			continue;
+		}
+
+		for ( const exportItem of module.exports ) {
+			if ( exportItem.exportKind === 'type' && exportItem.references ) {
+				if ( hasCommandClassReference( exportItem.references ) ) {
+					errors.push( {
+						...mapper.mapItemsViolatingPolicies( pkg, module, exportItem ),
+						'Action': 'Command class should be exported as value'
+					} );
+				}
+			}
+		}
+	}
+
+	return errors;
+}
+
+function hasCommandClassReference( ref, visited = new Set() ) {
+	if ( !ref ) {
+		return false;
+	}
+
+	if ( Array.isArray( ref ) ) {
+		return ref.some( r => hasCommandClassReference( r, visited ) );
+	}
+
+	if ( visited.has( ref ) ) {
+		return false;
+	}
+
+	visited.add( ref );
+
+	if ( ref.isCommandClass ) {
+		return true;
+	}
+
+	if ( ref.references ) {
+		return hasCommandClassReference( ref.references, visited );
+	}
+
+	return false;
+}

--- a/scripts/ci/exports/utils/getfilepaths.mjs
+++ b/scripts/ci/exports/utils/getfilepaths.mjs
@@ -19,6 +19,7 @@ export function getFilePaths() {
 	];
 
 	return globSync( typeScriptFilesGlobPaths )
+		.map( upath.normalize )
 		.filter( file => file.includes( 'ckeditor-cloud-services-collaboration' ) || !file.endsWith( '.d.ts' ) )
 		.filter( file => !file.includes( 'ckeditor5-build' ) )
 		.filter( file => !file.includes( 'ckeditor5-icons/' ) )

--- a/scripts/ci/exports/utils/module.mjs
+++ b/scripts/ci/exports/utils/module.mjs
@@ -532,22 +532,14 @@ export class Module {
 	}
 
 	get packageName() {
-		const normalizedPath = upath.normalize( this.fileName );
-		const pathParts = normalizedPath.split( upath.sep );
-		const packagesIndex = pathParts.indexOf( 'packages' );
-		const externalIndex = pathParts.indexOf( 'external' );
+		const packageDirMatch = this.fileName.match( /.+\/packages\/(.+?)\// );
+		const externalDirMatch = this.fileName.match( /.+\/external\/(.+?)\// );
 
-		const packageName = packagesIndex !== -1 ? pathParts[ packagesIndex + 1 ] : pathParts[ externalIndex + 1 ];
-
-		return upath.join( '@ckeditor', packageName );
+		return '@ckeditor/' + ( packageDirMatch ? packageDirMatch[ 1 ] : externalDirMatch[ 1 ] );
 	}
 
 	get relativeFileName() {
-		const normalizedPath = upath.normalize( this.fileName );
-		const pathParts = normalizedPath.split( upath.sep );
-		const srcIndex = pathParts.indexOf( 'src' );
-
-		return pathParts.slice( srcIndex + 1 ).join( upath.sep );
+		return this.fileName.replace( /.+\/src\//, '' );
 	}
 
 	resolvePath( fileName, packages ) {

--- a/scripts/ci/exports/utils/module.mjs
+++ b/scripts/ci/exports/utils/module.mjs
@@ -532,14 +532,22 @@ export class Module {
 	}
 
 	get packageName() {
-		const packageDirMatch = this.fileName.match( /.+\/packages\/(.+?)\// );
-		const externalDirMatch = this.fileName.match( /.+\/external\/(.+?)\// );
+		const normalizedPath = upath.normalize( this.fileName );
+		const pathParts = normalizedPath.split( upath.sep );
+		const packagesIndex = pathParts.indexOf( 'packages' );
+		const externalIndex = pathParts.indexOf( 'external' );
 
-		return '@ckeditor/' + ( packageDirMatch ? packageDirMatch[ 1 ] : externalDirMatch[ 1 ] );
+		const packageName = packagesIndex !== -1 ? pathParts[ packagesIndex + 1 ] : pathParts[ externalIndex + 1 ];
+
+		return upath.join( '@ckeditor', packageName );
 	}
 
 	get relativeFileName() {
-		return this.fileName.replace( /.+\/src\//, '' );
+		const normalizedPath = upath.normalize( this.fileName );
+		const pathParts = normalizedPath.split( upath.sep );
+		const srcIndex = pathParts.indexOf( 'src' );
+
+		return pathParts.slice( srcIndex + 1 ).join( upath.sep );
 	}
 
 	resolvePath( fileName, packages ) {

--- a/scripts/ci/validate-module-re-exports.mjs
+++ b/scripts/ci/validate-module-re-exports.mjs
@@ -9,6 +9,7 @@ import { publicTree } from './exports/policy/public-tree.mjs';
 import { isCommandClass } from './exports/policy/is-command.mjs';
 import { isPluginClass } from './exports/policy/is-plugin.mjs';
 import { isEvent } from './exports/policy/is-event.mjs';
+import { validateCommandExports } from './exports/policy/validate-command-exports.mjs';
 import { Export } from './exports/utils/export.mjs';
 import { logData, mapper } from './exports/utils/logger.mjs';
 import chalk from 'chalk';
@@ -38,7 +39,8 @@ async function main() {
 
 	const exportsToFix = getExportsToFix( library );
 	const declarationsWithMissingExports = getDeclarationsWithMissingExports( library );
-	const dataToLogUnwrapped = [ ...declarationsWithMissingExports, ...exportsToFix ];
+	const commandExportErrors = validateCommandExports( library );
+	const dataToLogUnwrapped = [ ...declarationsWithMissingExports, ...exportsToFix, ...commandExportErrors ];
 
 	// Do not log exceptions that are expected as errors.
 	const data = removeExpectedExceptions( dataToLogUnwrapped );


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Modified export validator to ensure command is exported as value instead of type.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes ckeditor/ckeditor5#18804

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
