### PR TITLE
Fixed restricted imports rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,13 +16,12 @@ const projectPackages = readdirSync( CKEDITOR5_PACKAGES_PATH, { withFileTypes: t
 	.filter( dirent => dirent.isDirectory() )
 	.map( dirent => dirent.name );
 
-const packageWhitelist = [
-	'inspector',
-	'mermaid'
-];
 const allowedPackageNames = [
-	...projectPackages.map( p => p.replace( /ckeditor5-?/, '' ) ).filter( Boolean ),
-	...packageWhitelist
+	'inspector',
+	'mermaid',
+	...projectPackages
+		.map( projectPackage => projectPackage.replace( /ckeditor5-?/, '' ) )
+		.filter( Boolean )
 ];
 
 const disallowedImportsPattern = `@ckeditor/ckeditor5-(?!${ allowedPackageNames.join( '|' ) })`;


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

`@ckeditor/ckeditor5-*` packages other than local and whitelisted packages are forbidden from being imported.


---

### 💡 Additional information

- Script detected dummy invalid imports properly, in source files as well as in snippets.
- Script also ran in related repositories and no errors were thrown.
