### PR TITLE
Fixed `pnpm release:clean` script to match all TS packages.

### DIFF
--- a/scripts-tests/release/utils/istypescriptpackage.mjs
+++ b/scripts-tests/release/utils/istypescriptpackage.mjs
@@ -4,61 +4,28 @@
  */
 
 import { vi, describe, it, expect } from 'vitest';
-import fs from 'fs-extra';
 import { glob } from 'glob';
 import isTypeScriptPackage from '../../../scripts/release/utils/istypescriptpackage.mjs';
 
-vi.mock( 'fs-extra' );
 vi.mock( 'glob' );
 
 describe( 'scripts/release/utils/istypescriptpackage', () => {
 	const packagePath = '/packages/foo';
 
-	it( 'returns true if package.json.main points to a TypeScript file', async () => {
-		vi.mocked( fs.readJson ).mockResolvedValue( { main: 'src/index.ts' } );
+	it( 'returns true if TypeScript files are found', async () => {
+		vi.mocked( glob ).mockResolvedValue( [ 'test.ts' ] );
 
 		const result = await isTypeScriptPackage( packagePath );
 
-		expect( fs.readJson ).toHaveBeenCalledWith( '/packages/foo/package.json' );
 		expect( result ).toBe( true );
 	} );
 
-	it( 'returns true if tsconfig.json exists', async () => {
-		vi.mocked( fs.readJson ).mockResolvedValue( { main: 'lib/index.js' } );
-		vi.mocked( fs.access ).mockResolvedValue( undefined );
-		vi.mocked( glob ).mockResolvedValue( [] );
-
-		const result = await isTypeScriptPackage( packagePath );
-
-		expect( fs.access ).toHaveBeenCalledWith( '/packages/foo/tsconfig.json', fs.constants.F_OK );
-		expect( result ).toBe( true );
-	} );
-
-	it( 'returns true if any .ts files exist in src directory', async () => {
-		vi.mocked( fs.readJson ).mockResolvedValue( { main: 'lib/index.js' } );
-		vi.mocked( fs.access ).mockRejectedValue( new Error( 'not found' ) );
-		vi.mocked( glob ).mockResolvedValue( [ 'src/index.ts', 'src/utils/helper.ts' ] );
-
-		const result = await isTypeScriptPackage( packagePath );
-
-		expect( glob ).toHaveBeenCalledWith( 'src/**/*.ts', { cwd: packagePath } );
-		expect( result ).toBe( true );
-	} );
-
-	it( 'returns false if no TypeScript indicators are found', async () => {
-		vi.mocked( fs.readJson ).mockResolvedValue( { main: 'lib/index.js' } );
-		vi.mocked( fs.access ).mockRejectedValue( new Error( 'not found' ) );
+	it( 'returns false if no TypeScript files are found', async () => {
 		vi.mocked( glob ).mockResolvedValue( [] );
 
 		const result = await isTypeScriptPackage( packagePath );
 
 		expect( result ).toBe( false );
-	} );
-
-	it( 'throws if reading package.json fails', async () => {
-		vi.mocked( fs.readJson ).mockRejectedValue( new Error( 'package.json not found' ) );
-
-		await expect( isTypeScriptPackage( packagePath ) ).rejects.toThrow( 'package.json not found' );
 	} );
 } );
 

--- a/scripts/release/utils/istypescriptpackage.mjs
+++ b/scripts/release/utils/istypescriptpackage.mjs
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import fs from 'fs-extra';
-import path from 'upath';
 import { glob } from 'glob';
 
 /**
@@ -12,28 +10,7 @@ import { glob } from 'glob';
  * @returns {Promise.<Boolean>}
  */
 export default async function isTypeScriptPackage( packagePath ) {
-	const packageJsonPath = path.join( packagePath, 'package.json' );
-	const packageJson = await fs.readJson( packageJsonPath );
-
-	// Almost all CKEditor 5 packages define an entry point. When it points to a TypeScript file,
-	// the package is written in TS.
-	if ( packageJson.main && packageJson.main.includes( '.ts' ) ) {
-		return true;
-	}
-
-	// In step two, Let's check if the package contains a `tsconfig.json` file.
-	if ( await checkFileExists( path.join( packagePath, 'tsconfig.json' ) ) ) {
-		return true;
-	}
-
-	// In the last step check if any typescript files are present in the src directory.
 	const tsFiles = await glob( 'src/**/*.ts', { cwd: packagePath } );
 
 	return tsFiles.length > 0;
-}
-
-function checkFileExists( file ) {
-	return fs.access( file, fs.constants.F_OK )
-		.then( () => true )
-		.catch( () => false );
 }


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Fixed `pnpm release:clean` script to match all TS packages.

The `packages/ckeditor5/package.json` file has a different value in the main field than the rest of the packages ( 'dist/ckediotr5.js` vs `src/index.ts` ), so it was recognised by the clean script as a JS package.

The `isTypeScriptPackage` function was modified to make to detect if any `.ts` files are present in `src` directory.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #19273

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
