### PR TITLE
Fixed widget-type-around not visible inside restricted editing exception regions

### DIFF
--- a/packages/ckeditor5-widget/theme/widgettypearound.css
+++ b/packages/ckeditor5-widget/theme/widgettypearound.css
@@ -99,15 +99,21 @@
 }
 
 /*
- * Integration with the restricted editing mode (feature) of the editor.
- */
-.ck.ck-editor__editable.ck-restricted-editing_mode_restricted .ck-widget__type-around {
-	display: none;
-}
-
-/*
  * Integration with the #isEnabled property of the WidgetTypeAround plugin.
  */
 .ck.ck-editor__editable.ck-widget__type-around_disabled .ck-widget__type-around {
 	display: none;
+}
+
+/*
+ * Integration with the restricted editing mode (feature) of the editor.
+ */
+.ck.ck-editor__editable.ck-restricted-editing_mode_restricted {
+	& .ck-widget__type-around {
+		display: none;
+	}
+
+	& div.restricted-editing-exception .ck-widget__type-around {
+		display: initial;
+	}
 }


### PR DESCRIPTION
### 🚀 Summary

Fixed widget-type-around not visible inside restricted editing exception regions

Closes https://github.com/ckeditor/ckeditor5-commercial/issues/8784.