### PR TITLE
docs: Move CKBox version to Umberto variable to keep examples snippets up-to-date

### DIFF
--- a/docs/getting-started/setup/loading-cdn-resources.md
+++ b/docs/getting-started/setup/loading-cdn-resources.md
@@ -89,7 +89,7 @@ Here is an example showing all the available options:
 	translations: [ 'es', 'de' ],
 	premium: true,
 	ckbox: {
-		version: '2.5.1',
+		version: '{%CKBOX_VERSION%}',
 		theme: 'lark' // Optional, default 'lark'.
 	},
 	plugins: {

--- a/docs/umberto.json
+++ b/docs/umberto.json
@@ -912,5 +912,8 @@
 			"navigationIncludeIndex": true,
 			"slug": "support"
 		}
-	]
+	],
+	"variables": {
+		"CKBOX_VERSION": "2.9.2"
+	}
 }

--- a/packages/ckeditor5-ckbox/docs/features/ckbox.md
+++ b/packages/ckeditor5-ckbox/docs/features/ckbox.md
@@ -53,7 +53,7 @@ To use this feature in your application, you must first load the CKBox library a
 The easiest way to load the CKBox library is to include the `<script>` tag loading the `ckbox.js` file first:
 
 ```html
-<script src="https://cdn.ckbox.io/ckbox/2.4.0/ckbox.js"></script>
+<script src="https://cdn.ckbox.io/ckbox/{%CKBOX_VERSION%}/ckbox.js"></script>
 ```
 
 Please note, that while using the `latest` call instead of a version number is available, it is not advised. The latest version may bring breaking changes that will stall your CKBox integration.
@@ -215,8 +215,8 @@ ClassicEditor
 Also, make sure to include the translation file after loading the CKBox library:
 
 ```html
-<script src="https://cdn.ckbox.io/ckbox/2.4.0/ckbox.js"></script>
-<script src="https://cdn.ckbox.io/ckbox/2.4.0/translations/es.js"></script>
+<script src="https://cdn.ckbox.io/ckbox/{%CKBOX_VERSION%}/ckbox.js"></script>
+<script src="https://cdn.ckbox.io/ckbox/{%CKBOX_VERSION%}/translations/es.js"></script>
 ```
 
 ### Providing the token URL

--- a/packages/ckeditor5-theme-lark/docs/_snippets/examples/theme-lark.js
+++ b/packages/ckeditor5-theme-lark/docs/_snippets/examples/theme-lark.js
@@ -43,7 +43,7 @@ class DarkModeCKBoxIntegration extends Plugin {
 		// Load CKBox dark theme.
 		this._ckboxLinkElement = document.createElement( 'link' );
 		this._ckboxLinkElement.rel = 'stylesheet';
-		this._ckboxLinkElement.href = 'https://cdn.ckbox.io/ckbox/2.4.0/styles/themes/dark.css';
+		this._ckboxLinkElement.href = 'https://cdn.ckbox.io/ckbox/latest/styles/themes/dark.css';
 
 		document.head.appendChild( this._ckboxLinkElement );
 


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Moves the CKBox versions found in the documentation to a variable in Umberto. This will help centralize the location of CKBox bumps after subsequent releases. 

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
