### PR TITLE
fix: too long translations

### DIFF
--- a/packages/ckeditor5-table/lang/translations/ja.po
+++ b/packages/ckeditor5-table/lang/translations/ja.po
@@ -269,7 +269,7 @@ msgstr "テーブル"
 
 msgctxt "Label for the insert table layout toolbar button."
 msgid "Insert table layout"
-msgstr "表のレイアウトを挿入コンテンツ表表の種類表の種類のオプション表示されるテキストリンクのプロパティメディアの埋め込み利用できるリンクがありません画像のサイズ変更代替テキスト全画面モードを終了全画面モードに入る"
+msgstr "表のレイアウトを挿入"
 
 msgctxt "The accessible label used in the table layout insert UI element."
 msgid "Table layout"
@@ -293,4 +293,4 @@ msgstr "表の種類"
 
 msgctxt "The accessible label of dropdown list that displays a user interface to choose table type."
 msgid "Table type options"
-msgstr "表の種類のオプション表示されるテキストリンクのプロパティメディアの埋め込み利用できるリンクがありません画像のサイズ変更代替テキスト全画面モードを終了全画面モードに入る"
+msgstr "表の種類のオプション"


### PR DESCRIPTION
### 🚀 Summary

 Fixed incorrect Japanese translations for table layout feature.

---

### 📌 Related issues

* Closes #19255 

---

### 💡 Additional information

nothing
