### PR TITLE
Set concurrency in release scripts to guarantee at least 1 CPU core and 1 GB of free RAM per task

### DIFF
--- a/scripts/release/utils/parsearguments.mjs
+++ b/scripts/release/utils/parsearguments.mjs
@@ -4,7 +4,7 @@
  */
 
 import minimist from 'minimist';
-import os from 'os';
+import { cpus, freemem } from 'os';
 import replaceKebabCaseWithCamelCase from '../../utils/replacekebabcasewithcamelcase.mjs';
 
 /**
@@ -41,7 +41,16 @@ export default function parseArguments( cliArguments ) {
 			nightly: false,
 			'nightly-alpha': false,
 			'nightly-next': false,
-			concurrency: os.cpus().length / 2,
+			// Set concurrency to guarantee at least 1 CPU core and 1 GB of free RAM per task.
+			// No less than 1, no more than 8.
+			concurrency: Math.max(
+				1,
+				Math.min(
+					cpus().length,
+					Math.floor( freemem() / ( 1024 ** 3 ) ),
+					8
+				)
+			),
 			'compile-only': false,
 			packages: null,
 			branch: 'release',


### PR DESCRIPTION
### 🚀 Summary

Set concurrency in release scripts to guarantee at least 1 CPU core and 1 GB of free RAM per task.

### 📌 Related issues

* See https://github.com/cksource/ckeditor5-commercial/issues/8048.

---

This PR addresses an out-of-memory (OOM) issue by capping the maximum build concurrency.

I benchmarked the impact of different concurrency levels on build performance. The results were:

* **1 → 4 concurrent builds**: Significant improvement, reducing build time from ~450 s to ~270 s.
* **4 → 8 concurrent builds**: Modest improvement, dropping to ~240 s.
* **8 → 16 concurrent builds**: No measurable performance gain.

~~Given the diminishing returns beyond 4 concurrent builds and to avoid more complex solutions (for example, based on CPU cores **and** available memory), this PR sets the maximum concurrency to 4 as a balanced default.~~

I verified the fix by running the full CI pipeline three times for this PR and cksource/ckeditor5-commercial#8052. The builds completed successfully (the failing CI status in the second PR is unrelated and occurred in post-build steps).
