### PR TITLE
Ignore `ckeditor5-root` when switching npm tags

### DIFF
--- a/scripts/release/switchlatestnpm.mjs
+++ b/scripts/release/switchlatestnpm.mjs
@@ -14,7 +14,6 @@ import { CKEDITOR5_ROOT_PATH } from '../constants.mjs';
 const rootPkgJson = fs.readJsonSync( upath.join( CKEDITOR5_ROOT_PATH, 'package.json' ) );
 
 const GLOB_PATTERNS = [
-	'package.json',
 	'packages/*/package.json',
 	'external/ckeditor5-commercial/packages/*/package.json'
 ];


### PR DESCRIPTION
### 🚀 Summary

This PR aims to ignore the `ckeditor5-root` name when switching npm tags during the release process. Without this change, the upcoming release could fail due to trying to update a non-existent package.

---

### 📌 Related issues

* Closes #19022

---

### 💡 Additional information

Before the change, the script updates `89` packages. Now it would be `88`.
