### PR TITLE
Fix: "Red pen" translated as "Red marker"

### DIFF
--- a/packages/ckeditor5-highlight/lang/translations/ja.po
+++ b/packages/ckeditor5-highlight/lang/translations/ja.po
@@ -29,7 +29,7 @@ msgstr "青のマーカー"
 
 msgctxt "Toolbar button tooltip for applying red pen (text color)."
 msgid "Red pen"
-msgstr "赤のマーカー"
+msgstr "赤のペン"
 
 msgctxt "Toolbar button tooltip for applying green pen (text color)."
 msgid "Green pen"


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Fix Japanese translation for "Red pen".

Current translation "赤のマーカー" means "Red marker".

It should be "赤のペン".

- "ペン" is "pen"
- "マーカー" is "marker"

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #000

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
