### PR TITLE
Fix incorrect table dimensions input alignment.

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableform.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableform.css
@@ -31,8 +31,12 @@
 		}
 
 		&.ck-table-form__dimensions-row {
+			--ck-table-form-dimensions-input-width: calc(var(--ck-table-form-default-input-width) * 2 + var(--ck-spacing-large));
+
+			width: var(--ck-table-form-dimensions-input-width);
+			max-width: var(--ck-table-form-dimensions-input-width);
+			min-width: var(--ck-table-form-dimensions-input-width);
 			padding: 0;
-			max-width: calc(var(--ck-table-form-default-input-width) * 2 + var(--ck-spacing-large));
 
 			& .ck-table-form__dimensions-row__width,
 			& .ck-table-form__dimensions-row__height {


### PR DESCRIPTION
### 🚀 Summary

Fix incorrect table dimensions input alignment.

---

### Before

<img width="658" height="712" alt="image" src="https://github.com/user-attachments/assets/4a274826-9cbd-48d7-b1c0-9ed68d17c95e" />

### After

<img width="614" height="500" alt="image" src="https://github.com/user-attachments/assets/5d71add3-be2a-4b14-9e2f-37223973364f" />
