### PR TITLE
Define owners for lock-oriented files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+scripts/release/utils/config.js     @ckeditor/ckeditor-5-admins
+
+packages/*/package.json             @ckeditor/ckeditor-5-platform
+package.json                        @ckeditor/ckeditor-5-platform
+pnpm-lock.yaml                      @ckeditor/ckeditor-5-platform


### PR DESCRIPTION
### 🚀 Summary

This change forces the acceptance of PRs that modify the lock-related files by the @ckeditor/ckeditor-5-platform team.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5-commercial/issues/8276.