### PR TITLE
Fix incorrect move of table row containing only th elements to thead if previous row was not header row (v48.x)

### DIFF
--- a/.changelog/20251126131616_ck_19431_v48.md
+++ b/.changelog/20251126131616_ck_19431_v48.md
@@ -1,0 +1,9 @@
+---
+type: Minor breaking change
+scope:
+  - ckeditor5-table
+see:
+  - https://github.com/ckeditor/ckeditor5/issues/19431
+---
+
+Upcasting of table heading rows has been changed to fix incorrect marking and moving of table rows as header rows when preceding rows are not header rows. It's no longer behind a experimental flag and is enabled by default.

--- a/packages/ckeditor5-table/src/converters/upcasttable.ts
+++ b/packages/ckeditor5-table/src/converters/upcasttable.ts
@@ -8,7 +8,6 @@
  */
 
 import type { ModelElement, UpcastDispatcher, UpcastElementEvent, ViewElement, ViewNode } from 'ckeditor5/src/engine.js';
-import type { Editor } from 'ckeditor5/src/core.js';
 
 import { createEmptyTableCell } from '../utils/common.js';
 import { getViewTableFromWrapper } from '../utils/structure.js';
@@ -82,9 +81,7 @@ export function upcastTableFigure() {
  * @returns Conversion helper.
  * @internal
  */
-export function upcastTable( editor: Editor ) {
-	const ignoreHeaderRowMoveIfNormalRowsBefore = !!editor.config.get( 'experimentalFlags.tableCellTypeSupport' );
-
+export function upcastTable() {
 	return ( dispatcher: UpcastDispatcher ): void => {
 		dispatcher.on<UpcastElementEvent>( 'element:table', ( evt, data, conversionApi ) => {
 			const viewTable = data.viewItem;
@@ -94,7 +91,7 @@ export function upcastTable( editor: Editor ) {
 				return;
 			}
 
-			const { rows, headingRows, headingColumns } = scanTable( viewTable, ignoreHeaderRowMoveIfNormalRowsBefore );
+			const { rows, headingRows, headingColumns } = scanTable( viewTable );
 
 			// Only set attributes if values is greater then 0.
 			const attributes: { headingColumns?: number; headingRows?: number } = {};
@@ -205,12 +202,9 @@ export function ensureParagraphInTableCell( elementName: string ) {
  * rows           - Sorted `<tr>` elements as they should go into the model - ie. if `<thead>` is inserted after `<tbody>` in the view.
  *
  * @param viewTable The view table element.
- * @param ignoreHeaderRowMoveIfNormalRowsBefore If set to `true`, then heading rows detection will stop
- * once a normal row is found between heading rows. If set to `false`, then heading rows will be detected
- * even if normal rows are between them.
  * @returns The table metadata.
  */
-function scanTable( viewTable: ViewElement, ignoreHeaderRowMoveIfNormalRowsBefore: boolean ) {
+function scanTable( viewTable: ViewElement ) {
 	let headingColumns: number | undefined = undefined;
 	let shouldAccumulateHeadingRows: boolean | null = null;
 
@@ -274,7 +268,7 @@ function scanTable( viewTable: ViewElement, ignoreHeaderRowMoveIfNormalRowsBefor
 					trColumns.every( e => e.is( 'element', 'th' ) ) &&
 					// If there is at least one "normal" table row between heading rows, then stop accumulating heading rows.
 					// However, if flag `ignoreHeaderRowMoveIfNormalRowsBefore` is set to `false`, then ignore this rule.
-					( !ignoreHeaderRowMoveIfNormalRowsBefore || shouldAccumulateHeadingRows === null || shouldAccumulateHeadingRows )
+					( shouldAccumulateHeadingRows === null || shouldAccumulateHeadingRows )
 				)
 			) {
 				headRows.push( tr );

--- a/packages/ckeditor5-table/src/tableediting.ts
+++ b/packages/ckeditor5-table/src/tableediting.ts
@@ -114,7 +114,7 @@ export class TableEditing extends Plugin {
 		conversion.for( 'upcast' ).add( upcastTableFigure() );
 
 		// Table conversion.
-		conversion.for( 'upcast' ).add( upcastTable( editor ) );
+		conversion.for( 'upcast' ).add( upcastTable() );
 
 		conversion.for( 'editingDowncast' ).elementToStructure( {
 			model: {

--- a/packages/ckeditor5-table/tests/converters/upcasttable.js
+++ b/packages/ckeditor5-table/tests/converters/upcasttable.js
@@ -539,13 +539,7 @@ describe( 'upcastTable()', () => {
 			);
 
 			expectModel(
-				'<table headingColumns="1" headingRows="2">' +
-				'<tableRow>' +
-					'<tableCell><paragraph>11</paragraph></tableCell>' +
-					'<tableCell><paragraph>12</paragraph></tableCell>' +
-					'<tableCell><paragraph>13</paragraph></tableCell>' +
-					'<tableCell><paragraph>14</paragraph></tableCell>' +
-				'</tableRow>' +
+				'<table headingColumns="1" headingRows="1">' +
 				'<tableRow>' +
 					'<tableCell><paragraph>21</paragraph></tableCell>' +
 					'<tableCell><paragraph>22</paragraph></tableCell>' +
@@ -569,6 +563,12 @@ describe( 'upcastTable()', () => {
 					'<tableCell><paragraph>52</paragraph></tableCell>' +
 					'<tableCell><paragraph>53</paragraph></tableCell>' +
 					'<tableCell><paragraph>54</paragraph></tableCell>' +
+				'</tableRow>' +
+				'<tableRow>' +
+					'<tableCell><paragraph>11</paragraph></tableCell>' +
+					'<tableCell><paragraph>12</paragraph></tableCell>' +
+					'<tableCell><paragraph>13</paragraph></tableCell>' +
+					'<tableCell><paragraph>14</paragraph></tableCell>' +
 				'</tableRow>' +
 				'</table>'
 			);
@@ -691,149 +691,74 @@ describe( 'upcastTable()', () => {
 			);
 		} );
 
-		describe( 'experimental skipping of movement of heading rows', () => {
-			beforeEach( async () => {
-				await editor.destroy();
+		it( 'should properly group heading rows in table containing multiple tbody', () => {
+			editor.setData( `
+				<figure class="table">
+					<table>
+						<thead>
+						<tr>
+							<th>Col Header 1</th>
+							<th>Col Header 2</th>
+							<th>Col Header 3</th>
+						</tr>
+						<tr>
+							<th colspan="3">Rowgroup Header 1</th>
+						</tr>
+						</thead>
+						<tbody>
+						<tr>
+							<th>Row Header 1</th>
+							<td>Data 1,1</td>
+							<td>Data 2,1</td>
+						</tr>
+						<tr>
+							<th colspan="3">Rowgroup Header 2</th>
+						</tr>
+						<tr>
+							<th>Row Header 2</th>
+							<td>Data 1,2</td>
+							<td>Data 2,2</td>
+						</tr>
+						<tr>
+							<th>Row Header 3</th>
+							<td>Data 1,3</td>
+							<td>Data 2,3</td>
+						</tr>
+						</tbody>
+					</table>
+				</figure>
+			` );
 
-				editor = await ClassicTestEditor.create( '', {
-					plugins: [ TableEditing, Paragraph, ImageBlockEditing, Widget ],
-					experimentalFlags: {
-						tableCellTypeSupport: true
-					}
-				} );
-
-				model = editor.model;
-
-				// Since this part of test tests only view->model conversion editing pipeline is not necessary
-				// so defining model->view converters won't be necessary.
-				editor.editing.destroy();
-			} );
-
-			it( 'should properly calculate heading columns when result is more than zero', () => {
-				editor.setData(
-					'<table>' +
-					'<tbody>' +
-					// This row starts with 2 th (3 total).
-					'<tr><th>31</th><th>32</th><td>33</td><th>34</th></tr>' +
-					// This row starts with 2 th (2 total).
-					'<tr><th>41</th><th>42</th><td>43</td><td>44</td></tr>' +
-					// This row starts with 1 th (1 total). This one has min number of heading columns: 1.
-					'<tr><th>51</th><td>52</td><td>53</td><td>54</td></tr>' +
-					// This row starts with 4 th (4 total).
-					'<tr><th>11</th><th>12</th><th>13</th><th>14</th></tr>' +
-					'</tbody>' +
-					'<thead>' +
-					// This row has 4 ths but it is a thead.
-					'<tr><th>21</th><th>22</th><th>23</th><th>24</th></tr>' +
-					'</thead>' +
-					'</table>'
-				);
-
-				expectModel(
-					'<table headingColumns="1" headingRows="1">' +
+			expectModel(
+				'<table headingColumns="1" headingRows="2">' +
 					'<tableRow>' +
-						'<tableCell><paragraph>21</paragraph></tableCell>' +
-						'<tableCell><paragraph>22</paragraph></tableCell>' +
-						'<tableCell><paragraph>23</paragraph></tableCell>' +
-						'<tableCell><paragraph>24</paragraph></tableCell>' +
+						'<tableCell><paragraph>Col Header 1</paragraph></tableCell>' +
+						'<tableCell><paragraph>Col Header 2</paragraph></tableCell>' +
+						'<tableCell><paragraph>Col Header 3</paragraph></tableCell>' +
 					'</tableRow>' +
 					'<tableRow>' +
-						'<tableCell><paragraph>31</paragraph></tableCell>' +
-						'<tableCell><paragraph>32</paragraph></tableCell>' +
-						'<tableCell><paragraph>33</paragraph></tableCell>' +
-						'<tableCell><paragraph>34</paragraph></tableCell>' +
+						'<tableCell colspan="3"><paragraph>Rowgroup Header 1</paragraph></tableCell>' +
 					'</tableRow>' +
 					'<tableRow>' +
-						'<tableCell><paragraph>41</paragraph></tableCell>' +
-						'<tableCell><paragraph>42</paragraph></tableCell>' +
-						'<tableCell><paragraph>43</paragraph></tableCell>' +
-						'<tableCell><paragraph>44</paragraph></tableCell>' +
+						'<tableCell><paragraph>Row Header 1</paragraph></tableCell>' +
+						'<tableCell><paragraph>Data 1,1</paragraph></tableCell>' +
+						'<tableCell><paragraph>Data 2,1</paragraph></tableCell>' +
 					'</tableRow>' +
 					'<tableRow>' +
-						'<tableCell><paragraph>51</paragraph></tableCell>' +
-						'<tableCell><paragraph>52</paragraph></tableCell>' +
-						'<tableCell><paragraph>53</paragraph></tableCell>' +
-						'<tableCell><paragraph>54</paragraph></tableCell>' +
+						'<tableCell colspan="3"><paragraph>Rowgroup Header 2</paragraph></tableCell>' +
 					'</tableRow>' +
 					'<tableRow>' +
-						'<tableCell><paragraph>11</paragraph></tableCell>' +
-						'<tableCell><paragraph>12</paragraph></tableCell>' +
-						'<tableCell><paragraph>13</paragraph></tableCell>' +
-						'<tableCell><paragraph>14</paragraph></tableCell>' +
+						'<tableCell><paragraph>Row Header 2</paragraph></tableCell>' +
+						'<tableCell><paragraph>Data 1,2</paragraph></tableCell>' +
+						'<tableCell><paragraph>Data 2,2</paragraph></tableCell>' +
 					'</tableRow>' +
-					'</table>'
-				);
-			} );
-
-			it( 'should properly group heading rows in table containing multiple tbody', () => {
-				editor.setData( `
-					<figure class="table">
-						<table>
-							<thead>
-							<tr>
-								<th>Col Header 1</th>
-								<th>Col Header 2</th>
-								<th>Col Header 3</th>
-							</tr>
-							<tr>
-								<th colspan="3">Rowgroup Header 1</th>
-							</tr>
-							</thead>
-							<tbody>
-							<tr>
-								<th>Row Header 1</th>
-								<td>Data 1,1</td>
-								<td>Data 2,1</td>
-							</tr>
-							<tr>
-								<th colspan="3">Rowgroup Header 2</th>
-							</tr>
-							<tr>
-								<th>Row Header 2</th>
-								<td>Data 1,2</td>
-								<td>Data 2,2</td>
-							</tr>
-							<tr>
-								<th>Row Header 3</th>
-								<td>Data 1,3</td>
-								<td>Data 2,3</td>
-							</tr>
-							</tbody>
-						</table>
-					</figure>
-				` );
-
-				expectModel(
-					'<table headingColumns="1" headingRows="2">' +
-						'<tableRow>' +
-							'<tableCell><paragraph>Col Header 1</paragraph></tableCell>' +
-							'<tableCell><paragraph>Col Header 2</paragraph></tableCell>' +
-							'<tableCell><paragraph>Col Header 3</paragraph></tableCell>' +
-						'</tableRow>' +
-						'<tableRow>' +
-							'<tableCell colspan="3"><paragraph>Rowgroup Header 1</paragraph></tableCell>' +
-						'</tableRow>' +
-						'<tableRow>' +
-							'<tableCell><paragraph>Row Header 1</paragraph></tableCell>' +
-							'<tableCell><paragraph>Data 1,1</paragraph></tableCell>' +
-							'<tableCell><paragraph>Data 2,1</paragraph></tableCell>' +
-						'</tableRow>' +
-						'<tableRow>' +
-							'<tableCell colspan="3"><paragraph>Rowgroup Header 2</paragraph></tableCell>' +
-						'</tableRow>' +
-						'<tableRow>' +
-							'<tableCell><paragraph>Row Header 2</paragraph></tableCell>' +
-							'<tableCell><paragraph>Data 1,2</paragraph></tableCell>' +
-							'<tableCell><paragraph>Data 2,2</paragraph></tableCell>' +
-						'</tableRow>' +
-						'<tableRow>' +
-							'<tableCell><paragraph>Row Header 3</paragraph></tableCell>' +
-							'<tableCell><paragraph>Data 1,3</paragraph></tableCell>' +
-							'<tableCell><paragraph>Data 2,3</paragraph></tableCell>' +
-						'</tableRow>' +
-					'</table>'
-				);
-			} );
+					'<tableRow>' +
+						'<tableCell><paragraph>Row Header 3</paragraph></tableCell>' +
+						'<tableCell><paragraph>Data 1,3</paragraph></tableCell>' +
+						'<tableCell><paragraph>Data 2,3</paragraph></tableCell>' +
+					'</tableRow>' +
+				'</table>'
+			);
 		} );
 	} );
 


### PR DESCRIPTION
### 🚀 Summary

Fix incorrect move of table row containing only `th` elements to `thead` if previous row was not header row.
It's change for `v48` version of the editor.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5/issues/19431