### PR TITLE
Do not crash when found a file inside the `packages/` directory

### DIFF
--- a/scripts/release/clean.mjs
+++ b/scripts/release/clean.mjs
@@ -6,10 +6,11 @@
  */
 
 import path from 'path';
-import fs from 'fs';
+import { glob } from 'glob';
 import { rimraf } from 'rimraf';
 import minimist from 'minimist';
 import isTypeScriptPackage from './utils/istypescriptpackage.mjs';
+import { PACKAGES_DIRECTORY } from './utils/constants.mjs';
 
 const options = parseArguments( process.argv.slice( 2 ) );
 
@@ -77,16 +78,10 @@ async function findTypeScriptPackages( repositoryRoot ) {
  * @param {String} repositoryRoot An absolute path to the repository where to look for packages.
  * @returns {Promise} Array of package names.
  */
-function findAllPackages( repositoryRoot ) {
-	return new Promise( ( resolve, reject ) => {
-		fs.readdir( path.join( repositoryRoot, 'packages' ), ( err, files ) => {
-			if ( err ) {
-				reject( err );
-			} else {
-				resolve( files.map( pkg => path.join( repositoryRoot, 'packages', pkg ) ) );
-			}
-		} );
-	} );
+async function findAllPackages( repositoryRoot ) {
+	return glob( `${ PACKAGES_DIRECTORY }/*/`, { cwd: repositoryRoot, absolute: true } )
+		// Glob returns packages from bottom to top (Z-A). Let's align the results to `fs.readdir()` (A-Z).
+		.then( items => items.reverse() );
 }
 
 /**


### PR DESCRIPTION
### 🚀 Summary

Use `glob()` with a pattern for matching directories only instead of manually reading a directory to avoid crashing the `release:clean` script.

---

### 📌 Related issues

* Closes ckeditor/ckeditor5-commercial#8476.

---

### 💡 Additional information

I used both repositories to check.

```
# ckeditor5

node ./scripts/release/clean.mjs
Done!

# ---

# ckeditor5-commercial

touch packages/.DS_Store

ls -la packages/ | grep DS_Store
-rw-r--r--@  1 pomek  staff     0 Sep 25 12:43 .DS_Store

node external/ckeditor5/scripts/release/clean.mjs --cwd .
Done!
```

Btw, the pull request targets the `#release` branch.