### PR TITLE
Fix not working replace of img src-set attributes in docs snippets.

### DIFF
--- a/docs/assets/global.js
+++ b/docs/assets/global.js
@@ -153,7 +153,7 @@ function createNotification( title, message ) {
 		element.setAttribute( 'srcset', srcset );
 	}
 
-	[ ...document.querySelectorAll( '.content-inner img' ) ]
+	[ ...document.querySelectorAll( '.live-snippet .ck-content img' ) ]
 		.filter( img => isRelativeUrl( img.getAttribute( 'src' ) ) )
 		.forEach( img => {
 			// Update `<img src="...">`.


### PR DESCRIPTION
### 🚀 Summary

The Export PDF and other export-related plugins do not work well with the relative image paths. In the old Umberto theme, this was resolved by querying all images and enforcing absolute paths. However, the names of the classes have changed, causing the plugin to ignore images and resulting in export-pdf demos failing.

---

### 📌 Related issues

Related issue https://github.com/cksource/ckeditor5-commercial/pull/8071