### PR TITLE
Use a deeper clone on CI to avoid issues when reading their messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
             ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run:
           name: Checkout code (single branch)
-          command: git clone --single-branch --depth 1 --branch "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" .
+          command: git clone --single-branch --depth 10 --branch "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" .
 
 jobs:
   generate_configuration:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -71,7 +71,7 @@ commands:
             ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run:
           name: Checkout code (single branch)
-          command: git clone --single-branch --depth 1 --branch "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" .
+          command: git clone --single-branch --depth 10 --branch "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" .
 
   # In the PRs that come from forked repositories, we do not share secret variables.
   # Hence, some of the scripts will not be executed. See: https://github.com/ckeditor/ckeditor5/issues/7745.


### PR DESCRIPTION
### 🚀 Summary

Increase the depth of the `git clone` command to avoid the "bad object" error.

---

### 📌 Related issues

* Closes #19519.

---

### 💡 Additional information

I did not change Commercial because this issue happens only in CKEditor 5. The commercial repository includes more clones, and I would like to avoid messing them up.