### PR TITLE
Update the `moduleResolution` and `module` fields in main `tsconfig.json`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,11 +22,11 @@
     "noImplicitAny": true,
     "noImplicitOverride": true,
     "strict": true,
-    "module": "es6",
+    "module": "esnext",
     "target": "es2022",
     "sourceMap": true,
     "allowJs": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true
   },


### PR DESCRIPTION
### 🚀 Summary

Update the `moduleResolution` and `module` fields in main `tsconfig.json`.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5-internal/issues/4173.

---

### 💡 Additional information

#### Successful CI runs

* Core - https://app.circleci.com/pipelines/github/ckeditor/ckeditor5/14825/workflows/2e682452-94a1-4414-abbe-85fda192c937
* Commercial - https://app.circleci.com/pipelines/github/ckeditor/ckeditor5-commercial/13145/workflows/06047ece-3dc2-41c1-86be-d61d5023f252

#### Differences

I compared the output of the release process before and after the change. The only difference was that in 4 `.d.ts` files the CSS imports were rewritten like so:

```js
// BEFORE
import './../../theme/inserttable.css';
//      ^^

// AFTER
import '../../theme/inserttable.css';
```

This shouldn't affect consuming projects.

#### Why `moduleResolution: bundler`?

Quote from official documentation:

> Like `node16` and `nodenext`, this mode supports package.json `"imports"` and `"exports"`, but unlike the Node.js resolution modes, `bundler` never requires file extensions on relative paths in imports.

We already have an ESLint rule that ensures file extensions in relative paths in imports.
