### PR TITLE
Adjust incorrectly exported exports.

### DIFF
--- a/.changelog/20251017133553_ck_8563_adjust_exports_engine.md
+++ b/.changelog/20251017133553_ck_8563_adjust_exports_engine.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-engine
+---
+
+Removed unnecessary public exports: `autoParagraphEmptyRoots`, `isParagraphable`, `wrapInParagraph`.
+
+These utilities were only provided as internal exports (prefixed with `_`), which indicates they are not part of the public API. Removing the duplicate public exports cleans up the API and reduces the risk of relying on implementation details.

--- a/.changelog/20251017133553_ck_8563_adjust_exports_link.md
+++ b/.changelog/20251017133553_ck_8563_adjust_exports_link.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-link
+---
+
+Removed unnecessary public export: `ensureSafeUrl`.
+
+This utility was only provided as an internal export (prefixed with `_`), which indicates it is not part of the public API. Removing the duplicate public export cleans up the API and reduces the risk of relying on implementation details.

--- a/.changelog/20251017133926_ck_8563_adjust_exports.md
+++ b/.changelog/20251017133926_ck_8563_adjust_exports.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope:
+  - ckeditor5-table
+---
+
+The `TableConfig` type is no longer exported as internal.

--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -195,13 +195,6 @@ export {
 export { ModelTypeCheckable } from './model/typecheckable.js';
 export { ModelWriter } from './model/writer.js';
 
-// Model utils.
-export {
-	autoParagraphEmptyRoots,
-	isParagraphable,
-	wrapInParagraph
-} from './model/utils/autoparagraphing.js';
-
 // Model Events.
 export type { ModelDocumentChangeEvent } from './model/document.js';
 export type { ModelDocumentSelectionChangeEvent } from './model/documentselection.js';

--- a/packages/ckeditor5-link/src/index.ts
+++ b/packages/ckeditor5-link/src/index.ts
@@ -34,7 +34,6 @@ export type {
 
 export {
 	addLinkProtocolIfApplicable,
-	ensureSafeUrl,
 	ensureSafeUrl as _ensureSafeLinkUrl,
 	isLinkableElement,
 	isLinkElement,

--- a/packages/ckeditor5-table/src/tableconfig.ts
+++ b/packages/ckeditor5-table/src/tableconfig.ts
@@ -23,8 +23,6 @@ import type { ColorOption, ColorPickerConfig } from 'ckeditor5/src/ui.js';
  * ```
  *
  * See {@link module:core/editor/editorconfig~EditorConfig all editor options}.
- *
- * @internal
  */
 export interface TableConfig {
 


### PR DESCRIPTION
### 🚀 Summary

After updating the export validation tool, we found a few redundant exports. According to the [migration guide](https://ckeditor.com/docs/ckeditor5/latest/updating/nim-migration/migrating-imports.html), these exports should no longer exist under their original names and should be renamed. It’s safe to remove them.

---

### 📌 Related issues

Check more: https://github.com/ckeditor/ckeditor5-commercial/issues/8563