### PR TITLE
No longer crash editor when getting data with `PlainTableOutput` plugin but without `TableProperties` (CKEditor v48.x)

### DIFF
--- a/.changelog/20251215144216_ck_19512.md
+++ b/.changelog/20251215144216_ck_19512.md
@@ -1,0 +1,10 @@
+---
+type: Fix
+scope:
+  - ckeditor5-table
+  - ckeditor5-paste-from-office
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/19512
+---
+
+The editor no longer crashes when calling `getData()` on content containing a table with custom styling, provided that the `TablePropertiesEditing` and `PlainTableOutput` plugins are loaded without the `TableProperties` plugin.

--- a/packages/ckeditor5-paste-from-office/src/pastefromoffice.ts
+++ b/packages/ckeditor5-paste-from-office/src/pastefromoffice.ts
@@ -76,8 +76,8 @@ export class PasteFromOffice extends Plugin {
 		const clipboardPipeline: ClipboardPipeline = editor.plugins.get( 'ClipboardPipeline' );
 		const viewDocument = editor.editing.view.document;
 		const normalizers: Array<PasteFromOfficeNormalizer> = [];
-		const hasMultiLevelListPlugin = this.editor.plugins.has( 'MultiLevelList' );
-		const hasTablePropertiesPlugin = this.editor.plugins.has( 'TableProperties' );
+		const hasMultiLevelListPlugin = this.editor.plugins.has( 'MultiLevelListEditing' );
+		const hasTablePropertiesPlugin = this.editor.plugins.has( 'TablePropertiesEditing' );
 
 		normalizers.push(
 			new PasteFromOfficeMSWordNormalizer(

--- a/packages/ckeditor5-table/src/converters/downcast.ts
+++ b/packages/ckeditor5-table/src/converters/downcast.ts
@@ -320,7 +320,7 @@ export function downcastPlainTable(
 
 	const tableAttributes: ViewElementAttributes = { class: 'table' };
 
-	if ( editor.plugins.has( 'TableProperties' ) && conversionApi.options.isClipboardPipeline ) {
+	if ( editor.plugins.has( 'TablePropertiesEditing' ) && conversionApi.options.isClipboardPipeline ) {
 		const defaultTableProperties = getNormalizedDefaultTableProperties(
 			editor.config.get( 'table.tableProperties.defaultProperties' )!,
 			{

--- a/packages/ckeditor5-table/src/tableediting.ts
+++ b/packages/ckeditor5-table/src/tableediting.ts
@@ -260,7 +260,7 @@ export class TableEditing extends Plugin {
 		} );
 
 		// Make sure table <caption> is downcasted into <caption> in the data pipeline when necessary.
-		if ( editor.plugins.has( 'TableCaption' ) ) {
+		if ( editor.plugins.has( 'TableCaptionEditing' ) ) {
 			editor.conversion.for( 'dataDowncast' ).elementToElement( {
 				model: 'caption',
 				view: convertPlainTableCaption( editor ),
@@ -269,7 +269,7 @@ export class TableEditing extends Plugin {
 		}
 
 		// Handle border-style, border-color, border-width and background-color table attributes.
-		if ( editor.plugins.has( 'TableProperties' ) ) {
+		if ( editor.plugins.has( 'TablePropertiesEditing' ) ) {
 			downcastTableBorderAndBackgroundAttributes( editor );
 		}
 	}

--- a/packages/ckeditor5-table/tests/plaintableoutput.js
+++ b/packages/ckeditor5-table/tests/plaintableoutput.js
@@ -11,8 +11,8 @@ import { _setModelData } from '@ckeditor/ckeditor5-engine';
 import { Table } from '../src/table.js';
 import { PlainTableOutput } from '../src/plaintableoutput.js';
 import { modelTable } from './_utils/utils.js';
-import { TableCaption } from '../src/tablecaption.js';
-import { TableProperties } from '../src/tableproperties.js';
+import { TableCaptionEditing } from '../src/tablecaption/tablecaptionediting.js';
+import { TablePropertiesEditing } from '../src/tableproperties/tablepropertiesediting.js';
 
 describe( 'PlainTableOutput', () => {
 	let editor, editorElement, model;
@@ -22,7 +22,7 @@ describe( 'PlainTableOutput', () => {
 		document.body.appendChild( editorElement );
 
 		editor = await ClassicTestEditor.create( editorElement, {
-			plugins: [ Paragraph, Table, TableCaption, TableProperties, PlainTableOutput, ClipboardPipeline ]
+			plugins: [ Paragraph, Table, TableCaptionEditing, TablePropertiesEditing, PlainTableOutput, ClipboardPipeline ]
 		} );
 
 		model = editor.model;
@@ -438,7 +438,7 @@ describe( 'PlainTableOutput', () => {
 
 			it( 'should not convert image captions', async () => {
 				const testEditor = await ClassicTestEditor.create( editorElement, {
-					plugins: [ ArticlePluginSet, Table, TableCaption, PlainTableOutput, ClipboardPipeline ],
+					plugins: [ ArticlePluginSet, Table, TableCaptionEditing, PlainTableOutput, ClipboardPipeline ],
 					image: { toolbar: [ '|' ] }
 				} );
 
@@ -462,7 +462,7 @@ describe( 'PlainTableOutput', () => {
 			// See: https://github.com/ckeditor/ckeditor5/issues/11394
 			it( 'should allow overriding image caption converters', async () => {
 				const testEditor = await ClassicTestEditor.create( editorElement, {
-					plugins: [ ArticlePluginSet, Table, TableCaption, PlainTableOutput, ClipboardPipeline ],
+					plugins: [ ArticlePluginSet, Table, TableCaptionEditing, PlainTableOutput, ClipboardPipeline ],
 					image: { toolbar: [ '|' ] }
 				} );
 


### PR DESCRIPTION
### 🚀 Summary

Merge commit to `v48` for https://github.com/ckeditor/ckeditor5/pull/19524
