### PR TITLE
Recognizable plugin names for FPOCL

### DIFF
--- a/packages/ckeditor5-core/src/editor/editor.ts
+++ b/packages/ckeditor5-core/src/editor/editor.ts
@@ -999,6 +999,10 @@ export abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 			}
 
 			if ( reason == 'pluginNotAllowed' ) {
+				// It's safe to assume `name` exists because `pluginNotAllowed` must know a plugin name when checking the license.
+				const gluePluginName = name!.replace( /(Editing|UI)$/, '' );
+				const containsGluePlugin = this.plugins.has( gluePluginName );
+
 				/**
 				 * The plugin you are trying to use is not permitted under your current license.
 				 * Please check the available features on the
@@ -1008,7 +1012,9 @@ export abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 				 * @error license-key-plugin-not-allowed
 				 * @param {String} pluginName The plugin you tried to load.
 				 */
-				throw new CKEditorError( 'license-key-plugin-not-allowed', null, { pluginName: name } );
+				throw new CKEditorError( 'license-key-plugin-not-allowed', null, {
+					pluginName: containsGluePlugin ? gluePluginName : name
+				} );
 			}
 
 			if ( reason == 'featureNotAllowed' ) {

--- a/packages/ckeditor5-core/tests/editor/licensecheck.js
+++ b/packages/ckeditor5-core/tests/editor/licensecheck.js
@@ -937,6 +937,44 @@ describe( 'Editor - license check', () => {
 			} );
 		}
 
+		it( 'should throw `license-key-plugin-not-allowed` pointing to the main plugin if a check is an editing part', async () => {
+			const editor = await TestEditor.create( {
+				licenseKey: 'GPL',
+				plugins: [
+					class TableColumnResize {
+						static get pluginName() {
+							return 'TableColumnResize';
+						}
+					}
+				]
+			} );
+
+			editor._showLicenseError( 'pluginNotAllowed', 'TableColumnResizeEditing' );
+
+			expectToThrowCKEditorError( () => clock.tick( 1 ), 'license-key-plugin-not-allowed', undefined, {
+				pluginName: 'TableColumnResize'
+			} );
+		} );
+
+		it( 'should throw `license-key-plugin-not-allowed` pointing to the main plugin if a check is a UI part', async () => {
+			const editor = await TestEditor.create( {
+				licenseKey: 'GPL',
+				plugins: [
+					class TableColumnResize {
+						static get pluginName() {
+							return 'TableColumnResize';
+						}
+					}
+				]
+			} );
+
+			editor._showLicenseError( 'pluginNotAllowed', 'TableColumnResizeUI' );
+
+			expectToThrowCKEditorError( () => clock.tick( 1 ), 'license-key-plugin-not-allowed', undefined, {
+				pluginName: 'TableColumnResize'
+			} );
+		} );
+
 		it( 'should throw error only once', () => {
 			const editor = new TestEditor( { licenseKey: 'GPL' } );
 


### PR DESCRIPTION
### 🚀 Summary

Use a recognizable plugin name when detecting a FPOCL feature.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes ckeditor/ckeditor5-commercial#8574

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
