### PR TITLE
Drop internal test timeout changelog entry.

### DIFF
--- a/.changelog/20251013115322_ck_19155.md
+++ b/.changelog/20251013115322_ck_19155.md
@@ -1,9 +1,0 @@
----
-type: Other
-scope:
-  - ckeditor5-core
-closes:
-  - https://github.com/ckeditor/ckeditor5/issues/19155
----
-
-Increased timeouts and added delays between create&destroy cycles to improve memory tests stability.


### PR DESCRIPTION
### 🚀 Summary

Removal of changelog entry which may be not useful for the users.
