### PR TITLE
Fixed non-previewed widget dragging on iOS

### DIFF
--- a/packages/ckeditor5-clipboard/src/dragdrop.ts
+++ b/packages/ckeditor5-clipboard/src/dragdrop.ts
@@ -705,8 +705,12 @@ export class DragDrop extends Plugin {
 				preview.style.backgroundColor = 'var(--ck-color-base-background)';
 			}
 		} else if ( env.isiOS ) {
-			// Custom preview for iOS.
+			// Custom preview for iOS. Note that it must have some dimensions for iOS to start dragging element.
 			preview.style.maxWidth = `${ editableWidth }px`;
+			preview.style.padding = '10px';
+			preview.style.minWidth = '200px';
+			preview.style.minHeight = '20px';
+			preview.style.boxSizing = 'border-box';
 			preview.style.backgroundColor = 'var(--ck-color-base-background)';
 		} else {
 			// If domTarget is inside the editable root, browsers will display the preview correctly by themselves.

--- a/packages/ckeditor5-clipboard/tests/dragdrop.js
+++ b/packages/ckeditor5-clipboard/tests/dragdrop.js
@@ -1665,7 +1665,10 @@ describe( 'Drag and Drop', () => {
 
 				sinon.assert.calledWith( spy, sinon.match( {
 					style: {
-						'padding-left': '',
+						'padding': '10px',
+						'min-width': '200px',
+						'min-height': '20px',
+						'box-sizing': 'border-box',
 						'max-width': sinon.match( /px$/ ),
 						'background-color': 'var(--ck-color-base-background)'
 					},


### PR DESCRIPTION
### 🚀 Summary

It's a fix for not yet released drag drop improvement: https://github.com/ckeditor/ckeditor5/pull/18929.

---

### 📌 Related issues

* Closes #19068.

---

### 💡 Additional information

The issue was that we used `DataTransfer#setDragImage()` on iOS. When the preview has no size, then the drag action does not start.
