### PR TITLE
Improve CSS styling of long tables in print mode.

### DIFF
--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -102,7 +102,7 @@
 		 * 	* The table has `display: table` style set.
 		 * 	* The block element is placed directly after the table.
 		 */
-		&:not(.layout-table):not(:has(> figcaption)) {
+		&:not(.layout-table) {
 			width: fit-content;
 			height: fit-content;
 		}


### PR DESCRIPTION
### 🚀 Summary

Improve CSS styling of long tables in print mode.

Parent PR: https://github.com/ckeditor/ckeditor5-commercial/pull/8725
