### PR TITLE
Reverted changes related to `:where()` pseudo-class in table styles.

### DIFF
--- a/.changelog/20250923165802_ck_19134.md
+++ b/.changelog/20250923165802_ck_19134.md
@@ -1,9 +1,0 @@
----
-type: Other
-scope:
-  - ckeditor5-table
-closes:
-  - https://github.com/ckeditor/ckeditor5/issues/19134
----
-
-Reduced specificity of table default styles selector in content styles so now it is easier to provide custom default table styles. 

--- a/packages/ckeditor5-table/docs/features/tables-styling.md
+++ b/packages/ckeditor5-table/docs/features/tables-styling.md
@@ -150,19 +150,22 @@ The **“Table properties”** and **“Table cell properties”** buttons in th
 The style sheet for the editor displayed below looks as follows:
 
 ```css
-.ck-content .table:not(.layout-table) {
+.ck-content figure.table:not(.layout-table) {
 	float: left;
 	width: 550px;
 	height: 450px;
 }
 
-.ck-content .table:not(.layout-table) table {
+.ck-content figure.table:not(.layout-table) > table {
 	border-style: dashed;
 	border-color: hsl(90, 75%, 60%);
 	border-width: 3px;
 }
 
-.ck-content .table:not(.layout-table) table td {
+.ck-content figure.table:not(.layout-table) > table  > tbody > tr > td,
+.ck-content figure.table:not(.layout-table) > table  > tbody > tr > th,
+.ck-content figure.table:not(.layout-table) > table  > thead > tr > td,
+.ck-content figure.table:not(.layout-table) > table  > thead > tr > th {
 	text-align: center;
 	vertical-align: bottom;
 	padding: 10px

--- a/packages/ckeditor5-table/tests/manual/tabledefaultproperties.html
+++ b/packages/ckeditor5-table/tests/manual/tabledefaultproperties.html
@@ -1,18 +1,21 @@
 <style id="table-properties-styles">
-	.ck-content .table {
+	.ck-content figure.table:not(.layout-table) {
 		float: left;
 		width: 300px;
 		height: 250px;
 	}
 
-	.ck-content .table table {
+	.ck-content figure.table:not(.layout-table) > table {
 		border-style: dashed;
 		border-color: hsl(0, 0%, 60%);
 		border-width: 3px;
 		background-color: #00f;
 	}
 
-	.ck-content .table table td {
+	.ck-content figure.table:not(.layout-table) > table  > tbody > tr > td,
+	.ck-content figure.table:not(.layout-table) > table  > tbody > tr > th,
+	.ck-content figure.table:not(.layout-table) > table  > thead > tr > td,
+	.ck-content figure.table:not(.layout-table) > table  > thead > tr > th {
 		border-style: dotted;
 		border-color: hsl(120, 75%, 60%);
 		border-width: 2px;

--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -14,8 +14,24 @@
 		text-align: left;
 	}
 
-	& :where(table).table:where(:not(.layout-table)),
-	& :where(figure).table:where(:not(.layout-table)) > table {
+	& figure.table:not(.layout-table) {
+		display: table;
+
+		& > table {
+			width: 100%;
+			height: 100%;
+		}
+	}
+
+	& .table:not(.layout-table) {
+		/* Give the table widget some air and center it horizontally */
+		/* The first value should be equal to --ck-spacing-large variable if used in the editor context
+		to avoid the content jumping (See https://github.com/ckeditor/ckeditor5/issues/9825). */
+		margin: 0.9em auto;
+	}
+
+	& table.table:not(.layout-table),
+	& figure.table:not(.layout-table) > table {
 		/* The table cells should have slight borders */
 		border-collapse: collapse;
 		border-spacing: 0;
@@ -24,12 +40,13 @@
 		Also see https://github.com/ckeditor/ckeditor5-table/issues/50. */
 		border: 1px double hsl(0, 0%, 70%);
 
-		& > :where(thead, tbody) {
+		& > thead,
+		& > tbody {
 			/* The linter is disabled here because linter is confused when resolving the `table.table:not(.layout-table)`
 			and `figure.table:not(.layout-table) > table` selectors combined with below selectors.
 			There is no need to split it into two large structures with same code just to make linter happy. */
 			/* stylelint-disable no-descending-specificity */
-			& > :where(tr) {
+			& > tr {
 				& > th {
 					font-weight: bold;
 					background: hsla(0, 0%, 0%, 5%);
@@ -68,22 +85,6 @@
 				}
 			}
 		}
-	}
-
-	& figure.table:not(.layout-table) {
-		display: table;
-
-		& > table {
-			width: 100%;
-			height: 100%;
-		}
-	}
-
-	& .table:not(.layout-table) {
-		/* Give the table widget some air and center it horizontally */
-		/* The first value should be equal to --ck-spacing-large variable if used in the editor context
-		to avoid the content jumping (See https://github.com/ckeditor/ckeditor5/issues/9825). */
-		margin: 0.9em auto;
 	}
 }
 


### PR DESCRIPTION
### 🚀 Summary

Reverted changes related to `:where()` pseudo-class in table styles.

---

### 💡 Additional information

As many Node.js tools/packages do not handle `:where()` selectors properly, we decided to roll back this change as it might cause issues on the integration side.
