### PR TITLE
Fix broken transformation of snippet images in docs.

### DIFF
--- a/docs/assets/global.js
+++ b/docs/assets/global.js
@@ -127,49 +127,54 @@ function createNotification( title, message ) {
 	return notification;
 }
 
-// Replaces all relative paths inside the content container with absolute URLs
-// to avoid a broken user experience when copying images between editors.
-// It parses all `<img>` elements and `<source>` elements if they belong to the `<picture>` node.
-( () => {
-	function isRelativeUrl( url ) {
-		return !/^[a-zA-Z][a-zA-Z\d+\-.]*?:/.test( url );
+// Replaces all relative paths inside a single live-snippet container with absolute URLs
+// (images and picture sources) to avoid a broken UX when copying images between editors.
+// The transformation is scoped to the provided root node (a .live-snippet element).
+function transformSnippetImages( root ) {
+	if ( !( root instanceof Element ) ) {
+		return;
 	}
 
-	function updateSrcSetAttribute( element, baseURI ) {
+	const isRelativeUrl = url => !/^[a-zA-Z][a-zA-Z\d+\-.]*?:/.test( url );
+
+	const updateSrcSetAttribute = ( element, baseURI ) => {
 		const srcset = element.srcset.split( ',' )
 			.map( item => {
 				const [ relativeUrl, ratio ] = item.trim().split( ' ' );
 
-				if ( !isRelativeUrl( relativeUrl ) ) {
+				if ( !relativeUrl || !isRelativeUrl( relativeUrl ) ) {
 					return item;
 				}
 
 				const absoluteUrl = new window.URL( relativeUrl, baseURI ).toString();
-
 				return [ absoluteUrl, ratio ].filter( i => i ).join( ' ' );
 			} )
 			.join( ', ' );
 
 		element.setAttribute( 'srcset', srcset );
-	}
+	};
 
-	[ ...document.querySelectorAll( '.live-snippet .ck-content img' ) ]
-		.filter( img => isRelativeUrl( img.getAttribute( 'src' ) ) )
-		.forEach( img => {
-			// Update `<img src="...">`.
+	[ ...root.querySelectorAll( 'img' ) ].forEach( img => {
+		// Update <img src="..."> if it's relative.
+		const srcAttr = img.getAttribute( 'src' );
+		if ( srcAttr && isRelativeUrl( srcAttr ) ) {
 			img.setAttribute( 'src', img.src );
+		}
 
-			// Update `<img srcset="...">`.
-			if ( img.srcset ) {
-				updateSrcSetAttribute( img, img.baseURI );
-			}
+		// Update <img srcset="..."> (only relative items are rewritten).
+		if ( img.srcset ) {
+			updateSrcSetAttribute( img, img.baseURI );
+		}
 
-			// Update `<source>` elements if grouped in the `<picture>` element.
-			if ( img.parentElement instanceof window.HTMLPictureElement ) {
-				[ ...img.parentElement.querySelectorAll( 'source' ) ]
-					.forEach( source => {
-						updateSrcSetAttribute( source, img.baseURI );
-					} );
-			}
-		} );
-} )();
+		// Update <source> elements if grouped in the <picture> element.
+		if ( img.parentElement instanceof window.HTMLPictureElement ) {
+			[ ...img.parentElement.querySelectorAll( 'source' ) ].forEach( source => {
+				updateSrcSetAttribute( source, img.baseURI );
+			} );
+		}
+	} );
+}
+
+document.addEventListener( 'ck:snippet-transform', event => {
+	transformSnippetImages( event.detail.snippet );
+} );

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "terser-webpack-plugin": "^5.0.0",
     "typescript": "5.0.4",
     "typescript-eslint": "^8.33.0",
-    "umberto": "^8.0.2",
+    "umberto": "^8.0.3",
     "upath": "^2.0.0",
     "wait-on": "^8.0.3",
     "webpack": "^5.94.0"

--- a/scripts/docs/snippetadapter.mjs
+++ b/scripts/docs/snippetadapter.mjs
@@ -208,9 +208,11 @@ async function buildDocuments( snippets, paths, constants, imports, getSnippetPl
 		`<script type="importmap">${ JSON.stringify( { imports } ) }</script>`,
 		'<link rel="modulepreload" href="%BASE_PATH%/assets/ckeditor5/ckeditor5.js">',
 		'<link rel="modulepreload" href="%BASE_PATH%/assets/ckeditor5-premium-features/ckeditor5-premium-features.js">',
+		'<link rel="preload" href="%BASE_PATH%/assets/global.js" as="script">',
+		'<link rel="preload" href="https://cdn.ckbox.io/ckbox/latest/ckbox.js" as="script">',
 		`<script>window.CKEDITOR_GLOBAL_LICENSE_KEY = '${ constants.LICENSE_KEY }';</script>`,
-		'<script defer src="%BASE_PATH%/assets/global.js"></script>',
-		'<script defer src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>',
+		'<script src="%BASE_PATH%/assets/global.js"></script>',
+		'<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>',
 		getLayeredStyles( 'editor', editorStylePaths )
 	];
 
@@ -228,7 +230,22 @@ async function buildDocuments( snippets, paths, constants, imports, getSnippetPl
 
 			documentContent = documentContent.replace(
 				getSnippetPlaceholder( snippet.snippetName ),
-				() => `<div class="doc live-snippet ${ snippetSizeCssClass }">${ data }</div>`
+				() => `
+					<div class="doc live-snippet ${ snippetSizeCssClass }">${ data }</div>
+					<script>
+						(function() {
+							const el = document.currentScript.previousElementSibling;
+
+							el.dispatchEvent( new CustomEvent( 'ck:snippet-transform', {
+								bubbles: true,
+								detail: { snippet: el }
+							} ) );
+						})();
+					</script>
+				`
+					.split( '\n' )
+					.map( line => line.trim() )
+					.join( '\n' )
 			);
 
 			if ( await fileExists( upath.join( snippet.outputPath, snippet.snippetName, 'snippet.css' ) ) ) {


### PR DESCRIPTION
### 🚀 Summary

Our script for replacing relative URLs with absolute ones was failing on certain pagination snippets. The root cause was an incorrect selector used to query images within those snippets. Another issue was that the snippets were sometimes loaded before `DOMContentLoaded`, causing the script to run too early. As a result, it updated the `src` attributes of images already loaded in the editor, but those changes were later reverted by the differ. This PR fixes both problems.
