### PR TITLE
Add ability to pass `id` to `attachTourBalloon`.

### DIFF
--- a/docs/_snippets/shared-helpers.js
+++ b/docs/_snippets/shared-helpers.js
@@ -29,7 +29,7 @@
  * @param {String} options.text The description to be shown in the tooltip.
  * @param {module:core/editor/editor~Editor} options.editor The editor instance.
  */
-export function attachTourBalloon( { target, text, editor, tippyOptions } ) {
+export function attachTourBalloon( { id, target, text, editor, tippyOptions } ) {
 	if ( !target ) {
 		console.warn( '[attachTourBalloon] The target DOM node for the feature tour balloon does not exist.', { text } );
 
@@ -43,6 +43,7 @@ export function attachTourBalloon( { target, text, editor, tippyOptions } ) {
 	}
 
 	const tooltip = window.umberto.Tooltip.create( {
+		id,
 		text,
 		trigger: target,
 		mode: 'click',


### PR DESCRIPTION
### 🚀 Summary

Add the ability to pass an `id` to `attachTourBalloon`. This will allow a custom `id` attribute to be assigned to an HTML tooltip element, making it easier to style.

---

### 📌 Related issues

* Caused by https://github.com/ckeditor/ckeditor5-commercial/issues/8944