### PR TITLE
Bump umberto version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "terser-webpack-plugin": "^5.0.0",
     "typescript": "5.0.4",
     "typescript-eslint": "^8.33.0",
-    "umberto": "^8.0.1",
+    "umberto": "^8.0.2",
     "upath": "^2.0.0",
     "wait-on": "^8.0.3",
     "webpack": "^5.94.0"


### PR DESCRIPTION
### 🚀 Summary

Caused by https://github.com/cksource/umberto/releases/tag/v8.0.2
