### PR TITLE
Docs: Use `https` to enable `crypto` API.

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "docs:api": "node scripts/docs/build-api-docs.mjs",
     "docs:ckeditor5": "node scripts/docs/build-ckeditor-packages.mjs",
     "docs:content-styles": "node -e \"import( './scripts/docs/build-content-styles.mjs' ).then( m => m.default() );\"",
-    "docs:serve": "ws --directory ./build/docs/ --compress --port 8080",
+    "docs:serve": "ws --directory ./build/docs/ --compress --http2 --port 8080",
     "docs:verify": "node ./scripts/web-crawler/index.mjs --docs",
     "docs:lint": "node scripts/vale/vale.mjs",
     "docs:vale": "vale",

--- a/scripts/web-crawler/index.mjs
+++ b/scripts/web-crawler/index.mjs
@@ -61,7 +61,7 @@ function parseArguments( args ) {
 	}
 
 	const defaultOptionsForDocs = minimist( [
-		'-u', 'http://fake.ckeditor.com:8080/ckeditor5/latest/',
+		'-u', 'https://fake.ckeditor.com:8080/ckeditor5/latest/',
 		'-e', '/ckfinder/',
 		'-e', '/api/',
 		'-e', '/assets/',
@@ -100,6 +100,7 @@ function parseArguments( args ) {
 		exclusions: options.exclusions ? toArray( options.exclusions ).filter( exclusion => exclusion.length > 0 ) : [],
 		timeout: options.timeout ? Number( options.timeout ) : DEFAULT_TIMEOUT,
 		concurrency: options.concurrency ? Number( options.concurrency ) : 1,
-		silent: options.silent
+		silent: options.silent,
+		ignoreHTTPSErrors: true
 	};
 }


### PR DESCRIPTION
### 🚀 Summary

Docs: Use `https` to enable `crypto` API.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5-commercial/issues/7888.
* See https://github.com/ckeditor/ckeditor5-commercial/pull/8209.

---

### 💡 Additional information

The new version of `@uploadcare/file-uploader` uses Crypto API, which requires the page to either use HTTPS or a localhost domain. Because we need to use the `fake.ckeditor.com` domain in docs, our only option might be using HTTPS.
