### PR TITLE
Handle title element attributes by redirecting to title-content element

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/downcastdispatcher.ts
+++ b/packages/ckeditor5-engine/src/conversion/downcastdispatcher.ts
@@ -916,9 +916,19 @@ function shouldMarkerChangeBeConverted(
 
 	const hasCustomHandling = ( ancestors as Array<ModelElement> ).some( element => {
 		if ( range.containsItem( element ) ) {
-			const viewElement = mapper.toViewElement( element )!;
+			const viewElement = mapper.toViewElement( element );
 
-			return !!viewElement.getCustomProperty( 'addHighlight' );
+			if ( viewElement ) {
+				return !!viewElement.getCustomProperty( 'addHighlight' );
+			}
+			// Technically, a marker can be created on an element that doesn't have a corresponding view element.
+			// This happens, for example, with the `title` element, which exists in the model but doesn't have
+			// a direct view representation (only its child `title-content` is converted to `<h1>` in the view).
+			// In such cases, we return `false` to indicate that there's no custom handling, allowing the marker
+			// conversion to proceed normally.
+			else {
+				return false;
+			}
 		}
 	} );
 

--- a/packages/ckeditor5-engine/tests/conversion/downcastdispatcher.js
+++ b/packages/ckeditor5-engine/tests/conversion/downcastdispatcher.js
@@ -1262,6 +1262,33 @@ describe( 'DowncastDispatcher', () => {
 			expect( dispatcher._conversionApi.writer ).to.be.undefined;
 			expect( dispatcher._conversionApi.consumable ).to.be.undefined;
 		} );
+
+		it( 'should fire event for marker if element has no view element', () => {
+			root._removeChildren( 0, root.childCount );
+
+			// Create a model element that doesn't have a view element mapping.
+			const titleContent = new ModelText( 'abc' );
+			const title = new ModelElement( 'title', null, titleContent );
+
+			root._appendChild( [ title ] );
+
+			model.change( writer => {
+				const range = writer.createRange( writer.createPositionAt( root, 0 ), writer.createPositionAt( root, 1 ) );
+				writer.addMarker( 'name', { range, usingOperation: false } );
+				writer.setSelection( title, 0 );
+			} );
+
+			sinon.spy( dispatcher, 'fire' );
+
+			const markers = Array.from( model.markers.getMarkersAtPosition( doc.selection.getFirstPosition() ) );
+
+			dispatcher.convertSelection( doc.selection, model.markers, markers );
+
+			expect( dispatcher.fire.calledWith( 'addMarker:name' ) ).to.be.true;
+
+			expect( dispatcher._conversionApi.writer ).to.be.undefined;
+			expect( dispatcher._conversionApi.consumable ).to.be.undefined;
+		} );
 	} );
 
 	describe( '_convertMarkerAdd', () => {


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

The `title` element in the model doesn't have a corresponding view element. Only its child `title-content` is converted to `<h1>` in the view. When attributes are set on the `title` element, the downcast conversion fails because there's no view element to apply them to.

Added a downcast converter that intercepts attribute changes on `title` elements and redirects them to the `title-content` corresponding view element. This ensures that attributes set on `title` in the model are correctly rendered in the view without causing conversion errors.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #000

---

### 💡 Additional information

These changes are required for the AI feature, as it handles elements by adding the `$elementId` attribute to each one.