### PR TITLE
Upgrade Chrome version to `143.0.7499.109`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ parameters:
     default: false
   chromeVersion:
     type: string
-    default: "142.0.7444.59"
+    default: "143.0.7499.109"
 
 orbs:
   continuation: circleci/continuation@0.1.2


### PR DESCRIPTION
### 🚀 Summary

This PR bumps the Chrome used in CI to **143.0.7499.109**.

---

### 📃 Additional information

- Generated automatically by the Chrome bump workflow.
- Triggered because a new Chrome stable version was detected.
