### PR TITLE
feat: Add support for specific table border sides

### DIFF
--- a/packages/ckeditor5-table/src/converters/tableproperties.ts
+++ b/packages/ckeditor5-table/src/converters/tableproperties.ts
@@ -209,6 +209,27 @@ export function upcastBorderStyles(
 
 		if ( reducedBorder.style !== localDefaultBorder.style ) {
 			conversionApi.writer.setAttribute( modelAttributes.style, reducedBorder.style, modelElement );
+		} else {
+			const borderTopStyle = normalizedBorder.style.top;
+			const borderRightStyle = normalizedBorder.style.right;
+			const borderBottomStyle = normalizedBorder.style.bottom;
+			const borderLeftStyle = normalizedBorder.style.left;
+
+			if ( borderTopStyle && borderTopStyle !== localDefaultBorder.style ) {
+				conversionApi.writer.setAttribute( 'borderTopStyle', borderTopStyle, modelElement );
+			}
+
+			if ( borderRightStyle && borderRightStyle !== localDefaultBorder.style ) {
+				conversionApi.writer.setAttribute( 'borderRightStyle', borderRightStyle, modelElement );
+			}
+
+			if ( borderBottomStyle && borderBottomStyle !== localDefaultBorder.style ) {
+				conversionApi.writer.setAttribute( 'borderBottomStyle', borderBottomStyle, modelElement );
+			}
+
+			if ( borderLeftStyle && borderLeftStyle !== localDefaultBorder.style ) {
+				conversionApi.writer.setAttribute( 'borderLeftStyle', borderLeftStyle, modelElement );
+			}
 		}
 
 		if ( reducedBorder.color !== localDefaultBorder.color ) {
@@ -247,6 +268,38 @@ export function downcastAttributeToStyle(
 				[ styleName ]: modelAttributeValue
 			}
 		} )
+	} );
+}
+
+/**
+ * Conversion helper for downcasting an attribute to a style.
+ *
+ * @internal
+ */
+export function downcastAttributeToSpecificStyle(
+	conversion: Conversion,
+	options: {
+		modelElement: string;
+		modelAttribute: string;
+		styleName: string;
+	}
+): void {
+	const { modelElement, modelAttribute, styleName } = options;
+
+	conversion.for( 'downcast' ).attributeToAttribute( {
+		model: {
+			name: modelElement,
+			key: modelAttribute
+		},
+		view: ( modelAttributeValue, { writer } ) => {
+			if ( !modelAttributeValue ) {
+				return;
+			}
+
+			return writer.createAttributeElement( 'span', {
+				style: `${ styleName }:${ modelAttributeValue }`
+			} );
+		}
 	} );
 }
 

--- a/packages/ckeditor5-table/src/tableproperties/commands/tableborderbottomstylecommand.ts
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tableborderbottomstylecommand.ts
@@ -1,0 +1,61 @@
+import { Command } from 'ckeditor5/src/core';
+
+import { getNewTableProperty } from '../../utils/table-properties';
+
+import type { Batch } from 'ckeditor5/src/engine';
+
+/**
+ * The table border bottom style command.
+ *
+ * The command is registered by {@link module:table/tableproperties/tablepropertiesediting~TablePropertiesEditing} as
+ * the `'tableBorderBottomStyle'` editor command.
+ *
+ * To change the bottom border style of a table, execute the command:
+ *
+ *		editor.execute( 'tableBorderBottomStyle', {
+ *			value: 'dashed'
+ *		} );
+ */
+export class TableBorderBottomStyleCommand extends Command {
+	/**
+	 * The default border style.
+	 */
+	declare public readonly defaultValue: string;
+
+	/**
+	 * @inheritDoc
+	 */
+	constructor( editor, defaultValue ) {
+		super( editor );
+
+		this.defaultValue = defaultValue;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public override refresh(): void {
+		const editor = this.editor;
+		const model = editor.model;
+		const document = model.document;
+
+		const table = document.selection.getFirstPosition().findAncestor( 'table' );
+
+		this.isEnabled = !!table;
+		this.value = this.isEnabled ? table.getAttribute( 'borderBottomStyle' ) || this.defaultValue : this.defaultValue;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public override execute( options: { value?: unknown; batch?: Batch } = {} ): void {
+		this.editor.model.change( writer => {
+			const value = getNewTableProperty( options.value, this.value, this.defaultValue );
+			const selectedCells = this.editor.model.document.selection.getSelectedCells();
+
+			for ( const cell of selectedCells ) {
+				writer.setAttribute( 'borderBottomStyle', value, cell );
+			}
+		} );
+	}
+}

--- a/packages/ckeditor5-table/src/tableproperties/commands/tableborderleftstylecommand.ts
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tableborderleftstylecommand.ts
@@ -1,0 +1,61 @@
+import { Command } from 'ckeditor5/src/core';
+
+import { getNewTableProperty } from '../../utils/table-properties';
+
+import type { Batch } from 'ckeditor5/src/engine';
+
+/**
+ * The table border left style command.
+ *
+ * The command is registered by {@link module:table/tableproperties/tablepropertiesediting~TablePropertiesEditing} as
+ * the `'tableBorderLeftStyle'` editor command.
+ *
+ * To change the left border style of a table, execute the command:
+ *
+ *		editor.execute( 'tableBorderLeftStyle', {
+ *			value: 'dashed'
+ *		} );
+ */
+export class TableBorderLeftStyleCommand extends Command {
+	/**
+	 * The default border style.
+	 */
+	declare public readonly defaultValue: string;
+
+	/**
+	 * @inheritDoc
+	 */
+	constructor( editor, defaultValue ) {
+		super( editor );
+
+		this.defaultValue = defaultValue;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public override refresh(): void {
+		const editor = this.editor;
+		const model = editor.model;
+		const document = model.document;
+
+		const table = document.selection.getFirstPosition().findAncestor( 'table' );
+
+		this.isEnabled = !!table;
+		this.value = this.isEnabled ? table.getAttribute( 'borderLeftStyle' ) || this.defaultValue : this.defaultValue;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public override execute( options: { value?: unknown; batch?: Batch } = {} ): void {
+		this.editor.model.change( writer => {
+			const value = getNewTableProperty( options.value, this.value, this.defaultValue );
+			const selectedCells = this.editor.model.document.selection.getSelectedCells();
+
+			for ( const cell of selectedCells ) {
+				writer.setAttribute( 'borderLeftStyle', value, cell );
+			}
+		} );
+	}
+}

--- a/packages/ckeditor5-table/src/tableproperties/commands/tableborderrightstylecommand.ts
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tableborderrightstylecommand.ts
@@ -1,0 +1,61 @@
+import { Command } from 'ckeditor5/src/core';
+
+import { getNewTableProperty } from '../../utils/table-properties';
+
+import type { Batch } from 'ckeditor5/src/engine';
+
+/**
+ * The table border right style command.
+ *
+ * The command is registered by {@link module:table/tableproperties/tablepropertiesediting~TablePropertiesEditing} as
+ * the `'tableBorderRightStyle'` editor command.
+ *
+ * To change the right border style of a table, execute the command:
+ *
+ *		editor.execute( 'tableBorderRightStyle', {
+ *			value: 'dashed'
+ *		} );
+ */
+export class TableBorderRightStyleCommand extends Command {
+	/**
+	 * The default border style.
+	 */
+	declare public readonly defaultValue: string;
+
+	/**
+	 * @inheritDoc
+	 */
+	constructor( editor, defaultValue ) {
+		super( editor );
+
+		this.defaultValue = defaultValue;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public override refresh(): void {
+		const editor = this.editor;
+		const model = editor.model;
+		const document = model.document;
+
+		const table = document.selection.getFirstPosition().findAncestor( 'table' );
+
+		this.isEnabled = !!table;
+		this.value = this.isEnabled ? table.getAttribute( 'borderRightStyle' ) || this.defaultValue : this.defaultValue;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public override execute( options: { value?: unknown; batch?: Batch } = {} ): void {
+		this.editor.model.change( writer => {
+			const value = getNewTableProperty( options.value, this.value, this.defaultValue );
+			const selectedCells = this.editor.model.document.selection.getSelectedCells();
+
+			for ( const cell of selectedCells ) {
+				writer.setAttribute( 'borderRightStyle', value, cell );
+			}
+		} );
+	}
+}

--- a/packages/ckeditor5-table/src/tableproperties/commands/tablebordertopstylecommand.ts
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tablebordertopstylecommand.ts
@@ -1,0 +1,61 @@
+import { Command } from 'ckeditor5/src/core';
+
+import { getNewTableProperty } from '../../utils/table-properties';
+
+import type { Batch } from 'ckeditor5/src/engine';
+
+/**
+ * The table border top style command.
+ *
+ * The command is registered by {@link module:table/tableproperties/tablepropertiesediting~TablePropertiesEditing} as
+ * the `'tableBorderTopStyle'` editor command.
+ *
+ * To change the top border style of a table, execute the command:
+ *
+ *		editor.execute( 'tableBorderTopStyle', {
+ *			value: 'dashed'
+ *		} );
+ */
+export class TableBorderTopStyleCommand extends Command {
+	/**
+	 * The default border style.
+	 */
+	declare public readonly defaultValue: string;
+
+	/**
+	 * @inheritDoc
+	 */
+	constructor( editor, defaultValue ) {
+		super( editor );
+
+		this.defaultValue = defaultValue;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public override refresh(): void {
+		const editor = this.editor;
+		const model = editor.model;
+		const document = model.document;
+
+		const table = document.selection.getFirstPosition().findAncestor( 'table' );
+
+		this.isEnabled = !!table;
+		this.value = this.isEnabled ? table.getAttribute( 'borderTopStyle' ) || this.defaultValue : this.defaultValue;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public override execute( options: { value?: unknown; batch?: Batch } = {} ): void {
+		this.editor.model.change( writer => {
+			const value = getNewTableProperty( options.value, this.value, this.defaultValue );
+			const selectedCells = this.editor.model.document.selection.getSelectedCells();
+
+			for ( const cell of selectedCells ) {
+				writer.setAttribute( 'borderTopStyle', value, cell );
+			}
+		} );
+	}
+}

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
@@ -29,6 +29,10 @@ import {
 import { TableBackgroundColorCommand } from './commands/tablebackgroundcolorcommand.js';
 import { TableBorderColorCommand } from './commands/tablebordercolorcommand.js';
 import { TableBorderStyleCommand } from './commands/tableborderstylecommand.js';
+import { TableBorderTopStyleCommand } from './commands/tablebordertopstylecommand.js';
+import { TableBorderRightStyleCommand } from './commands/tableborderrightstylecommand.js';
+import { TableBorderBottomStyleCommand } from './commands/tableborderbottomstylecommand.js';
+import { TableBorderLeftStyleCommand } from './commands/tableborderleftstylecommand.js';
 import { TableBorderWidthCommand } from './commands/tableborderwidthcommand.js';
 import { TableWidthCommand } from './commands/tablewidthcommand.js';
 import { TableHeightCommand } from './commands/tableheightcommand.js';
@@ -103,6 +107,10 @@ export class TablePropertiesEditing extends Plugin {
 
 		editor.commands.add( 'tableBorderColor', new TableBorderColorCommand( editor, defaultTableProperties.borderColor ) );
 		editor.commands.add( 'tableBorderStyle', new TableBorderStyleCommand( editor, defaultTableProperties.borderStyle ) );
+		editor.commands.add( 'tableBorderTopStyle', new TableBorderTopStyleCommand( editor, defaultTableProperties.borderStyle ) );
+		editor.commands.add( 'tableBorderRightStyle', new TableBorderRightStyleCommand( editor, defaultTableProperties.borderStyle ) );
+		editor.commands.add( 'tableBorderBottomStyle', new TableBorderBottomStyleCommand( editor, defaultTableProperties.borderStyle ) );
+		editor.commands.add( 'tableBorderLeftStyle', new TableBorderLeftStyleCommand( editor, defaultTableProperties.borderStyle ) );
 		editor.commands.add( 'tableBorderWidth', new TableBorderWidthCommand( editor, defaultTableProperties.borderWidth ) );
 
 		enableAlignmentProperty( schema, conversion, defaultTableProperties.alignment! );
@@ -157,7 +165,11 @@ function enableBorderProperties(
 	const modelAttributes = {
 		width: 'tableBorderWidth',
 		color: 'tableBorderColor',
-		style: 'tableBorderStyle'
+		style: 'tableBorderStyle',
+		topStyle: 'borderTopStyle',
+		rightStyle: 'borderRightStyle',
+		bottomStyle: 'borderBottomStyle',
+		leftStyle: 'borderLeftStyle'
 	};
 
 	schema.extend( 'table', {
@@ -172,6 +184,10 @@ function enableBorderProperties(
 
 	downcastTableAttribute( conversion, { modelAttribute: modelAttributes.color, styleName: 'border-color' } );
 	downcastTableAttribute( conversion, { modelAttribute: modelAttributes.style, styleName: 'border-style' } );
+	downcastTableAttribute( conversion, { modelAttribute: modelAttributes.topStyle, styleName: 'border-top-style' } );
+	downcastTableAttribute( conversion, { modelAttribute: modelAttributes.rightStyle, styleName: 'border-right-style' } );
+	downcastTableAttribute( conversion, { modelAttribute: modelAttributes.bottomStyle, styleName: 'border-bottom-style' } );
+	downcastTableAttribute( conversion, { modelAttribute: modelAttributes.leftStyle, styleName: 'border-left-style' } );
 	downcastTableAttribute( conversion, { modelAttribute: modelAttributes.width, styleName: 'border-width' } );
 }
 

--- a/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.ts
+++ b/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.ts
@@ -91,7 +91,47 @@ export class TablePropertiesView extends View {
 	 * @observable
 	 * @default ''
 	 */
+	declare public border: string;
+
+	/**
+	 * The value of the border style.
+	 *
+	 * @observable
+	 * @default ''
+	 */
 	declare public borderStyle: string;
+
+	/**
+	 * The value of the top border style.
+	 *
+	 * @observable
+	 * @default ''
+	 */
+	declare public borderTopStyle: string;
+
+	/**
+	 * The value of the right border style.
+	 *
+	 * @observable
+	 * @default ''
+	 */
+	declare public borderRightStyle: string;
+
+	/**
+	 * The value of the bottom border style.
+	 *
+	 * @observable
+	 * @default ''
+	 */
+	declare public borderBottomStyle: string;
+
+	/**
+	 * The value of the left border style.
+	 *
+	 * @observable
+	 * @default ''
+	 */
+	declare public borderLeftStyle: string;
 
 	/**
 	 * The value of the border width style.
@@ -167,6 +207,26 @@ export class TablePropertiesView extends View {
 	public readonly borderStyleDropdown: LabeledFieldView<DropdownView>;
 
 	/**
+	 * A dropdown that allows selecting the style of the table top border.
+	 */
+	public readonly borderTopStyleDropdown: LabeledFieldView<DropdownView>;
+
+	/**
+	 * A dropdown that allows selecting the style of the table right border.
+	 */
+	public readonly borderRightStyleDropdown: LabeledFieldView<DropdownView>;
+
+	/**
+	 * A dropdown that allows selecting the style of the table bottom border.
+	 */
+	public readonly borderBottomStyleDropdown: LabeledFieldView<DropdownView>;
+
+	/**
+	 * A dropdown that allows selecting the style of the table left border.
+	 */
+	public readonly borderLeftStyleDropdown: LabeledFieldView<DropdownView>;
+
+	/**
 	 * An input that allows specifying the width of the table border.
 	 */
 	public readonly borderWidthInput: LabeledFieldView<InputTextView>;
@@ -224,7 +284,12 @@ export class TablePropertiesView extends View {
 		super( locale );
 
 		this.set( {
+			border: 'all',
 			borderStyle: '',
+			borderTopStyle: '',
+			borderRightStyle: '',
+			borderBottomStyle: '',
+			borderLeftStyle: '',
 			borderWidth: '',
 			borderColor: '',
 			backgroundColor: '',
@@ -235,7 +300,16 @@ export class TablePropertiesView extends View {
 
 		this.options = options;
 
-		const { borderStyleDropdown, borderWidthInput, borderColorInput, borderRowLabel } = this._createBorderFields();
+		const {
+			borderStyleDropdown,
+			borderTopStyleDropdown,
+			borderRightStyleDropdown,
+			borderBottomStyleDropdown,
+			borderLeftStyleDropdown,
+			borderWidthInput,
+			borderColorInput,
+			borderRowLabel
+		} = this._createBorderFields();
 		const { backgroundRowLabel, backgroundInput } = this._createBackgroundFields();
 		const { widthInput, operatorLabel, heightInput, dimensionsLabel } = this._createDimensionFields();
 		const { alignmentToolbar, alignmentLabel } = this._createAlignmentFields();
@@ -245,6 +319,10 @@ export class TablePropertiesView extends View {
 		this.children = this.createCollection();
 
 		this.borderStyleDropdown = borderStyleDropdown;
+		this.borderTopStyleDropdown = borderTopStyleDropdown;
+		this.borderRightStyleDropdown = borderRightStyleDropdown;
+		this.borderBottomStyleDropdown = borderBottomStyleDropdown;
+		this.borderLeftStyleDropdown = borderLeftStyleDropdown;
 		this.borderWidthInput = borderWidthInput;
 		this.borderColorInput = borderColorInput;
 		this.backgroundInput = backgroundInput;
@@ -284,6 +362,10 @@ export class TablePropertiesView extends View {
 			children: [
 				borderRowLabel,
 				borderStyleDropdown,
+				borderTopStyleDropdown,
+				borderRightStyleDropdown,
+				borderBottomStyleDropdown,
+				borderLeftStyleDropdown,
 				borderColorInput,
 				borderWidthInput
 			],
@@ -369,6 +451,10 @@ export class TablePropertiesView extends View {
 
 		[
 			this.borderStyleDropdown,
+			this.borderTopStyleDropdown,
+			this.borderRightStyleDropdown,
+			this.borderBottomStyleDropdown,
+			this.borderLeftStyleDropdown,
 			this.borderColorInput,
 			this.borderWidthInput,
 			this.backgroundInput,
@@ -468,6 +554,134 @@ export class TablePropertiesView extends View {
 			ariaLabel: accessibleLabel
 		} );
 
+		// -- Top Style ---------------------------------------------------
+
+		const borderTopStyleDropdown = new LabeledFieldView( locale, createLabeledDropdown );
+		borderTopStyleDropdown.set( {
+			label: t( 'Top border style' ),
+			class: 'ck-table-form__border-style'
+		} );
+
+		borderTopStyleDropdown.fieldView.buttonView.set( {
+			ariaLabel: t( 'Top border style' ),
+			ariaLabelledBy: undefined,
+			isOn: false,
+			withText: true,
+			tooltip: t( 'Top border style' )
+		} );
+
+		borderTopStyleDropdown.fieldView.buttonView.bind( 'label' ).to( this, 'borderTopStyle', value => {
+			return styleLabels[ value ? value : 'none' ];
+		} );
+
+		borderTopStyleDropdown.fieldView.on( 'execute', evt => {
+			this.borderTopStyle = ( evt.source as any )._borderStyleValue;
+		} );
+
+		borderTopStyleDropdown.bind( 'isEmpty' ).to( this, 'borderTopStyle', value => !value );
+		borderTopStyleDropdown.bind( 'isVisible' ).to( this, 'border', value => value === 'separate' );
+
+		addListToDropdown( borderTopStyleDropdown.fieldView, getBorderStyleDefinitions( this, defaultBorder.style! ), {
+			role: 'menu',
+			ariaLabel: t( 'Top border style' )
+		} );
+
+		// -- Right Style ---------------------------------------------------
+
+		const borderRightStyleDropdown = new LabeledFieldView( locale, createLabeledDropdown );
+		borderRightStyleDropdown.set( {
+			label: t( 'Right border style' ),
+			class: 'ck-table-form__border-style'
+		} );
+
+		borderRightStyleDropdown.fieldView.buttonView.set( {
+			ariaLabel: t( 'Right border style' ),
+			ariaLabelledBy: undefined,
+			isOn: false,
+			withText: true,
+			tooltip: t( 'Right border style' )
+		} );
+
+		borderRightStyleDropdown.fieldView.buttonView.bind( 'label' ).to( this, 'borderRightStyle', value => {
+			return styleLabels[ value ? value : 'none' ];
+		} );
+
+		borderRightStyleDropdown.fieldView.on( 'execute', evt => {
+			this.borderRightStyle = ( evt.source as any )._borderStyleValue;
+		} );
+
+		borderRightStyleDropdown.bind( 'isEmpty' ).to( this, 'borderRightStyle', value => !value );
+		borderRightStyleDropdown.bind( 'isVisible' ).to( this, 'border', value => value === 'separate' );
+
+		addListToDropdown( borderRightStyleDropdown.fieldView, getBorderStyleDefinitions( this, defaultBorder.style! ), {
+			role: 'menu',
+			ariaLabel: t( 'Right border style' )
+		} );
+
+		// -- Bottom Style ---------------------------------------------------
+
+		const borderBottomStyleDropdown = new LabeledFieldView( locale, createLabeledDropdown );
+		borderBottomStyleDropdown.set( {
+			label: t( 'Bottom border style' ),
+			class: 'ck-table-form__border-style'
+		} );
+
+		borderBottomStyleDropdown.fieldView.buttonView.set( {
+			ariaLabel: t( 'Bottom border style' ),
+			ariaLabelledBy: undefined,
+			isOn: false,
+			withText: true,
+			tooltip: t( 'Bottom border style' )
+		} );
+
+		borderBottomStyleDropdown.fieldView.buttonView.bind( 'label' ).to( this, 'borderBottomStyle', value => {
+			return styleLabels[ value ? value : 'none' ];
+		} );
+
+		borderBottomStyleDropdown.fieldView.on( 'execute', evt => {
+			this.borderBottomStyle = ( evt.source as any )._borderStyleValue;
+		} );
+
+		borderBottomStyleDropdown.bind( 'isEmpty' ).to( this, 'borderBottomStyle', value => !value );
+		borderBottomStyleDropdown.bind( 'isVisible' ).to( this, 'border', value => value === 'separate' );
+
+		addListToDropdown( borderBottomStyleDropdown.fieldView, getBorderStyleDefinitions( this, defaultBorder.style! ), {
+			role: 'menu',
+			ariaLabel: t( 'Bottom border style' )
+		} );
+
+		// -- Left Style ---------------------------------------------------
+
+		const borderLeftStyleDropdown = new LabeledFieldView( locale, createLabeledDropdown );
+		borderLeftStyleDropdown.set( {
+			label: t( 'Left border style' ),
+			class: 'ck-table-form__border-style'
+		} );
+
+		borderLeftStyleDropdown.fieldView.buttonView.set( {
+			ariaLabel: t( 'Left border style' ),
+			ariaLabelledBy: undefined,
+			isOn: false,
+			withText: true,
+			tooltip: t( 'Left border style' )
+		} );
+
+		borderLeftStyleDropdown.fieldView.buttonView.bind( 'label' ).to( this, 'borderLeftStyle', value => {
+			return styleLabels[ value ? value : 'none' ];
+		} );
+
+		borderLeftStyleDropdown.fieldView.on( 'execute', evt => {
+			this.borderLeftStyle = ( evt.source as any )._borderStyleValue;
+		} );
+
+		borderLeftStyleDropdown.bind( 'isEmpty' ).to( this, 'borderLeftStyle', value => !value );
+		borderLeftStyleDropdown.bind( 'isVisible' ).to( this, 'border', value => value === 'separate' );
+
+		addListToDropdown( borderLeftStyleDropdown.fieldView, getBorderStyleDefinitions( this, defaultBorder.style! ), {
+			role: 'menu',
+			ariaLabel: t( 'Left border style' )
+		} );
+
 		// -- Width ---------------------------------------------------
 
 		const borderWidthInput = new LabeledFieldView( locale, createLabeledInputText );
@@ -518,6 +732,10 @@ export class TablePropertiesView extends View {
 		return {
 			borderRowLabel,
 			borderStyleDropdown,
+			borderTopStyleDropdown,
+			borderRightStyleDropdown,
+			borderBottomStyleDropdown,
+			borderLeftStyleDropdown,
 			borderColorInput,
 			borderWidthInput
 		};


### PR DESCRIPTION
This pull request adds support for specifying border styles for each side of a table. This includes changes to the Table Properties GUI to allow you to set the border-top-style, border-right-style, border-bottom-style, and border-left-style properties.

The following changes were made:

Added new commands for each side of the border: TableBorderTopStyleCommand, TableBorderRightStyleCommand, TableBorderBottomStyleCommand, and TableBorderLeftStyleCommand.
Modified TablePropertiesView to include new dropdowns for each border side.
Updated TablePropertiesUI to handle the new fields.
Updated the table converters to handle the new border styles.
Added the new commands to the TableProperties plugin.