### PR TITLE
No longer crash editor when selection change occurs within detached lement and during rendering of the editing.

### DIFF
--- a/.changelog/20250820065521_ck_1889.md
+++ b/.changelog/20250820065521_ck_1889.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-engine
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/18744
+---
+
+Fixed an issue where the editor could crash if the selection was moved to a non-existent node during the blur event.

--- a/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
@@ -13,10 +13,10 @@ import { FocusObserver } from './focusobserver.js';
 import { env, type ObservableChangeEvent } from '@ckeditor/ckeditor5-utils';
 import { debounce, type DebouncedFunc } from 'es-toolkit/compat';
 
-import { type EditingView } from '../view.js';
-import { type ViewDocumentSelection } from '../documentselection.js';
-import { type ViewDomConverter } from '../domconverter.js';
-import { type ViewSelection } from '../selection.js';
+import type { EditingView } from '../view.js';
+import type { ViewDocumentSelection } from '../documentselection.js';
+import type { ViewDomConverter } from '../domconverter.js';
+import type { ViewSelection } from '../selection.js';
 import type { ViewDocumentCompositionStartEvent } from './compositionobserver.js';
 
 // @if CK_DEBUG_TYPING // const { _debouncedLine, _buildLogMessage } = require( '../../dev-utils/utils.js' );
@@ -334,7 +334,14 @@ export class SelectionObserver extends Observer {
 			return;
 		}
 
-		if ( this.selection.isSimilar( newViewSelection ) ) {
+		if ( isOrphanedSelectionRange( newViewSelection ) ) {
+			// Occasionally, such as when removing markers during a focus change, the selection may end up inside a view element
+			// whose parent has already been detached from the DOM. In most cases this is harmless, but if the selectionchange
+			// event fires before the view is fully synchronized with the DOM converter, some elements in the selection may become orphans.
+			// This can result in the view being out of sync with the actual DOM structure.
+			// See: https://github.com/ckeditor/ckeditor5/issues/18744
+			this.view.forceRender();
+		} else if ( this.selection.isSimilar( newViewSelection ) ) {
 			// If selection was equal and we are at this point of algorithm, it means that it was incorrect.
 			// Just re-render it, no need to fire any events, etc.
 			this.view.forceRender();
@@ -369,6 +376,31 @@ export class SelectionObserver extends Observer {
 	private _clearInfiniteLoop(): void {
 		this._loopbackCounter = 0;
 	}
+}
+
+/**
+ * Checks if given selection first or last range item has a detached parent.
+ * It often means that the selection starts or ends outside of the editing root.
+ */
+function isOrphanedSelectionRange( selection: ViewSelection ): boolean {
+	return Array
+		.from( selection.getRanges() )
+		.flatMap( range => [ range.start.parent, range.end.parent ] )
+		.some( element => {
+			while ( element ) {
+				if ( element.is( 'rootElement' ) ) {
+					return false;
+				}
+
+				if ( !element.parent ) {
+					return true;
+				}
+
+				element = element.parent;
+			}
+
+			return false;
+		} );
 }
 
 /**

--- a/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
@@ -551,7 +551,7 @@ describe( 'SelectionObserver', () => {
 		sel.collapse( domText, 3 );
 	} );
 
-	// See: https://github.com/ckeditor/ckeditor5/pull/18958
+	// See: https://github.com/ckeditor/ckeditor5/issues/18744
 	it( 'should not crash even if domConverter returns view range with items detached from root', done => {
 		const { domConverter } = selectionObserver;
 

--- a/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
@@ -556,7 +556,7 @@ describe( 'SelectionObserver', () => {
 		const { domConverter } = selectionObserver;
 
 		const forceRenderSpy = sinon.stub( view, 'forceRender' ).callsFake( () => {} );
-		const stub = testUtils.sinon.stub( domConverter, 'domSelectionToView' ).callsFake( ( ...args ) => {
+		const stub = sinon.stub( domConverter, 'domSelectionToView' ).callsFake( ( ...args ) => {
 			const selection = stub.wrappedMethod.call( domConverter, ...args );
 			const getRangesStub = sinon.stub( selection, 'getRanges' ).callsFake( () => {
 				const ranges = [ ...getRangesStub.wrappedMethod.call( selection ) ];


### PR DESCRIPTION
### 🚀 Summary

No longer crash the editor when a selection change occurs within a detached element and during rendering of the editing.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5/issues/18744
---

### 💡 Additional information

Occasionally, such as when removing markers during a focus change, the selection may end up inside a view element whose parent has already been detached from the DOM but is still present in the view DOM mappings. In most cases this is harmless, but if the `selectionchange` event fires before the view is fully synchronized with the DOM converter, some elements in the selection may become orphans.
For example:

<img width="2060" height="237" alt="obraz" src="https://github.com/user-attachments/assets/b41a7f78-0156-48bf-a4ff-a80ce1213b3b" />

The `comment` marker has been removed from the view, but it's still present in DOM converter mappings. 


