### PR TITLE
Docs: Remove outdated warning from NIM migration guide.

### DIFF
--- a/docs/updating/nim-migration/customized-builds.md
+++ b/docs/updating/nim-migration/customized-builds.md
@@ -13,10 +13,6 @@ Migrating from a customized build to the new installation methods should mostly 
 
 Regardless of whether you used our old Online Builder or created a custom build from source using webpack or Vite, the new installation methods allow you to build and run the editor with any bundler or JavaScript meta-framework you like. This means that by the end of the migration, you can remove the CKEditor-specific webpack or Vite setup from your project if you already use another bundler to build your project.
 
-<info-box warning>
-	Currently, the new installation methods do not support {@link framework/how-tos#how-to-customize-the-ckeditor-5-icons the customization of the CKEditor&nbsp;5 icons}. This feature will be added in a future release.
-</info-box>
-
 ## Prerequisites
 
 Before you start, follow the usual upgrade path to update your project to use the latest version of CKEditor&nbsp;5. This will rule out any problems that may be caused by upgrading from an outdated version of the editor.


### PR DESCRIPTION
Docs: Remove outdated warning from NIM migration guide.