### PR TITLE
Fixed duplicate global identifier

### DIFF
--- a/.changelog/20250723121141_ck_18856.md
+++ b/.changelog/20250723121141_ck_18856.md
@@ -1,0 +1,45 @@
+---
+# Required: Type of change.
+# Allowed values:
+# - Feature
+# - Fix
+# - Other
+# - Major breaking change
+# - Minor breaking change
+#
+# For guidance on breaking changes, see:
+# https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html#major-and-minor-breaking-changes
+type: Fix
+
+# Optional: Affected package(s), using short names.
+# Can be skipped when processing a non-mono-repository.
+# Example: ckeditor5-core
+scope:
+  - ckeditor5-utils
+
+# Optional: Issues this change closes.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+closes:
+  - 18856
+
+# Optional: Related issues.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+see:
+  - 
+
+# Optional: Community contributors.
+# Format:
+# - {github-username}
+communityCredits:
+  - 
+
+# Before committing, consider removing all comments to reduce file size and enhance readability.
+---
+
+Fixed the `Identifier 'global' has already been declared.` error being thrown in some environments due to global variable name in `ckeditor5-utils` package.

--- a/packages/ckeditor5-utils/src/dom/global.ts
+++ b/packages/ckeditor5-utils/src/dom/global.ts
@@ -32,11 +32,11 @@ export interface GlobalType {
  * console.log( global.window.innerWidth );
  * ```
  */
-let global: GlobalType; // named globalVar instead of global: https://github.com/ckeditor/ckeditor5/issues/12971
+let globalVar: GlobalType; // named globalVar instead of global: https://github.com/ckeditor/ckeditor5/issues/12971
 
 // In some environments window and document API might not be available.
 try {
-	global = { window, document };
+	globalVar = { window, document };
 } catch {
 	// It's not possible to mock a window object to simulate lack of a window object without writing extremely convoluted code.
 	/* istanbul ignore next -- @preserve */
@@ -45,7 +45,7 @@ try {
 	// We only handle this so loading editor in environments without window and document doesn't fail.
 	// For better DX we shouldn't introduce mixed types and require developers to check the type manually.
 	// This module should not be used on purpose in any environment outside browser.
-	global = { window: {} as any, document: {} as any };
+	globalVar = { window: {} as any, document: {} as any };
 }
 
-export { global };
+export { globalVar as global };

--- a/scripts/ci/validate-module-re-exports.mjs
+++ b/scripts/ci/validate-module-re-exports.mjs
@@ -166,5 +166,6 @@ function removeExpectedExceptions( data ) {
 		.filter( record => !memberExistInRecord( record, '@ckeditor/ckeditor5-engine', 'ViewUpcastWriter' ) )
 		// TODO Remove after it is moved to the clipboard package.
 		.filter( record => !memberExistInRecord( record, '@ckeditor/ckeditor5-image', 'isHtmlInDataTransfer' ) )
-		.filter( record => !memberExistInRecord( record, '@ckeditor/ckeditor5-find-and-replace', 'FindReplaceCommandBase' ) );
+		.filter( record => !memberExistInRecord( record, '@ckeditor/ckeditor5-find-and-replace', 'FindReplaceCommandBase' ) )
+		.filter( record => !memberExistInRecord( record, '@ckeditor/ckeditor5-utils', 'globalVar' ) );
 }


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Fixed the `Identifier 'global' has already been declared.` error being thrown in some environments due to global variable name in `ckeditor5-utils` package.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #18856

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
