### PR TITLE
Fixed an issue where Watchdog incorrectly restored collaboration data

### DIFF
--- a/.changelog/20250829113424_feat_nextgenai.md
+++ b/.changelog/20250829113424_feat_nextgenai.md
@@ -1,0 +1,11 @@
+---
+type: Fix
+
+scope:
+  - ckeditor5-watchdog
+
+closes:
+  - 19033
+---
+
+Fixed an issue where Watchdog incorrectly restored collaboration data (comment threads and suggestions) after a crash in load and save integrations.


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Fixed an issue where Watchdog incorrectly restored collaboration data in load&save integrations.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #19033
