### PR TITLE
Allow using custom button labels in a dropdown component [WIP]

### DIFF
--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -678,19 +678,14 @@ function bindViewCollectionItemsToDefinitions(
 			groupView.items.delegate( 'execute' ).to( dropdownView );
 
 			return groupView;
-		} else if ( def.type === 'button' || def.type === 'switchbutton' || def.type === 'labelledbutton' ) {
+		} else if ( def.type === 'button' || def.type === 'switchbutton' ) {
 			const isToggleable = def.model.role === 'menuitemcheckbox' || def.model.role === 'menuitemradio';
 			const listItemView = new ListItemView( locale );
 
 			let buttonView: ButtonView;
 
 			if ( def.type === 'button' ) {
-				buttonView = new ListItemButtonView( locale );
-				buttonView.set( {
-					isToggleable
-				} );
-			} else if ( def.type === 'labelledbutton' ) {
-				buttonView = new ListItemButtonView( locale, def.label );
+				buttonView = new ListItemButtonView( locale, def.labelView );
 				buttonView.set( {
 					isToggleable
 				} );
@@ -829,7 +824,6 @@ function bindDropdownToggleableButtonsAlignment( listItems: ViewCollection ) {
 export type ListDropdownItemDefinition =
 	ListDropdownSeparatorDefinition |
 	ListDropdownButtonDefinition |
-	ListDropdownLabelledButtonDefinition |
 	ListDropdownGroupDefinition;
 
 /**
@@ -849,23 +843,11 @@ export type ListDropdownButtonDefinition = {
 	 * Model of the item. Its properties fuel the newly created list item (or its children, depending on the `type`).
 	 */
 	model: UIModel;
-};
-
-/**
- * A definition of the 'custombutton' list item.
- */
-export type ListDropdownLabelledButtonDefinition = {
-	type: 'labelledbutton';
-
-	/**
-	 * Model of the item. Its properties fuel the newly created list item (or its children, depending on the `type`).
-	 */
-	model: UIModel;
 
 	/**
 	 * A view that will be used as a button body in the list item.
 	 */
-	label: ButtonLabelView;
+	labelView?: ButtonLabelView;
 };
 
 /**
@@ -882,5 +864,5 @@ export type ListDropdownGroupDefinition = {
 	/**
 	 * The collection of the child list items inside this group.
 	 */
-	items: Collection<ListDropdownButtonDefinition | ListDropdownLabelledButtonDefinition>;
+	items: Collection<ListDropdownButtonDefinition>;
 };

--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -47,6 +47,7 @@ import '../../theme/components/dropdown/listdropdown.css';
 import { ListItemGroupView } from '../list/listitemgroupview.js';
 import { ListItemButtonView } from '../button/listitembuttonview.js';
 import type { DropdownMenuDefinition } from './menu/utils.js';
+import type { ButtonLabelView } from '../button/buttonlabelview.js';
 
 /**
  * A helper for creating dropdowns. It creates an instance of a {@link module:ui/dropdown/dropdownview~DropdownView dropdown},
@@ -677,7 +678,7 @@ function bindViewCollectionItemsToDefinitions(
 			groupView.items.delegate( 'execute' ).to( dropdownView );
 
 			return groupView;
-		} else if ( def.type === 'button' || def.type === 'switchbutton' ) {
+		} else if ( def.type === 'button' || def.type === 'switchbutton' || def.type === 'labelledbutton' ) {
 			const isToggleable = def.model.role === 'menuitemcheckbox' || def.model.role === 'menuitemradio';
 			const listItemView = new ListItemView( locale );
 
@@ -685,6 +686,11 @@ function bindViewCollectionItemsToDefinitions(
 
 			if ( def.type === 'button' ) {
 				buttonView = new ListItemButtonView( locale );
+				buttonView.set( {
+					isToggleable
+				} );
+			} else if ( def.type === 'labelledbutton' ) {
+				buttonView = new ListItemButtonView( locale, def.label );
 				buttonView.set( {
 					isToggleable
 				} );
@@ -820,7 +826,11 @@ function bindDropdownToggleableButtonsAlignment( listItems: ViewCollection ) {
  * A definition of the list item used by the {@link module:ui/dropdown/utils~addListToDropdown}
  * utility.
  */
-export type ListDropdownItemDefinition = ListDropdownSeparatorDefinition | ListDropdownButtonDefinition | ListDropdownGroupDefinition;
+export type ListDropdownItemDefinition =
+	ListDropdownSeparatorDefinition |
+	ListDropdownButtonDefinition |
+	ListDropdownLabelledButtonDefinition |
+	ListDropdownGroupDefinition;
 
 /**
  * A definition of the 'separator' list item.
@@ -842,6 +852,23 @@ export type ListDropdownButtonDefinition = {
 };
 
 /**
+ * A definition of the 'custombutton' list item.
+ */
+export type ListDropdownLabelledButtonDefinition = {
+	type: 'labelledbutton';
+
+	/**
+	 * Model of the item. Its properties fuel the newly created list item (or its children, depending on the `type`).
+	 */
+	model: UIModel;
+
+	/**
+	 * A view that will be used as a button body in the list item.
+	 */
+	label: ButtonLabelView;
+};
+
+/**
  * A definition of the group inside the list. A group can contain one or more list items (buttons).
  */
 export type ListDropdownGroupDefinition = {
@@ -855,5 +882,5 @@ export type ListDropdownGroupDefinition = {
 	/**
 	 * The collection of the child list items inside this group.
 	 */
-	items: Collection<ListDropdownButtonDefinition>;
+	items: Collection<ListDropdownButtonDefinition | ListDropdownLabelledButtonDefinition>;
 };

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -105,7 +105,6 @@ export {
 	type ListDropdownItemDefinition,
 	type ListDropdownSeparatorDefinition,
 	type ListDropdownButtonDefinition,
-	type ListDropdownLabelledButtonDefinition,
 	type ListDropdownGroupDefinition,
 	createDropdown,
 	addMenuToDropdown,

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -105,6 +105,7 @@ export {
 	type ListDropdownItemDefinition,
 	type ListDropdownSeparatorDefinition,
 	type ListDropdownButtonDefinition,
+	type ListDropdownLabelledButtonDefinition,
 	type ListDropdownGroupDefinition,
 	createDropdown,
 	addMenuToDropdown,

--- a/packages/ckeditor5-ui/tests/dropdown/utils.js
+++ b/packages/ckeditor5-ui/tests/dropdown/utils.js
@@ -1109,6 +1109,206 @@ describe( 'utils', () => {
 				} );
 			} );
 
+			describe( 'with ListItemButtonView as LabelledButton', () => {
+				it( 'is populated using item definitions', () => {
+					definitions.add( {
+						type: 'labelledbutton',
+						model: new UIModel( { label: 'a', labelStyle: 'b' } ),
+						label: new View( locale )
+					} );
+
+					definitions.add( {
+						type: 'labelledbutton',
+						model: new UIModel( { label: 'c', labelStyle: 'd' } ),
+						label: new View( locale )
+					} );
+
+					expect( listItems ).to.have.length( 2 );
+					expect( listItems.first ).to.be.instanceOf( ListItemView );
+					expect( listItems.first.children.first ).to.be.instanceOf( ButtonView );
+
+					expect( listItems.get( 1 ).children.first.label ).to.equal( 'c' );
+					expect( listItems.get( 1 ).children.first.labelStyle ).to.equal( 'd' );
+
+					definitions.remove( 1 );
+					expect( listItems ).to.have.length( 1 );
+					expect( listItems.first.children.first.label ).to.equal( 'a' );
+					expect( listItems.first.children.first.labelStyle ).to.equal( 'b' );
+				} );
+
+				it( 'should set `isToggleable=true` only if role `menuitemcheckbox` or `menuitemradio` is set', () => {
+					definitions.addMany( [
+						{
+							type: 'labelledbutton',
+							model: new UIModel( { label: 'a', role: 'menuitemcheckbox' } ),
+							label: new View( locale )
+						},
+						{
+							type: 'labelledbutton',
+							model: new UIModel( { label: 'b', role: 'menuitemradio' } ),
+							label: new View( locale )
+						},
+						{
+							type: 'labelledbutton',
+							model: new UIModel( { label: 'c', role: 'menuitem' } ),
+							label: new View( locale )
+						}
+					] );
+
+					expect( listItems.get( 0 ).children.first.isToggleable ).to.be.true;
+					expect( listItems.get( 1 ).children.first.isToggleable ).to.be.true;
+					expect( listItems.get( 2 ).children.first.isToggleable ).to.be.false;
+				} );
+
+				it( 'should reserve checkbox holder space if there is at least one toggleable item', () => {
+					definitions.addMany( [
+						{
+							type: 'labelledbutton',
+							model: new UIModel( { label: 'a', role: 'menuitemcheckbox' } ),
+							label: new View( locale )
+						},
+						{
+							type: 'labelledbutton',
+							model: new UIModel( { label: 'b', role: 'menuitemradio' } ),
+							label: new View( locale )
+						},
+						{
+							type: 'labelledbutton',
+							model: new UIModel( { label: 'c', role: 'menuitem' } ),
+							label: new View( locale )
+						}
+					] );
+
+					for ( const item of listItems ) {
+						expect( item.children.first.hasCheckSpace ).to.be.true;
+					}
+				} );
+
+				it( 'should reserve checkbox holder space on non-toggleable items', () => {
+					definitions.addMany( [
+						{
+							type: 'labelledbutton',
+							model: new UIModel( { label: 'a', role: 'menuitem' } ),
+							label: new View( locale )
+						},
+						{
+							type: 'labelledbutton',
+							model: new UIModel( { label: 'b', role: 'menuitem' } ),
+							label: new View( locale )
+						},
+						{
+							type: 'labelledbutton',
+							model: new UIModel( { label: 'c', role: 'menuitemradio' } ),
+							label: new View( locale )
+						}
+					] );
+
+					for ( const item of listItems ) {
+						expect( item.children.first.hasCheckSpace ).to.be.true;
+					}
+				} );
+
+				it( 'should restore checkbox holder space if the only toggleable was removed', () => {
+					definitions.addMany( [
+						{
+							type: 'labelledbutton',
+							model: new UIModel( { label: 'a', role: 'menuitem' } ),
+							label: new View( locale )
+						},
+						{
+							type: 'labelledbutton',
+							model: new UIModel( { label: 'b', role: 'menuitem' } ),
+							label: new View( locale )
+						},
+						{
+							type: 'labelledbutton',
+							model: new UIModel( { label: 'c', role: 'menuitemradio' } ),
+							label: new View( locale )
+						}
+					] );
+
+					for ( const item of listItems ) {
+						expect( item.children.first.hasCheckSpace ).to.be.true;
+					}
+
+					definitions.remove( 2 );
+
+					for ( const item of listItems ) {
+						expect( item.children.first.hasCheckSpace ).to.be.false;
+					}
+				} );
+
+				it( 'should not reserve checkbox holder space if there is at least one toggleable item', () => {
+					definitions.addMany( [
+						{
+							type: 'labelledbutton',
+							model: new UIModel( { label: 'a', role: 'menuitem' } ),
+							label: new View( locale )
+						},
+						{
+							type: 'labelledbutton',
+							model: new UIModel( { label: 'b', role: 'menuitem' } ),
+							label: new View( locale )
+						}
+					] );
+
+					for ( const item of listItems ) {
+						expect( item.children.first.hasCheckSpace ).to.be.false;
+					}
+				} );
+
+				it( 'binds all button properties', () => {
+					const def = {
+						type: 'labelledbutton',
+						model: new UIModel( { label: 'a', labelStyle: 'b', foo: 'bar', baz: 'qux' } ),
+						label: new View( locale )
+					};
+
+					definitions.add( def );
+
+					const button = listItems.first.children.first;
+
+					expect( button.foo ).to.equal( 'bar' );
+					expect( button.baz ).to.equal( 'qux' );
+
+					button.isToggleable = true;
+					button.isOn = true;
+
+					expect( button.element.getAttribute( 'aria-pressed' ) ).to.be.equal( 'true' );
+
+					button.isOn = false;
+					expect( button.element.getAttribute( 'aria-pressed' ) ).to.be.equal( 'false' );
+
+					button.isOn = true;
+					button.role = 'checkbox';
+					expect( button.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'true' );
+					expect( button.element.getAttribute( 'aria-pressed' ) ).to.be.null;
+
+					def.model.baz = 'foo?';
+					expect( button.baz ).to.equal( 'foo?' );
+				} );
+
+				it( 'delegates ButtonView#execute to the ListItemView', done => {
+					definitions.add( {
+						type: 'labelledbutton',
+						model: new UIModel( { label: 'a', labelStyle: 'b' } ),
+						label: new View( locale )
+					} );
+
+					const listItem = listItems.first;
+					const button = listItem.children.first;
+
+					dropdownView.on( 'execute', evt => {
+						expect( evt.source ).to.equal( button );
+						expect( evt.path ).to.deep.equal( [ button, listItem, dropdownView ] );
+
+						done();
+					} );
+
+					button.fire( 'execute' );
+				} );
+			} );
+
 			describe( 'with SwitchButtonView', () => {
 				it( 'is populated using item definitions', () => {
 					definitions.add( {

--- a/packages/ckeditor5-ui/tests/dropdown/utils.js
+++ b/packages/ckeditor5-ui/tests/dropdown/utils.js
@@ -28,7 +28,7 @@ import { ListItemView } from '../../src/list/listitemview.js';
 import { ListSeparatorView } from '../../src/list/listseparatorview.js';
 import { ListView } from '../../src/list/listview.js';
 import { ViewCollection } from '../../src/viewcollection.js';
-import { BodyCollection, DropdownMenuRootListView, ListItemGroupView } from '../../src/index.js';
+import { BodyCollection, ButtonLabelView, DropdownMenuRootListView, ListItemGroupView } from '../../src/index.js';
 
 describe( 'utils', () => {
 	let locale, dropdownView;
@@ -1107,205 +1107,54 @@ describe( 'utils', () => {
 
 					button.fire( 'execute' );
 				} );
-			} );
 
-			describe( 'with ListItemButtonView as LabelledButton', () => {
-				it( 'is populated using item definitions', () => {
-					definitions.add( {
-						type: 'labelledbutton',
-						model: new UIModel( { label: 'a', labelStyle: 'b' } ),
-						label: new View( locale )
+				describe( 'optional labelView support', () => {
+					it( 'should use a custom ButtonLabelView instance if provided', () => {
+						definitions.add( {
+							type: 'button',
+							model: new UIModel( {
+								label: 'foo',
+								labelStyle: 'color: red',
+								ariaLabelledBy: 'bar'
+							} )
+						} );
+
+						expect( listItems.first.children.first.labelView ).to.be.instanceOf( ButtonLabelView );
+						expect( listItems.first.children.first.labelView.text ).to.equal( 'foo' );
+						expect( listItems.first.children.first.labelView.style ).to.equal( 'color: red' );
+						expect( listItems.first.children.first.labelView.id ).to.equal( 'bar' );
 					} );
 
-					definitions.add( {
-						type: 'labelledbutton',
-						model: new UIModel( { label: 'c', labelStyle: 'd' } ),
-						label: new View( locale )
+					it( 'should use a ButtonLabelView instance by default', () => {
+						class CustomButttonLabelView extends ButtonLabelView {
+							constructor( locale ) {
+								super( locale );
+
+								this.set( {
+									text: '',
+									style: '',
+									id: ''
+								} );
+							}
+						}
+
+						const labelView = new CustomButttonLabelView( locale );
+
+						definitions.add( {
+							type: 'button',
+							model: new UIModel( {
+								label: 'foo',
+								labelStyle: 'color: red',
+								ariaLabelledBy: 'bar'
+							} ),
+							labelView
+						} );
+
+						expect( listItems.first.children.first.labelView ).to.equal( labelView );
+						expect( listItems.first.children.first.labelView.text ).to.equal( 'foo' );
+						expect( listItems.first.children.first.labelView.style ).to.equal( 'color: red' );
+						expect( listItems.first.children.first.labelView.id ).to.equal( 'bar' );
 					} );
-
-					expect( listItems ).to.have.length( 2 );
-					expect( listItems.first ).to.be.instanceOf( ListItemView );
-					expect( listItems.first.children.first ).to.be.instanceOf( ButtonView );
-
-					expect( listItems.get( 1 ).children.first.label ).to.equal( 'c' );
-					expect( listItems.get( 1 ).children.first.labelStyle ).to.equal( 'd' );
-
-					definitions.remove( 1 );
-					expect( listItems ).to.have.length( 1 );
-					expect( listItems.first.children.first.label ).to.equal( 'a' );
-					expect( listItems.first.children.first.labelStyle ).to.equal( 'b' );
-				} );
-
-				it( 'should set `isToggleable=true` only if role `menuitemcheckbox` or `menuitemradio` is set', () => {
-					definitions.addMany( [
-						{
-							type: 'labelledbutton',
-							model: new UIModel( { label: 'a', role: 'menuitemcheckbox' } ),
-							label: new View( locale )
-						},
-						{
-							type: 'labelledbutton',
-							model: new UIModel( { label: 'b', role: 'menuitemradio' } ),
-							label: new View( locale )
-						},
-						{
-							type: 'labelledbutton',
-							model: new UIModel( { label: 'c', role: 'menuitem' } ),
-							label: new View( locale )
-						}
-					] );
-
-					expect( listItems.get( 0 ).children.first.isToggleable ).to.be.true;
-					expect( listItems.get( 1 ).children.first.isToggleable ).to.be.true;
-					expect( listItems.get( 2 ).children.first.isToggleable ).to.be.false;
-				} );
-
-				it( 'should reserve checkbox holder space if there is at least one toggleable item', () => {
-					definitions.addMany( [
-						{
-							type: 'labelledbutton',
-							model: new UIModel( { label: 'a', role: 'menuitemcheckbox' } ),
-							label: new View( locale )
-						},
-						{
-							type: 'labelledbutton',
-							model: new UIModel( { label: 'b', role: 'menuitemradio' } ),
-							label: new View( locale )
-						},
-						{
-							type: 'labelledbutton',
-							model: new UIModel( { label: 'c', role: 'menuitem' } ),
-							label: new View( locale )
-						}
-					] );
-
-					for ( const item of listItems ) {
-						expect( item.children.first.hasCheckSpace ).to.be.true;
-					}
-				} );
-
-				it( 'should reserve checkbox holder space on non-toggleable items', () => {
-					definitions.addMany( [
-						{
-							type: 'labelledbutton',
-							model: new UIModel( { label: 'a', role: 'menuitem' } ),
-							label: new View( locale )
-						},
-						{
-							type: 'labelledbutton',
-							model: new UIModel( { label: 'b', role: 'menuitem' } ),
-							label: new View( locale )
-						},
-						{
-							type: 'labelledbutton',
-							model: new UIModel( { label: 'c', role: 'menuitemradio' } ),
-							label: new View( locale )
-						}
-					] );
-
-					for ( const item of listItems ) {
-						expect( item.children.first.hasCheckSpace ).to.be.true;
-					}
-				} );
-
-				it( 'should restore checkbox holder space if the only toggleable was removed', () => {
-					definitions.addMany( [
-						{
-							type: 'labelledbutton',
-							model: new UIModel( { label: 'a', role: 'menuitem' } ),
-							label: new View( locale )
-						},
-						{
-							type: 'labelledbutton',
-							model: new UIModel( { label: 'b', role: 'menuitem' } ),
-							label: new View( locale )
-						},
-						{
-							type: 'labelledbutton',
-							model: new UIModel( { label: 'c', role: 'menuitemradio' } ),
-							label: new View( locale )
-						}
-					] );
-
-					for ( const item of listItems ) {
-						expect( item.children.first.hasCheckSpace ).to.be.true;
-					}
-
-					definitions.remove( 2 );
-
-					for ( const item of listItems ) {
-						expect( item.children.first.hasCheckSpace ).to.be.false;
-					}
-				} );
-
-				it( 'should not reserve checkbox holder space if there is at least one toggleable item', () => {
-					definitions.addMany( [
-						{
-							type: 'labelledbutton',
-							model: new UIModel( { label: 'a', role: 'menuitem' } ),
-							label: new View( locale )
-						},
-						{
-							type: 'labelledbutton',
-							model: new UIModel( { label: 'b', role: 'menuitem' } ),
-							label: new View( locale )
-						}
-					] );
-
-					for ( const item of listItems ) {
-						expect( item.children.first.hasCheckSpace ).to.be.false;
-					}
-				} );
-
-				it( 'binds all button properties', () => {
-					const def = {
-						type: 'labelledbutton',
-						model: new UIModel( { label: 'a', labelStyle: 'b', foo: 'bar', baz: 'qux' } ),
-						label: new View( locale )
-					};
-
-					definitions.add( def );
-
-					const button = listItems.first.children.first;
-
-					expect( button.foo ).to.equal( 'bar' );
-					expect( button.baz ).to.equal( 'qux' );
-
-					button.isToggleable = true;
-					button.isOn = true;
-
-					expect( button.element.getAttribute( 'aria-pressed' ) ).to.be.equal( 'true' );
-
-					button.isOn = false;
-					expect( button.element.getAttribute( 'aria-pressed' ) ).to.be.equal( 'false' );
-
-					button.isOn = true;
-					button.role = 'checkbox';
-					expect( button.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'true' );
-					expect( button.element.getAttribute( 'aria-pressed' ) ).to.be.null;
-
-					def.model.baz = 'foo?';
-					expect( button.baz ).to.equal( 'foo?' );
-				} );
-
-				it( 'delegates ButtonView#execute to the ListItemView', done => {
-					definitions.add( {
-						type: 'labelledbutton',
-						model: new UIModel( { label: 'a', labelStyle: 'b' } ),
-						label: new View( locale )
-					} );
-
-					const listItem = listItems.first;
-					const button = listItem.children.first;
-
-					dropdownView.on( 'execute', evt => {
-						expect( evt.source ).to.equal( button );
-						expect( evt.path ).to.deep.equal( [ button, listItem, dropdownView ] );
-
-						done();
-					} );
-
-					button.fire( 'execute' );
 				} );
 			} );
 


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Extended dropdown component utils to allow creating a dropdown list with custom `ButtonLabelView` (passed from outside code, not auto-created).

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

None.

---

### 💡 Additional information

Required for https://github.com/cksource/ckeditor5-commercial/pull/8070.