### PR TITLE
OIM: Update `ckeditor5-dev-*` to follow the v54 version

### DIFF
--- a/docs/getting-started/advanced/integrating-from-source-webpack.md
+++ b/docs/getting-started/advanced/integrating-from-source-webpack.md
@@ -40,8 +40,8 @@ The second step is to install the dependencies needed to build the editor. The l
 
 ```bash
 npm install --save \
-	@ckeditor/ckeditor5-dev-translations@43 \
-	@ckeditor/ckeditor5-dev-utils@43 \
+	@ckeditor/ckeditor5-dev-translations@54 \
+	@ckeditor/ckeditor5-dev-utils@54 \
 	css-loader@5 \
 	postcss-loader@4 \
 	raw-loader@4 \

--- a/docs/getting-started/legacy-getting-started/integrations/react.md
+++ b/docs/getting-started/legacy-getting-started/integrations/react.md
@@ -417,7 +417,7 @@ Before you start modifying the webpack configuration, first install some CKEdito
 ```bash
 yarn add \
 	raw-loader@4 \
-	@ckeditor/ckeditor5-dev-utils@43 \
+	@ckeditor/ckeditor5-dev-utils@54 \
 	@ckeditor/ckeditor5-theme-lark \
 	@ckeditor/ckeditor5-react \
 	@ckeditor/ckeditor5-editor-classic \

--- a/docs/getting-started/legacy-getting-started/integrations/vuejs-v2.md
+++ b/docs/getting-started/legacy-getting-started/integrations/vuejs-v2.md
@@ -314,8 +314,8 @@ First, install the necessary dependencies:
 ```bash
 npm install --save \
 	@ckeditor/ckeditor5-vue2 \
-	@ckeditor/ckeditor5-dev-translations@43 \
-	@ckeditor/ckeditor5-dev-utils@43 \
+	@ckeditor/ckeditor5-dev-translations@54 \
+	@ckeditor/ckeditor5-dev-utils@54 \
 	postcss-loader@4 \
 	raw-loader@4
 ```

--- a/docs/getting-started/legacy-getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/legacy-getting-started/integrations/vuejs-v3.md
@@ -331,8 +331,8 @@ First, install the necessary dependencies:
 ```bash
 npm install --save \
     @ckeditor/ckeditor5-vue \
-    @ckeditor/ckeditor5-dev-translations@43 \
-    @ckeditor/ckeditor5-dev-utils@43 \
+    @ckeditor/ckeditor5-dev-translations@54 \
+    @ckeditor/ckeditor5-dev-utils@54 \
     postcss-loader@4 \
     raw-loader@4
 ```

--- a/docs/getting-started/legacy-getting-started/quick-start-other.md
+++ b/docs/getting-started/legacy-getting-started/quick-start-other.md
@@ -294,7 +294,7 @@ You can start with the {@link examples/builds/classic-editor classic editor} wit
 
 ```bash
 npm install --save \
-	@ckeditor/ckeditor5-dev-utils@43 \
+	@ckeditor/ckeditor5-dev-utils@54 \
 	@ckeditor/ckeditor5-editor-classic \
 	@ckeditor/ckeditor5-essentials \
 	@ckeditor/ckeditor5-paragraph \


### PR DESCRIPTION
### 🚀 Summary

This change suggests using `ckeditor5-dev-*` packages in `v54` to avoid installing vulnerable transitive dependencies.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* See #19492

---

### 💡 Additional information

Tests: https://github.com/ckeditor/ckeditor5/issues/19492#issuecomment-3654264348.
