### PR TITLE
Fixed export validator file filter being too greedy after moving `ckeditor5` to a separate package.

### DIFF
--- a/scripts/ci/exports/utils/getfilepaths.mjs
+++ b/scripts/ci/exports/utils/getfilepaths.mjs
@@ -21,7 +21,7 @@ export function getFilePaths() {
 	return globSync( typeScriptFilesGlobPaths )
 		.map( upath.normalize )
 		.filter( file => file.includes( 'ckeditor-cloud-services-collaboration' ) || !file.endsWith( '.d.ts' ) )
-		.filter( file => !file.includes( 'ckeditor5' ) )
+		.filter( file => !file.includes( 'packages/ckeditor5/' ) )
 		.filter( file => !file.includes( 'ckeditor5-build' ) )
 		.filter( file => !file.includes( 'ckeditor5-icons/' ) )
 		.filter( file => !file.includes( 'ckeditor5-operations-compressor/' ) )


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Fixed export validator file filter being too greedy after moving `ckeditor5` to a separate package.

The new `ckeditor5` should be ignored in the export validation, as it contains reexports of all packages and the validator was not designed to handle it. The first attempt at ignoring `packages/ckeditor5/` directory made it too greedy, so we are making sure that only the `packages/ckeditor5/` directory is ignored, and not all of the files.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* See #18925

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
