### PR TITLE
Updated tests for the spec update that will relax attribute name restrictions (since Chrome v.143).

### DIFF
--- a/packages/ckeditor5-html-support/src/integrations/customelement.ts
+++ b/packages/ckeditor5-html-support/src/integrations/customelement.ts
@@ -74,6 +74,7 @@ export class CustomElementSupport extends Plugin {
 						return null;
 					}
 
+					// It is ignored intentionally because CI runs on latest Chrome.
 					/* istanbul ignore next -- @preserve */
 					if ( !isValidElementName( viewElement.name ) ) {
 						return null;
@@ -198,6 +199,7 @@ function isValidElementName( name: string ): boolean {
 	try {
 		document.createElement( name );
 	} catch {
+		// It is ignored intentionally because CI runs on latest Chrome.
 		/* istanbul ignore next -- @preserve */
 		return false;
 	}

--- a/packages/ckeditor5-html-support/tests/datafilter.js
+++ b/packages/ckeditor5-html-support/tests/datafilter.js
@@ -983,13 +983,12 @@ describe( 'DataFilter', () => {
 			);
 		} );
 
-		// Unskip it when every major browser (Chrome, Firefox, Safari) will support creating elements with this value.
-		// Currently, only Chrome supports it since v143.
+		// This test is currently only supported in Chrome since v143.
 		// See details:
 		// [x] Chrome: bugs.chromium.org/p/chromium/issues/detail?id=1334640
 		// [ ] Firefox: bugzilla.mozilla.org/show_bug.cgi?id=1773312
 		// [ ] Safari: bugs.webkit.org/show_bug.cgi?id=241419
-		it.skip( 'should not allow invalid attributes with unclosed `p` tag', () => {
+		it( 'should not allow invalid attributes with unclosed `p` tag', () => {
 			dataFilter.allowElement( 'p' );
 			dataFilter.allowAttributes( {
 				name: 'p',
@@ -1009,6 +1008,7 @@ describe( 'DataFilter', () => {
 					},
 					2: {
 						attributes: {
+							'bar<': '',
 							body: '',
 							foo: 'a'
 						}
@@ -1017,7 +1017,7 @@ describe( 'DataFilter', () => {
 			} );
 
 			expect( editor.getData() ).to.equal(
-				'<p zzz="a">x</p><p foo="a" body="">&nbsp;</p>'
+				'<p zzz="a">x</p><p foo="a" bar<="" body="">&nbsp;</p>'
 			);
 		} );
 	} );

--- a/packages/ckeditor5-utils/tests/dom/isvalidattributename.js
+++ b/packages/ckeditor5-utils/tests/dom/isvalidattributename.js
@@ -14,20 +14,20 @@ describe( 'isValidAttributeName', () => {
 		'style',
 		'id',
 		'name',
-		undefined
-		// Uncomment last valid test case when every major browser (Chrome, Firefox, Safari) will support creating elements with this value.
-		// Currently, only Chrome supports it since v143.
+		undefined,
+		// Below values for this test are currently only supported in Chrome since v143.
 		// See details:
 		// [x] Chrome: bugs.chromium.org/p/chromium/issues/detail?id=1334640
 		// [ ] Firefox: bugzilla.mozilla.org/show_bug.cgi?id=1773312
 		// [ ] Safari: bugs.webkit.org/show_bug.cgi?id=241419
-		// '200',
-		// '<',
-		// '"',
-		// "'",
-		// '`',
-		// 200,
-		// '🙂'
+		'200',
+		'<',
+		'"',
+		// eslint-disable-next-line @stylistic/quotes
+		"'",
+		'`',
+		200,
+		'🙂'
 	];
 
 	for ( const name of validTestCases ) {


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

*A brief summary of what this PR changes.*

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes https://github.com/ckeditor/ckeditor5/issues/19334

---

### 💡 Additional information

*More details here 👉  https://github.com/ckeditor/ckeditor5/pull/19316*
