### PR TITLE
Use patterns instead of globs to match branches on CI (`#release`)

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -338,7 +338,7 @@ workflows:
             branches:
               only:
                 - release
-                - release-v*
+                - /^release-v.*$/
       - notify_ci_failure:
           filters:
             branches:
@@ -346,6 +346,7 @@ workflows:
                 - master
                 - stable
                 - release
+                - /^release-v.*$/
 
   nightly:
     when: << pipeline.parameters.isNightly >>


### PR DESCRIPTION
### 🚀 Summary

Use patterns instead of globs to match branches on CI.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #000

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
