### PR TITLE
Module export validator improvements.

### DIFF
--- a/scripts/ci/exports/utils/module.mjs
+++ b/scripts/ci/exports/utils/module.mjs
@@ -17,8 +17,12 @@ import { globSync } from 'glob';
 import { CKEDITOR5_ROOT_PATH } from '../../../constants.mjs';
 import { PACKAGES_DIRECTORY } from '../../../release/utils/constants.mjs';
 
-// E.g. `packages/ckeditor5-core/` or `packages/ckeditor5/`.
-const PUBLIC_PACKAGES = globSync( `${ PACKAGES_DIRECTORY }/*/`, { cwd: CKEDITOR5_ROOT_PATH, mark: true } );
+// The trailing `/` is important to mark the end of a package name.
+const PUBLIC_PACKAGES = globSync( `${ PACKAGES_DIRECTORY }/*/`, {
+	cwd: CKEDITOR5_ROOT_PATH,
+	mark: true,
+	absolute: true
+} ).map( upath.normalize );
 
 export class Module {
 	static load( fileName, errorCollector ) {
@@ -378,12 +382,8 @@ export class Module {
 	}
 
 	_isFromPublicPackages( fileName ) {
-		// Checking if fileName contains the package that is marked as public API by default.
-		return PUBLIC_PACKAGES.some( publicPackageName => {
-			const publicPackageFullPath = upath.join( CKEDITOR5_ROOT_PATH, publicPackageName );
-
-			return fileName.includes( publicPackageFullPath );
-		} );
+		// Checking if the file belongs to the public package.
+		return PUBLIC_PACKAGES.some( publicPackagePath => fileName.startsWith( publicPackagePath ) );
 	}
 
 	resolveImportsExports( packages, modules ) {

--- a/scripts/ci/exports/utils/module.mjs
+++ b/scripts/ci/exports/utils/module.mjs
@@ -15,9 +15,10 @@ import { isInternalNode } from './misc.mjs';
 import { createExportResolutionError } from './errorutils.mjs';
 import { globSync } from 'glob';
 import { CKEDITOR5_ROOT_PATH } from '../../../constants.mjs';
+import { PACKAGES_DIRECTORY } from '../../../release/utils/constants.mjs';
 
-// E.g. `packages/ckeditor5-core/` or `packages/ckeditor5`.
-const PUBLIC_PACKAGES = globSync( 'packages/*', { cwd: CKEDITOR5_ROOT_PATH, mark: true } );
+// E.g. `packages/ckeditor5-core/` or `packages/ckeditor5/`.
+const PUBLIC_PACKAGES = globSync( `${ PACKAGES_DIRECTORY }/*/`, { cwd: CKEDITOR5_ROOT_PATH, mark: true } );
 
 export class Module {
 	static load( fileName, errorCollector ) {
@@ -378,7 +379,11 @@ export class Module {
 
 	_isFromPublicPackages( fileName ) {
 		// Checking if fileName contains the package that is marked as public API by default.
-		return PUBLIC_PACKAGES.some( publicPackageName => fileName.includes( publicPackageName ) );
+		return PUBLIC_PACKAGES.some( publicPackageName => {
+			const publicPackageFullPath = upath.join( CKEDITOR5_ROOT_PATH, publicPackageName );
+
+			return fileName.includes( publicPackageFullPath );
+		} );
 	}
 
 	resolveImportsExports( packages, modules ) {

--- a/scripts/ci/exports/utils/module.mjs
+++ b/scripts/ci/exports/utils/module.mjs
@@ -32,8 +32,7 @@ export class Module {
 
 	constructor( fileName, ast, { publicApiTag }, errorCollector ) {
 		this.fileName = fileName.replace( /\.d\.ts$/, '.ts' );
-		// TODO: `/external/` check doesn't seem correct, because it causes some errors to be silenced.
-		this.isPublicApi = fileName.includes( '/external/' ) || this.relativeFileName === 'index.ts' ? true : publicApiTag;
+		this.isPublicApi = this._isFromPublicPackages( fileName ) || this.relativeFileName === 'index.ts' ? true : publicApiTag;
 		this.exports = [];
 		this.imports = [];
 		this.declarations = [];
@@ -370,6 +369,10 @@ export class Module {
 				}
 			}
 		} );
+	}
+
+	_isFromPublicPackages( fileName ) {
+		return fileName.includes( '/external/ckeditor5/packages/' );
 	}
 
 	resolveImportsExports( packages, modules ) {

--- a/scripts/ci/exports/utils/module.mjs
+++ b/scripts/ci/exports/utils/module.mjs
@@ -13,6 +13,11 @@ import { Declaration } from './declaration.mjs';
 import { ExternalModule } from './externalmodule.mjs';
 import { isInternalNode } from './misc.mjs';
 import { createExportResolutionError } from './errorutils.mjs';
+import { globSync } from 'glob';
+import { CKEDITOR5_ROOT_PATH } from '../../../constants.mjs';
+
+// E.g. `packages/ckeditor5-core/` or `packages/ckeditor5`.
+const PUBLIC_PACKAGES = globSync( 'packages/*', { cwd: CKEDITOR5_ROOT_PATH, mark: true } );
 
 export class Module {
 	static load( fileName, errorCollector ) {
@@ -372,7 +377,8 @@ export class Module {
 	}
 
 	_isFromPublicPackages( fileName ) {
-		return fileName.includes( '/external/ckeditor5/packages/' );
+		// Checking if fileName contains the package that is marked as public API by default.
+		return PUBLIC_PACKAGES.some( publicPackageName => fileName.includes( publicPackageName ) );
 	}
 
 	resolveImportsExports( packages, modules ) {


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Replaced broad `/external` check with a more precise for exporting public module members in `external/ckeditor5/packages`.

We want to keep the old behaviour, and mark all files from `ckeditor5/packages` as public API.

The rest of the files would have to be set manually to be marked as public API.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #18993

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
