### PR TITLE
Minimizing the AI sidebar in fullscreen mode will properly adjust visibility of sidebars

### DIFF
--- a/packages/ckeditor5-fullscreen/src/handlers/abstracteditorhandler.ts
+++ b/packages/ckeditor5-fullscreen/src/handlers/abstracteditorhandler.ts
@@ -936,13 +936,21 @@ export class FullscreenAbstractEditorHandler {
 
 		// Adjust the visible elements when the transition (changing the size of the AI tabs) ends. Earlier we do not have the
 		// correct sizes of elements.
-		aiTabs.view.element.addEventListener( 'transitionend', this._adjustVisibleElementsBound );
+		aiTabs.view.element.addEventListener( 'transitionend', ( evt: TransitionEvent ) => this._handleAISidebarTransitions( evt ) );
 	}
 
 	/**
-	 * A bound reference to the _adjustVisibleElements method. To be used as a callback for the transitionend event.
+	 * Checks the transition event to see if it's changing the width of the AI tabs and if so, adjusts the visible fullscreen mode elements.
 	 */
-	private _adjustVisibleElementsBound = this._adjustVisibleElements.bind( this );
+	private _handleAISidebarTransitions( evt: TransitionEvent ): void {
+		const aiTabs = this._editor.plugins.get( 'AITabs' ) as any;
+
+		// Transition may occur on any element inside the AI tabs (e.g. changing the box-shadow in review mode),
+		// so we need to check the target and the property name.
+		if ( evt.target === aiTabs.view.element && evt.propertyName.includes( 'width' ) ) {
+			this._adjustVisibleElements();
+		}
+	}
 
 	/**
 	 * Restores the state of the AI Tabs to the original values.
@@ -957,7 +965,7 @@ export class FullscreenAbstractEditorHandler {
 
 		this._aiTabsData = null;
 
-		aiTabs.view.element.removeEventListener( 'transitionend', this._adjustVisibleElementsBound );
+		aiTabs.view.element.removeEventListener( 'transitionend', this._handleAISidebarTransitions );
 	}
 
 	/**

--- a/packages/ckeditor5-fullscreen/tests/handlers/abstracteditorhandler.js
+++ b/packages/ckeditor5-fullscreen/tests/handlers/abstracteditorhandler.js
@@ -993,6 +993,63 @@ describe( 'AbstractHandler', () => {
 				.classList.contains( 'ck-fullscreen__right-sidebar--collapsed' ) ).to.be.true;
 		} );
 	} );
+
+	describe( '_handleAISidebarTransitions', () => {
+		let aiElement, nestedElement;
+
+		beforeEach( () => {
+			aiElement = global.document.createElement( 'div' );
+			nestedElement = global.document.createElement( 'div' );
+			aiElement.appendChild( nestedElement );
+
+			sinon.stub( editor.plugins, 'get' ).withArgs( 'AITabs' ).returns( {
+				view: {
+					element: aiElement
+				}
+			} );
+		} );
+
+		afterEach( () => {
+			sinon.restore();
+			aiElement.remove();
+		} );
+
+		it( 'should not adjust the fullscreen elements if the transition is not on the AI tabs', () => {
+			const adjustVisibleElementsStub = sinon.stub( abstractHandler, '_adjustVisibleElements' );
+			const evt = new TransitionEvent( 'transitionend', {
+				target: nestedElement,
+				propertyName: 'width'
+			} );
+
+			abstractHandler._handleAISidebarTransitions( evt );
+
+			expect( adjustVisibleElementsStub ).to.not.have.been.called;
+		} );
+
+		it( 'should not adjust the fullscreen elements if the transition concerns non-width properties of the AI tabs', () => {
+			const adjustVisibleElementsStub = sinon.stub( abstractHandler, '_adjustVisibleElements' );
+			const evt = new TransitionEvent( 'transitionend', {
+				target: aiElement,
+				propertyName: 'height'
+			} );
+
+			abstractHandler._handleAISidebarTransitions( evt );
+
+			expect( adjustVisibleElementsStub ).to.not.have.been.called;
+		} );
+
+		it( 'should adjust the fullscreen elements if the transition is on the AI tabs', () => {
+			const adjustVisibleElementsStub = sinon.stub( abstractHandler, '_adjustVisibleElements' );
+			const fakeEvt = {
+				target: aiElement,
+				propertyName: 'width'
+			};
+
+			abstractHandler._handleAISidebarTransitions( fakeEvt );
+
+			expect( adjustVisibleElementsStub ).to.have.been.called;
+		} );
+	} );
 } );
 
 function wait( time ) {


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

We listen on `transitionend` event to catch the moment when sidebar width settles down and filter out bubbling events and unimportant properties.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #19279.

---

### 💡 Additional information

No changelog entry as this is a fix for the unreleased feature.
