### PR TITLE
Added "v" prefix before version number in changelog header.

### DIFF
--- a/scripts/docs/get-latest-changelogs.cjs
+++ b/scripts/docs/get-latest-changelogs.cjs
@@ -57,7 +57,7 @@ module.exports = () => {
 				.replace( getSectionRegexp( 'Released packages' ), '' );
 
 			return [
-				`## CKEditor 5 ${ version } release`,
+				`## CKEditor 5 v${ version } release`,
 				'',
 				`${ changelog }`,
 				''


### PR DESCRIPTION
Added "v" prefix before version number in changelog header.

<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

It is an agreed convention witing CK Source, that we always want to separate "5" in "CKEditor 5" with particular version number by placing prefix "v" before.

Good example: **CKEditor 5 v47.1.0 release**
Bad example: <s>CKEditor 5 47.1.0 release</s>

---
