### PR TITLE
Fixed order of align with wrap buttons in table alignment toolbar.

### DIFF
--- a/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.ts
+++ b/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.ts
@@ -771,10 +771,10 @@ export class TablePropertiesView extends View {
 
 		// Returns object with a proper order of labels.
 		if ( locale.uiLanguageDirection === 'rtl' ) {
-			return { left, right, blockRight, center, blockLeft };
+			return { right, left, blockRight, center, blockLeft };
 		}
 
-		return { blockLeft, center, blockRight, right, left };
+		return { blockLeft, center, blockRight, left, right };
 	}
 }
 

--- a/packages/ckeditor5-table/tests/tableproperties/ui/tablepropertiesview.js
+++ b/packages/ckeditor5-table/tests/tableproperties/ui/tablepropertiesview.js
@@ -473,8 +473,8 @@ describe( 'table properties', () => {
 								'Align table to the left with no text wrapping',
 								'Center table with no text wrapping',
 								'Align table to the right with no text wrapping',
-								'Align table to the right with text wrapping',
-								'Align table to the left with text wrapping'
+								'Align table to the left with text wrapping',
+								'Align table to the right with text wrapping'
 							] );
 
 							expect( toolbar.items.map( ( { isOn } ) => isOn ) ).to.have.ordered.members( [
@@ -493,8 +493,8 @@ describe( 'table properties', () => {
 							const toolbar = view.alignmentToolbar;
 
 							expect( toolbar.items.map( ( { label } ) => label ) ).to.have.ordered.members( [
-								'Align table to the left with text wrapping',
 								'Align table to the right with text wrapping',
+								'Align table to the left with text wrapping',
 								'Align table to the right with no text wrapping',
 								'Center table with no text wrapping',
 								'Align table to the left with no text wrapping'
@@ -512,8 +512,8 @@ describe( 'table properties', () => {
 								'blockLeft',
 								'center',
 								'blockRight',
-								'right',
-								'left'
+								'left',
+								'right'
 							];
 
 							for ( let i = 0; i < values.length; i++ ) {


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

*Proper order of alignments buttons in the toolbar:*

<img width="311" height="81" alt="Screenshot 2025-11-17 at 17 42 25" src="https://github.com/user-attachments/assets/5aa64682-d617-4243-b2c0-c72852ccd82b" />


---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes https://github.com/ckeditor/ckeditor5/issues/19382

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
