### PR TITLE
Do not export `TableSlot` and `FileLoader` classes as type-only to prevent TypeDoc v0.28.6+ from converting them to interfaces

### DIFF
--- a/packages/ckeditor5-table/src/tablewalker.ts
+++ b/packages/ckeditor5-table/src/tablewalker.ts
@@ -598,7 +598,7 @@ class TableSlot {
 	}
 }
 
-export type { TableSlot };
+export { TableSlot };
 
 /**
  * This `TableSlot`'s getter (property) was removed in CKEditor 5 v20.0.0.

--- a/packages/ckeditor5-upload/src/filerepository.ts
+++ b/packages/ckeditor5-upload/src/filerepository.ts
@@ -575,7 +575,7 @@ class FileLoader extends /* #__PURE__ */ ObservableMixin() {
 	}
 }
 
-export type { FileLoader };
+export { FileLoader };
 
 /**
  * Upload adapter interface used by the {@link module:upload/filerepository~FileRepository file repository}


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Since TypeDoc v0.28.6+, type-only class exports are explicitly converted to interfaces. Hence, changed the type-only exports for `TableSlot` and `FileLoader` to normal exports.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Part of https://github.com/ckeditor/ckeditor5/issues/18905

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
