### PR TITLE
Described new option for an eslint rule

### DIFF
--- a/docs/framework/contributing/code-style.md
+++ b/docs/framework/contributing/code-style.md
@@ -815,7 +815,7 @@ While importing modules from other packages, it is not allowed to use relative p
 
 Options:
 
-* `newInstallationMethod` (`boolean`) &ndash; (optional) enforces usage of package entry points.
+* `usePackageEntryPoint` (`boolean`) &ndash; (optional) enforces usage of package entry points.
 
 👎&nbsp; Examples of incorrect code for this rule:
 
@@ -826,7 +826,7 @@ import CKEditorError from '../../../ckeditor5-utils/src/ckeditorerror';
 ```
 
 ```js
-// Assume we use the `newInstallationMethod` option.
+// Assume we use the `usePackageEntryPoint` option.
 
 import Foo from '@ckeditor/ckeditor5-core/src/foo.js';
 ```
@@ -842,7 +842,7 @@ import { CKEditorError } from 'ckeditor5';
 ```
 
 ```js
-// Assume we use the `newInstallationMethod` option.
+// Assume we use the `usePackageEntryPoint` option.
 
 import { Foo } from '@ckeditor/ckeditor5-core';
 ```

--- a/docs/framework/contributing/code-style.md
+++ b/docs/framework/contributing/code-style.md
@@ -813,12 +813,22 @@ import insertContent from './utils/insertcontent';
 
 While importing modules from other packages, it is not allowed to use relative paths, and the import must be done using the package name, like this:
 
+Options:
+
+* `newInstallationMethod` (`boolean`) &ndash; (optional) enforces usage of package entry points.
+
 👎&nbsp; Examples of incorrect code for this rule:
 
 ```js
 // Assume we edit a file located in the path: `packages/ckeditor5-engine/src/model/model.js`
 
 import CKEditorError from '../../../ckeditor5-utils/src/ckeditorerror';
+```
+
+```js
+// Assume we use the `newInstallationMethod` option.
+
+import Foo from '@ckeditor/ckeditor5-core/src/foo.js';
 ```
 
 Even if the import statement works locally, it will throw an error when developers install packages from npm.
@@ -829,6 +839,12 @@ Even if the import statement works locally, it will throw an error when develope
 // Assume we edit a file located in the path: `packages/ckeditor5-engine/src/model/model.js`
 
 import { CKEditorError } from 'ckeditor5';
+```
+
+```js
+// Assume we use the `newInstallationMethod` option.
+
+import { Foo } from '@ckeditor/ckeditor5-core';
 ```
 
 [History of the change.](https://github.com/ckeditor/ckeditor5/issues/7128)


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Described `usePackageEntryPoint` option for `ckeditor5-rules/no-relative-imports` rule that enforces usage of package entry points.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* See #18857

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
