### PR TITLE
Drop `@internal` from `TableConfig` type.

### DIFF
--- a/.changelog/20251017133926_ck_8563_adjust_exports.md
+++ b/.changelog/20251017133926_ck_8563_adjust_exports.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope:
+  - ckeditor5-table
+---
+
+The `TableConfig` type is no longer exported as internal.

--- a/packages/ckeditor5-table/src/tableconfig.ts
+++ b/packages/ckeditor5-table/src/tableconfig.ts
@@ -23,8 +23,6 @@ import type { ColorOption, ColorPickerConfig } from 'ckeditor5/src/ui.js';
  * ```
  *
  * See {@link module:core/editor/editorconfig~EditorConfig all editor options}.
- *
- * @internal
  */
 export interface TableConfig {
 


### PR DESCRIPTION
### 🚀 Summary

Drop `@internal` from `TableConfig` type.  

---

### 📌 Related issues

* Caused by https://github.com/ckeditor/ckeditor5-commercial/issues/8563