### PR TITLE
Setting chrome version in generated Circle CI config using `chrome-version` parameter.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ parameters:
     default: false
   chromeVersion:
     type: string
-    default: "140.0.7339.81"
+    default: "140.0.7339.127"
 
 orbs:
   node: circleci/node@7.1.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,9 @@ parameters:
   isStaleBot:
     type: boolean
     default: false
+  chromeVersion:
+    type: string
+    default: "140.0.7339.81"
 
 orbs:
   node: circleci/node@7.1.1
@@ -36,7 +39,7 @@ commands:
       - add_ssh_keys:
           fingerprints:
             - "a0:41:a2:56:c8:7d:3f:29:41:d1:87:92:fd:50:2b:6b"
-  
+
   checkout_command:
     description: "Clone the CKEditor 5 repository with limited depth and branches"
     steps:
@@ -66,7 +69,7 @@ jobs:
           pkg-manager: pnpm
       - run:
           name: Generate a new configuration to check all packages in the repository
-          command: node scripts/ci/generate-circleci-configuration.mjs
+          command: node scripts/ci/generate-circleci-configuration.mjs --chrome-version="<< pipeline.parameters.chromeVersion >>"
       - continuation/continue:
           configuration_path: .circleci/config-tests.yml
 

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -6,7 +6,7 @@ version: 2.1
 
 orbs:
   node: circleci/node@7.1.1
-  browser-tools: circleci/browser-tools@2.1.2
+  browser-tools: circleci/browser-tools@2.3.1
 
 # List of parameters are automatically inherited from `config.yml`.
 parameters:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -8,14 +8,8 @@ orbs:
   node: circleci/node@7.1.1
   browser-tools: circleci/browser-tools@2.1.2
 
-# List of parameters must be synchronized between configuration files.
+# List of parameters are automatically inherited from `config.yml`.
 parameters:
-  isNightly:
-    type: boolean
-    default: false
-  isStaleBot:
-    type: boolean
-    default: false
 
 commands:
   install_newest_emoji:

--- a/scripts/ci/generate-circleci-configuration.mjs
+++ b/scripts/ci/generate-circleci-configuration.mjs
@@ -17,6 +17,7 @@ import { glob } from 'glob';
 import yaml from 'js-yaml';
 import IS_COMMUNITY_PR from './is-community-pr.mjs';
 import { CKEDITOR5_ROOT_PATH, CKEDITOR5_MAIN_PACKAGE_PATH } from '../constants.mjs';
+import { parseArgs } from 'util';
 
 const CIRCLECI_CONFIGURATION_DIRECTORY = upath.join( CKEDITOR5_ROOT_PATH, '.circleci' );
 
@@ -38,11 +39,24 @@ const NON_FULL_COVERAGE_PACKAGES = [
 	'ckeditor5-minimap'
 ];
 
+const { values: options } = parseArgs( {
+	options: {
+		'chrome-version': {
+			type: 'string',
+			default: 'latest'
+		}
+	}
+} );
+
 const bootstrapCommands = () => ( [
 	'checkout_command',
 	'halt_if_short_flow',
 	'bootstrap_repository_command',
-	'browser-tools/install_chrome'
+	{
+		'browser-tools/install_chrome': {
+			chrome_version: options[ 'chrome-version' ]
+		}
+	}
 ] );
 
 const prepareCodeCoverageDirectories = () => ( {

--- a/scripts/ci/generate-circleci-configuration.mjs
+++ b/scripts/ci/generate-circleci-configuration.mjs
@@ -312,7 +312,8 @@ function substituteChromeVersion( version, items ) {
 
 						return {
 							'browser-tools/install_chrome': {
-								chrome_version: version
+								chrome_version: version,
+								timeout: '5m'
 							}
 						};
 					} )

--- a/scripts/ci/generate-circleci-configuration.mjs
+++ b/scripts/ci/generate-circleci-configuration.mjs
@@ -103,6 +103,12 @@ const persistToWorkspace = fileName => ( {
 		await fs.readFile( upath.join( CIRCLECI_CONFIGURATION_DIRECTORY, 'template.yml' ) )
 	);
 
+	const rootConfig = yaml.load(
+		await fs.readFile( upath.join( CIRCLECI_CONFIGURATION_DIRECTORY, 'config.yml' ) )
+	);
+
+	config.parameters = rootConfig.parameters;
+
 	const featureTestBatches = featurePackages.reduce( ( output, packageName, packageIndex ) => {
 		let currentBatch = FEATURE_BATCH_SIZES.findIndex( ( batchSize, batchIndex, allBatches ) => {
 			return packageIndex < allBatches.slice( 0, batchIndex + 1 ).reduce( ( a, b ) => a + b );


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Setting chrome version in generated Circle CI config using `chrome-version` parameter.
Added a new `chromeVersion` parameter to `.circleci/config.yml` with a default value of `140.0.7339.127`.
Inheriting `parameters` in `template.yml` from `config.yml`.
Enhanced the `generate-circleci-configuration.mjs` script to accept a `--chrome-version` command line argument.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #000

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
