### PR TITLE
Chrome `142.0.7444.59`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ parameters:
     default: false
   chromeVersion:
     type: string
-    default: "141.0.7390.54"
+    default: "142.0.7444.59"
 
 orbs:
   continuation: circleci/continuation@0.1.2


### PR DESCRIPTION
### 🚀 Summary

Upgrade the Chrome version used on CI to `142.0.7444.59`.

---

### 📌 Related issues

* Closes #8788