### PR TITLE
Disable corepack on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ parameters:
     default: false
 
 orbs:
-  node: circleci/node@7.1.1
   continuation: circleci/continuation@0.1.2
 
 commands:
@@ -60,10 +59,15 @@ jobs:
     steps:
       - checkout_command
       - install_ssh_keys_command
-      - node/install-pnpm:
-          version: "10"
-      - node/install-packages:
-          pkg-manager: pnpm
+      - run:
+          name: Disable Corepack
+          command: sudo corepack disable
+      - run:
+          name: Install pnpm
+          command: sudo npm i -g pnpm@^10
+      - run:
+          name: Install pnpm
+          command: pnpm install --frozen-lockfile
       - run:
           name: Generate a new configuration to check all packages in the repository
           command: node scripts/ci/generate-circleci-configuration.mjs

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -5,7 +5,6 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@7.1.1
   browser-tools: circleci/browser-tools@2.1.2
 
 # List of parameters must be synchronized between configuration files.
@@ -55,10 +54,15 @@ commands:
     description: "Bootstrap the CKEditor 5 project"
     steps:
       - install_ssh_keys_command
-      - node/install-pnpm:
-          version: "10"
-      - node/install-packages:
-          pkg-manager: pnpm
+      - run:
+          name: Disable Corepack
+          command: sudo corepack disable
+      - run:
+          name: Install pnpm
+          command: sudo npm i -g pnpm@^10
+      - run:
+          name: Install pnpm
+          command: pnpm install --frozen-lockfile
       - prepare_environment_variables_commands
 
   checkout_command:


### PR DESCRIPTION
### 🚀 Summary

Disable corepack on CI.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* See ckeditor/ckeditor5-commercial#8335.