### PR TITLE
Docs: Make sure `snippet.css` is included before `snippet.js`.

### DIFF
--- a/scripts/docs/snippetadapter.mjs
+++ b/scripts/docs/snippetadapter.mjs
@@ -205,12 +205,12 @@ async function buildDocuments( snippets, paths, constants, imports, getSnippetPl
 				() => `<div class="doc live-snippet ${ snippetSizeCssClass }">${ data }</div>`
 			);
 
-			if ( await fileExists( upath.join( snippet.outputPath, snippet.snippetName, 'snippet.js' ) ) ) {
-				documentTags.push( getScript( `%BASE_PATH%/snippets/${ snippet.snippetName }/snippet.js` ) );
-			}
-
 			if ( await fileExists( upath.join( snippet.outputPath, snippet.snippetName, 'snippet.css' ) ) ) {
 				documentTags.push( getStyle( `%BASE_PATH%/snippets/${ snippet.snippetName }/snippet.css` ) );
+			}
+
+			if ( await fileExists( upath.join( snippet.outputPath, snippet.snippetName, 'snippet.js' ) ) ) {
+				documentTags.push( getScript( `%BASE_PATH%/snippets/${ snippet.snippetName }/snippet.js` ) );
 			}
 		}
 


### PR DESCRIPTION
### 🚀 Summary

Occasionally, `snippet.js` runs before `snippet.css` is parsed and available via `document.querySelector`, causing instability in the verify utility on demos relying on `querySnippetCSSUrl`. This PR ensures that the CSS is loaded and available before `snippet.js` is executed, stabilizing PDF export functionality in the docs.

---

### 📌 Related PRs

Source PR:
https://github.com/ckeditor/ckeditor5/pull/18887/files#diff-5b4762b6792aa2a933df1fc08e8441b6949b053be4cc4dd8703be6d8f3ac7254R288
