### PR TITLE
Replaced `npm view` command with the util from release tools

### DIFF
--- a/scripts/release/switchlatestnpm.mjs
+++ b/scripts/release/switchlatestnpm.mjs
@@ -5,7 +5,6 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import { execSync } from 'child_process';
 import fs from 'fs-extra';
 import upath from 'upath';
 import semver from 'semver';
@@ -24,7 +23,7 @@ const npmOwner = 'ckeditor';
 const packages = globSync( GLOB_PATTERNS, { absolute: true, cwd: CKEDITOR5_ROOT_PATH } )
 	.map( packageJsonPath => fs.readJsonSync( packageJsonPath ).name );
 
-const latestPublishedVersion = execSync( 'npm view ckeditor5@latest version', { encoding: 'utf-8' } ).trim();
+const latestPublishedVersion = await releaseTools.getLastFromTag( 'ckeditor5', 'latest' );
 
 console.log( `Assigning the \`@latest\` npm tag for v${ rootPkgJson.version }.` );
 


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

- Replaced `npm view` command with the new util from `@ckeditor/ckeditor5-dev-release-tools`.
- It requires https://github.com/ckeditor/ckeditor5-dev/pull/1206.
    - Hence, changes in this PR does not target the `#release` branch.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #000

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
