### PR TITLE
Add "backdoors" for operations validation for AI purposes

### DIFF
--- a/packages/ckeditor5-engine/src/model/operation/mergeoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/mergeoperation.ts
@@ -165,7 +165,7 @@ export class MergeOperation extends Operation {
 			 * @error merge-operation-target-position-invalid
 			 */
 			throw new CKEditorError( 'merge-operation-target-position-invalid', this );
-		} else if ( this.howMany != sourceElement.maxOffset ) {
+		} else if ( this.howMany !== Number.NEGATIVE_INFINITY && this.howMany != sourceElement.maxOffset ) {
 			/**
 			 * Merge operation specifies wrong number of nodes to move.
 			 *
@@ -173,6 +173,8 @@ export class MergeOperation extends Operation {
 			 */
 			throw new CKEditorError( 'merge-operation-how-many-invalid', this );
 		}
+
+		this.howMany = this.sourcePosition.parent.maxOffset;
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/model/operation/renameoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/renameoperation.ts
@@ -104,7 +104,7 @@ export class RenameOperation extends Operation {
 				'rename-operation-wrong-position',
 				this
 			);
-		} else if ( element.name !== this.oldName ) {
+		} else if ( this.oldName !== '' && element.name !== this.oldName ) {
 			/**
 			 * Element to change has different name than operation's old name.
 			 *
@@ -115,6 +115,8 @@ export class RenameOperation extends Operation {
 				this
 			);
 		}
+
+		this.oldName = element.name;
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/model/operation/splitoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/splitoperation.ts
@@ -169,7 +169,7 @@ export class SplitOperation extends Operation {
 			 * @error split-operation-split-in-root
 			 */
 			throw new CKEditorError( 'split-operation-split-in-root', this );
-		} else if ( this.howMany != element.maxOffset - this.splitPosition.offset ) {
+		} else if ( this.howMany !== Number.NEGATIVE_INFINITY && this.howMany != element.maxOffset - this.splitPosition.offset ) {
 			/**
 			 * Split operation specifies wrong number of nodes to move.
 			 *
@@ -184,6 +184,8 @@ export class SplitOperation extends Operation {
 			 */
 			throw new CKEditorError( 'split-operation-graveyard-position-invalid', this );
 		}
+
+		this.howMany = this.splitPosition.parent.maxOffset - this.splitPosition.offset;
 	}
 
 	/**


### PR DESCRIPTION
Internal (engine): Add "backdoors" for operations validation for AI purposes.

---

In this PR I "allowed" for some properties in operations to have "special" values - negative infinity or empty string. These properties, as I checked, are used only for validation purposes and reversing operations.

Since it was difficult in model diff algorithm to calculate these values, I decided it is easier to use these "special" values and turn off validation. The "special"  value is overwritten with the "current" value as soon as the operation is validated.