### PR TITLE
Added validator, fixed exports

### DIFF
--- a/packages/ckeditor5-html-support/src/index.ts
+++ b/packages/ckeditor5-html-support/src/index.ts
@@ -22,17 +22,17 @@ export { FullPage } from './fullpage.js';
 export { HtmlPageDataProcessor } from './htmlpagedataprocessor.js';
 export { EmptyBlock } from './emptyblock.js';
 export type { GeneralHtmlSupportConfig, GHSFullPageConfig, GHSCssSanitizeOutput } from './generalhtmlsupportconfig.js';
-export type { CodeBlockElementSupport } from './integrations/codeblock.js';
-export type { CustomElementSupport } from './integrations/customelement.js';
-export type { ListElementSupport } from './integrations/list.js';
-export type { DualContentModelElementSupport } from './integrations/dualcontent.js';
-export type { HeadingElementSupport } from './integrations/heading.js';
-export type { ImageElementSupport } from './integrations/image.js';
-export type { MediaEmbedElementSupport } from './integrations/mediaembed.js';
-export type { ScriptElementSupport } from './integrations/script.js';
-export type { StyleElementSupport } from './integrations/style.js';
-export type { TableElementSupport } from './integrations/table.js';
-export type { HorizontalLineElementSupport } from './integrations/horizontalline.js';
+export { CodeBlockElementSupport } from './integrations/codeblock.js';
+export { CustomElementSupport } from './integrations/customelement.js';
+export { ListElementSupport } from './integrations/list.js';
+export { DualContentModelElementSupport } from './integrations/dualcontent.js';
+export { HeadingElementSupport } from './integrations/heading.js';
+export { ImageElementSupport } from './integrations/image.js';
+export { MediaEmbedElementSupport } from './integrations/mediaembed.js';
+export { ScriptElementSupport } from './integrations/script.js';
+export { StyleElementSupport } from './integrations/style.js';
+export { TableElementSupport } from './integrations/table.js';
+export { HorizontalLineElementSupport } from './integrations/horizontalline.js';
 
 export {
 	viewToModelObjectConverter as _viewToModelObjectContentHtmlSupportConverter,

--- a/scripts/ci/exports/policy/validate-plugin-exports.mjs
+++ b/scripts/ci/exports/policy/validate-plugin-exports.mjs
@@ -1,0 +1,66 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+import { mapper } from '../utils/logger.mjs';
+
+/**
+ * Validates that plugin classes are exported as values, not types.
+ * This prevents regressions related to #18583 where plugin classes were exported as types.
+ */
+export function validatePluginExports( library ) {
+	const errors = [];
+
+	for ( const pkg of library.packages.values() ) {
+		// Only check the index module!
+		const module = pkg.index;
+
+		if ( !module ) {
+			continue;
+		}
+
+		for ( const exportItem of module.exports ) {
+			if ( exportItem.exportKind === 'type' && exportItem.references ) {
+				if ( hasPluginClassReference( exportItem.references ) ) {
+					errors.push( {
+						...mapper.mapItemsViolatingPolicies( pkg, module, exportItem ),
+						'Action': 'Plugin class should be exported as value'
+					} );
+				}
+			}
+		}
+	}
+
+	return errors;
+}
+
+function hasPluginClassReference( ref, visited = new Set() ) {
+	if ( !ref ) {
+		return false;
+	}
+
+	if ( Array.isArray( ref ) ) {
+		return ref.some( r => hasPluginClassReference( r, visited ) );
+	}
+
+	if ( visited.has( ref ) ) {
+		return false;
+	}
+
+	visited.add( ref );
+
+	if ( ref.isPluginClass ) {
+		return true;
+	}
+
+	if ( ref.type !== 'class' ) {
+		return false;
+	}
+
+	if ( ref.references ) {
+		return hasPluginClassReference( ref.references, visited );
+	}
+
+	return false;
+}

--- a/scripts/ci/validate-module-re-exports.mjs
+++ b/scripts/ci/validate-module-re-exports.mjs
@@ -10,6 +10,7 @@ import { isCommandClass } from './exports/policy/is-command.mjs';
 import { isPluginClass } from './exports/policy/is-plugin.mjs';
 import { isEvent } from './exports/policy/is-event.mjs';
 import { validateCommandExports } from './exports/policy/validate-command-exports.mjs';
+import { validatePluginExports } from './exports/policy/validate-plugin-exports.mjs';
 import { Export } from './exports/utils/export.mjs';
 import { logData, mapper } from './exports/utils/logger.mjs';
 import chalk from 'chalk';
@@ -40,7 +41,13 @@ async function main() {
 	const exportsToFix = getExportsToFix( library );
 	const declarationsWithMissingExports = getDeclarationsWithMissingExports( library );
 	const commandExportErrors = validateCommandExports( library );
-	const dataToLogUnwrapped = [ ...declarationsWithMissingExports, ...exportsToFix, ...commandExportErrors ];
+	const pluginExportErrors = validatePluginExports( library );
+	const dataToLogUnwrapped = [
+		...declarationsWithMissingExports,
+		...exportsToFix,
+		...commandExportErrors,
+		...pluginExportErrors
+	];
 
 	// Do not log exceptions that are expected as errors.
 	const data = removeExpectedExceptions( dataToLogUnwrapped );


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Added validator that enforces exporting plugins as values, and not types.

Converted plugins exported as types to be exported as values instead.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes https://github.com/ckeditor/ckeditor5/issues/18855

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
