### PR TITLE
Use a path to the "ckeditor5" package when calculating a new version

### DIFF
--- a/scripts/release/utils/getreleasedescription.mjs
+++ b/scripts/release/utils/getreleasedescription.mjs
@@ -3,7 +3,11 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
+import upath from 'upath';
 import * as releaseTools from '@ckeditor/ckeditor5-dev-release-tools';
+import { CKEDITOR5_PACKAGES_PATH } from '../../constants.mjs';
+
+const CKEDITOR5_PATH = upath.join( CKEDITOR5_PACKAGES_PATH, 'ckeditor5' );
 
 /**
  * @param {ReleaseOptions} cliArguments
@@ -14,7 +18,7 @@ export default async function getReleaseDescription( cliArguments ) {
 		const CKE5_NEXT_RELEASE_VERSION = process.env.CKE5_NEXT_RELEASE_VERSION.trim();
 
 		return [
-			await releaseTools.getNextPreRelease( `${ CKE5_NEXT_RELEASE_VERSION }-alpha` ), null
+			await releaseTools.getNextPreRelease( `${ CKE5_NEXT_RELEASE_VERSION }-alpha`, CKEDITOR5_PATH ), null
 		];
 	}
 
@@ -22,22 +26,23 @@ export default async function getReleaseDescription( cliArguments ) {
 		const releaseIdentifier = `0.0.0-nightly-next-${ releaseTools.getDateIdentifier() }`;
 
 		return [
-			await releaseTools.getNextPreRelease( releaseIdentifier ), null
+			await releaseTools.getNextPreRelease( releaseIdentifier, CKEDITOR5_PATH ), null
 		];
 	}
 
 	if ( cliArguments.nightly ) {
 		return [
-			await releaseTools.getNextNightly(), null
+			await releaseTools.getNextNightly( CKEDITOR5_PATH ), null
 		];
 	}
 
 	if ( cliArguments.internal ) {
 		return [
-			await releaseTools.getNextInternal(), null
+			await releaseTools.getNextInternal( CKEDITOR5_PATH ), null
 		];
 	}
 
+	// Changelog is stored in the repository root directory.
 	const version = releaseTools.getLastFromChangelog();
 
 	return [


### PR DESCRIPTION
### 🚀 Summary

> [!WARNING]
> Target: **`#release`**.

Use a path to the "ckeditor5" package when calculating a new version for nightly releases.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes https://github.com/ckeditor/ckeditor5-commercial/issues/8285.

---

### 💡 Additional information

Please, check the changes manually.
