### PR TITLE
No longer preserve `tableCellType` attribute after changing table type to layout.

### DIFF
--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.ts
@@ -382,6 +382,15 @@ function enableCellTypeProperty( editor: Editor ) {
 		isFormatting: true
 	} );
 
+	// Do not allow setting `tableCellType` in layout tables.
+	schema.addAttributeCheck( context => {
+		const nearestTable = Array.from( context ).reverse().find( item => item.name === 'table' );
+
+		if ( nearestTable?.getAttribute( 'tableType' ) === 'layout' ) {
+			return false;
+		}
+	}, 'tableCellType' );
+
 	// Upcast conversion for td/th elements.
 	conversion.for( 'upcast' ).add( dispatcher => {
 		dispatcher.on<UpcastElementEvent>( 'element:th', ( evt, data, conversionApi ) => {

--- a/packages/ckeditor5-table/src/tablelayout/tablelayoutui.ts
+++ b/packages/ckeditor5-table/src/tablelayout/tablelayoutui.ts
@@ -150,20 +150,25 @@ export class TableLayoutUI extends Plugin {
 	 * @inheritDoc
 	 */
 	public afterInit(): void {
-		const editor = this.editor;
+		const { editor } = this;
+		const { ui, plugins } = editor;
 
-		if ( !editor.plugins.has( 'TablePropertiesUI' ) ) {
+		let tablePropertiesUI: any;
+
+		if ( plugins.has( 'TablePropertiesUIExperimental' ) ) {
+			tablePropertiesUI = plugins.get( 'TablePropertiesUIExperimental' );
+		} else if ( plugins.has( 'TablePropertiesUI' ) ) {
+			tablePropertiesUI = plugins.get( 'TablePropertiesUI' );
+		} else {
 			return;
 		}
-
-		const tablePropertiesUI = editor.plugins.get( 'TablePropertiesUI' );
 
 		// Override the default table properties button to include the table type dropdown.
 		// It needs to be done in `afterInit()` to make sure that `tableProperties` button is
 		// registered after the initialization of the `TablePropertiesUI`. Otherwise, the
 		// button will be overridden by the default one if the `TablePropertiesUI` is
 		// initialized after the `TableLayoutUI`.
-		editor.ui.componentFactory.add( 'tableProperties', locale => {
+		ui.componentFactory.add( 'tableProperties', locale => {
 			const baseButton = tablePropertiesUI._createTablePropertiesButton();
 			const splitButtonView = new SplitButtonView( locale, baseButton );
 

--- a/packages/ckeditor5-table/tests/manual/tablecelltype.js
+++ b/packages/ckeditor5-table/tests/manual/tablecelltype.js
@@ -29,7 +29,9 @@ ClassicEditor
 			TableLayout
 		],
 		toolbar: [
-			'heading', '|', 'insertTable', '|', 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
+			'heading', '|',
+			'insertTable', 'insertTableLayout', '|',
+			'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
 		],
 		table: {
 			contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells', 'tableProperties', 'tableCellProperties' ],

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -1913,6 +1913,19 @@ describe( 'table cell properties', () => {
 				it( 'should register tableCellType attribute as a formatting attribute', () => {
 					expect( schema.getAttributeProperties( 'tableCellType' ).isFormatting ).to.be.true;
 				} );
+
+				it( 'should disallow tableCellType attribute in layout tables', () => {
+					model.change( writer => {
+						const table = writer.createElement( 'table', { tableType: 'layout' } );
+						const tableRow = writer.createElement( 'tableRow' );
+						const tableCell = writer.createElement( 'tableCell' );
+
+						writer.insert( tableRow, table );
+						writer.insert( tableCell, tableRow );
+
+						expect( schema.checkAttribute( tableCell, 'tableCellType' ) ).to.be.false;
+					} );
+				} );
 			} );
 
 			describe( 'upcast conversion', () => {

--- a/packages/ckeditor5-table/tests/tablelayout/commands/tabletypecommand.js
+++ b/packages/ckeditor5-table/tests/tablelayout/commands/tabletypecommand.js
@@ -11,6 +11,8 @@ import { TableEditing } from '../../../src/tableediting.js';
 import { TableCaptionEditing } from '../../../src/tablecaption/tablecaptionediting.js';
 import { TableLayoutEditing } from '../../../src/tablelayout/tablelayoutediting.js';
 import { TableTypeCommand } from '../../../src/tablelayout/commands/tabletypecommand.js';
+import { TableCellPropertiesEditing } from '../../../src/tablecellproperties/tablecellpropertiesediting.js';
+import { TableCellWidthEditing } from '../../../src/tablecellwidth/tablecellwidthediting.js';
 
 import { modelTable } from '../../_utils/utils.js';
 
@@ -341,6 +343,62 @@ describe( 'TableTypeCommand', () => {
 				'<table tableType="layout">' +
 					'<tableRow><tableCell><paragraph>1</paragraph></tableCell></tableRow>' +
 				'</table>'
+			);
+		} );
+	} );
+
+	describe( 'integration with TableCellPropertiesEditing', () => {
+		let editor, model, command;
+
+		beforeEach( async () => {
+			editor = await ModelTestEditor.create( {
+				plugins: [
+					Paragraph,
+					TableEditing,
+					TableCaptionEditing,
+					TableLayoutEditing,
+					TableCellPropertiesEditing,
+					TableCellWidthEditing
+				],
+				experimentalFlags: {
+					tableCellTypeSupport: true
+				}
+			} );
+
+			model = editor.model;
+			command = new TableTypeCommand( editor );
+		} );
+
+		afterEach( () => {
+			return editor.destroy();
+		} );
+
+		it( 'should remove tableCellType attribute from cells when changing table type to layout', () => {
+			editor.setData(
+				'<table class="table content-table">' +
+					'<thead>' +
+						'<tr><th>1</th></tr>' +
+					'</thead>' +
+					'<tbody>' +
+						'<tr><td>2</td></tr>' +
+					'</tbody>' +
+				'</table>'
+			);
+
+			expect( _getModelData( model, { withoutSelection: true } ) ).to.equal(
+				modelTable( [
+					[ { contents: '1', tableCellType: 'header' } ],
+					[ '2' ]
+				], { tableType: 'content', headingRows: 1 } )
+			);
+
+			command.execute( 'layout' );
+
+			expect( _getModelData( model, { withoutSelection: true } ) ).to.equal(
+				modelTable( [
+					[ '1' ],
+					[ '2' ]
+				], { tableType: 'layout' } )
 			);
 		} );
 	} );

--- a/packages/ckeditor5-table/tests/tablelayout/tablelayoutui.js
+++ b/packages/ckeditor5-table/tests/tablelayout/tablelayoutui.js
@@ -14,6 +14,7 @@ import { TableLayoutEditing } from '../../src/tablelayout/tablelayoutediting.js'
 import { InsertTableView } from '../../src/ui/inserttableview.js';
 import { IconTableLayout, IconTableProperties } from '@ckeditor/ckeditor5-icons';
 import { TableProperties } from '../../src/tableproperties.js';
+import { TablePropertiesUIExperimental } from '../../src/tableproperties/tablepropertiesuiexperimental.js';
 import { TableTypeCommand } from '../../src/tablelayout/commands/tabletypecommand.js';
 import { TableUI } from '../../src/tableui.js';
 
@@ -309,6 +310,40 @@ describe( 'TableLayoutUI', () => {
 			const dropdown = editor.ui.componentFactory.has( 'tableProperties' );
 
 			expect( dropdown ).to.be.false;
+		} );
+	} );
+
+	describe( 'tableProperties dropdown extending (experimental)', () => {
+		let tablePropertiesDropdown;
+
+		beforeEach( async () => {
+			await editor.destroy();
+
+			editor = await ClassicTestEditor.create( element, {
+				plugins: [ TableProperties, TablePropertiesUIExperimental, TableEditing, TableLayoutUI, TableLayoutEditing, TableUI ]
+			} );
+
+			const command = new TableTypeCommand( editor );
+			sinon.spy( command, 'execute' );
+			editor.commands.add( 'tableType', command );
+
+			tablePropertiesDropdown = editor.ui.componentFactory.create( 'tableProperties' );
+			tablePropertiesDropdown.render();
+
+			document.body.appendChild( tablePropertiesDropdown.element );
+
+			tablePropertiesDropdown.isOpen = true;
+		} );
+
+		afterEach( () => {
+			tablePropertiesDropdown?.element.remove();
+
+			return editor.destroy();
+		} );
+
+		it( 'should register tableProperties dropdown with a split button', () => {
+			expect( tablePropertiesDropdown.buttonView ).to.be.instanceOf( SplitButtonView );
+			expect( tablePropertiesDropdown.buttonView.tooltip ).to.equal( 'Choose table type' );
 		} );
 	} );
 


### PR DESCRIPTION
### 🚀 Summary

No longer preserve `tableCellType` attribute after changing table type to layout.


### 📌 Related issues

* Closes #19553 

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [x] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [x] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [x] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [x] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
