### PR TITLE
Aligned tests with how Chrome v139 changed escaping `<` and `>` in attributes.

### DIFF
--- a/.changelog/20250806105747_cc_8122.md
+++ b/.changelog/20250806105747_cc_8122.md
@@ -1,0 +1,7 @@
+---
+type: Other
+scope:
+  - ckeditor5-engine
+---
+
+Aligned tests with how Chrome in version 139 changed escaping of `<` and `>` in attributes.

--- a/packages/ckeditor5-engine/tests/controller/datacontroller.js
+++ b/packages/ckeditor5-engine/tests/controller/datacontroller.js
@@ -1216,7 +1216,9 @@ describe( 'DataController', () => {
 
 			_setModelData( model, '<container><caption>foo<softBreak></softBreak><$text bold="true">baz</$text></caption></container>' );
 
-			expect( data.get() ).to.equal( '<div data-caption="foo<br><strong>baz</strong>">&nbsp;</div>' );
+			// The Chrome browser in version 139 changed escaping `<` and `>` in attributes.
+			// See: https://github.com/ckeditor/ckeditor5-commercial/issues/8122
+			expect( data.get() ).to.equal( '<div data-caption="foo&lt;br&gt;&lt;strong&gt;baz&lt;/strong&gt;">&nbsp;</div>' );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
@@ -573,9 +573,12 @@ describe( 'ViewDomConverter', () => {
 							'bar' +
 							'</iframe>' +
 							'</div>',
+						// The Chrome browser in version 139 changed escaping `<` and `>` in attributes.
+						// See: https://github.com/ckeditor/ckeditor5-commercial/issues/8122
 						expected: '<div data-foo="bar">' +
 							'foo' +
-							'<iframe class="foo-class" style="border:1px solid blue" data-foo="bar" srcdoc="<script>baz</script>">' +
+							'<iframe class="foo-class" style="border:1px solid blue" data-foo="bar" ' +
+								'srcdoc="&lt;script&gt;baz&lt;/script&gt;">' +
 							'bar' +
 							'</iframe>' +
 							'</div>'
@@ -693,13 +696,15 @@ describe( 'ViewDomConverter', () => {
 							'bar' +
 							'</iframe>' +
 							'</div>',
+						// The Chrome browser in version 139 changed escaping `<` and `>` in attributes.
+						// See: https://github.com/ckeditor/ckeditor5-commercial/issues/8122
 						expected: '<div data-foo="bar">' +
 							'foo' +
 							'<iframe ' +
 								'class="foo-class" ' +
 								'style="border:1px solid blue" ' +
 								'data-foo="bar" ' +
-								'data-ck-unsafe-attribute-srcdoc="<script>baz</script>">bar' +
+								'data-ck-unsafe-attribute-srcdoc="&lt;script&gt;baz&lt;/script&gt;">bar' +
 							'</iframe>' +
 							'</div>'
 					},


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

*Aligned tests with how Chrome in version 139 changed escaping of `<` and `>` in attributes.*

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #000

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
