### PR TITLE
Handling long titles using ellipsis in `FormHeader` component.

### DIFF
--- a/packages/ckeditor5-ui/tests/manual/formheader/formheader.html
+++ b/packages/ckeditor5-ui/tests/manual/formheader/formheader.html
@@ -1,0 +1,15 @@
+<div dir="ltr">
+	<div id="playground" class="ck-reset ck-reset_all"></div>
+</div>
+
+<style>
+	#playground {
+		max-width: 400px;
+		margin: 0 auto;
+	}
+
+	#playground > .ck.ck-form__header {
+		margin-bottom: 2em;
+		border: 1px solid #000;
+	}
+</style>

--- a/packages/ckeditor5-ui/tests/manual/formheader/formheader.js
+++ b/packages/ckeditor5-ui/tests/manual/formheader/formheader.js
@@ -1,0 +1,80 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+import { ButtonView, FormHeaderView } from '../../../src/index.js';
+
+const icon = `<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+	<path d="M2 14.994C2 16.102 2.895 17 3.994 17h12.012A2 2 0 0 0 18 14.994V5.006A2.001 2.001 0 0 0
+	16.006 3H3.994A2 2 0 0 0 2 5.006v9.988zm1-9.992C3 4.45 3.45 4 4.007 4h11.986A1.01 1.01 0 0 1 17
+	5.002v9.996C17 15.55 16.55 16 15.993 16H4.007A1.01 1.01 0 0 1 3 14.998V5.002zm1.024
+	10H16v-3.096l-2.89-4.263-3.096 5.257-3.003-2.103L4 13.96l.024 1.043zM6.406 6A1.4 1.4 0 0 0 5
+	7.393a1.4 1.4 0 0 0 1.406 1.393 1.4 1.4 0 0 0 1.407-1.393A1.4 1.4 0 0 0 6.406 6z"
+	fill-rule="evenodd"/>
+</svg>`;
+
+const cancelIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+	<path d="m11.591 10.177 4.243 4.242a1 1 0 0 1-1.415 1.415l-4.242-4.243-4.243 4.243a1 1 0 0 1-1.414-1.415l4.243-4.242L4.52
+	 5.934A1 1 0 0 1 5.934 4.52l4.243 4.243 4.242-4.243a1 1 0 1 1 1.415 1.414z"/></svg>`;
+
+const playground = document.querySelector( '#playground' );
+
+const textOnlyView = new FormHeaderView(
+	undefined,
+	{
+		label: 'Foo bar'
+	} );
+
+textOnlyView.render();
+
+const withIconView = new FormHeaderView(
+	undefined,
+	{
+		label: 'Foo bar',
+		icon
+	} );
+
+withIconView.render();
+
+const withIconAndButtonView = new FormHeaderView(
+	undefined,
+	{
+		label: 'Foo bar',
+		icon
+	} );
+
+withIconAndButtonView.children.add( createButton( 'Example button', cancelIcon ) );
+withIconAndButtonView.render();
+
+const withLongTitleView = new FormHeaderView(
+	undefined,
+	{
+		label: 'Foo bar Foo bar Foo bar Foo bar Foo bar Foo bar Foo bar Foo bar',
+		icon
+	} );
+
+withLongTitleView.children.add( createButton( 'Example button', cancelIcon ) );
+withLongTitleView.render();
+
+playground.appendChild( textOnlyView.element );
+playground.appendChild( withIconView.element );
+playground.appendChild( withIconAndButtonView.element );
+playground.appendChild( withLongTitleView.element );
+
+function createButton( label = 'Example button', icon ) {
+	const button = new ButtonView();
+
+	button.set( {
+		label,
+		withText: false,
+		icon,
+		tooltip: true
+	} );
+
+	button.on( 'execute', () => {
+		console.log( 'Button clicked!' );
+	} );
+
+	return button;
+}

--- a/packages/ckeditor5-ui/tests/manual/formheader/formheader.md
+++ b/packages/ckeditor5-ui/tests/manual/formheader/formheader.md
@@ -1,0 +1,4 @@
+# FormHeader component
+
+1. There are four examples of a form header in this test.
+2. Make sure all render correctly, especially the one with the long title.

--- a/packages/ckeditor5-ui/theme/components/formheader/formheader.css
+++ b/packages/ckeditor5-ui/theme/components/formheader/formheader.css
@@ -12,5 +12,7 @@
 
 	& h2.ck-form__header__label {
 		flex-grow: 1;
+		text-overflow: ellipsis;
+		overflow: hidden;
 	}
 }


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Handling long titles using CSS ellipsis in `FormHeader` component.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

None.

---

### 💡 Additional information

*Required for: https://github.com/ckeditor/ckeditor5-commercial/pull/8128*
