### PR TITLE
Backport table cell type schema fixes to `v48`. 

### DIFF
--- a/packages/ckeditor5-table/src/tablelayout/tablelayoutui.ts
+++ b/packages/ckeditor5-table/src/tablelayout/tablelayoutui.ts
@@ -153,15 +153,11 @@ export class TableLayoutUI extends Plugin {
 		const { editor } = this;
 		const { ui, plugins } = editor;
 
-		let tablePropertiesUI: any;
-
-		if ( plugins.has( 'TablePropertiesUIExperimental' ) ) {
-			tablePropertiesUI = plugins.get( 'TablePropertiesUIExperimental' );
-		} else if ( plugins.has( 'TablePropertiesUI' ) ) {
-			tablePropertiesUI = plugins.get( 'TablePropertiesUI' );
-		} else {
+		if ( !editor.plugins.has( 'TablePropertiesUI' ) ) {
 			return;
 		}
+
+		const tablePropertiesUI = plugins.get( 'TablePropertiesUI' );
 
 		// Override the default table properties button to include the table type dropdown.
 		// It needs to be done in `afterInit()` to make sure that `tableProperties` button is

--- a/packages/ckeditor5-table/tests/tablelayout/tablelayoutui.js
+++ b/packages/ckeditor5-table/tests/tablelayout/tablelayoutui.js
@@ -14,7 +14,6 @@ import { TableLayoutEditing } from '../../src/tablelayout/tablelayoutediting.js'
 import { InsertTableView } from '../../src/ui/inserttableview.js';
 import { IconTableLayout, IconTableProperties } from '@ckeditor/ckeditor5-icons';
 import { TableProperties } from '../../src/tableproperties.js';
-import { TablePropertiesUIExperimental } from '../../src/tableproperties/tablepropertiesuiexperimental.js';
 import { TableTypeCommand } from '../../src/tablelayout/commands/tabletypecommand.js';
 import { TableUI } from '../../src/tableui.js';
 
@@ -310,40 +309,6 @@ describe( 'TableLayoutUI', () => {
 			const dropdown = editor.ui.componentFactory.has( 'tableProperties' );
 
 			expect( dropdown ).to.be.false;
-		} );
-	} );
-
-	describe( 'tableProperties dropdown extending (experimental)', () => {
-		let tablePropertiesDropdown;
-
-		beforeEach( async () => {
-			await editor.destroy();
-
-			editor = await ClassicTestEditor.create( element, {
-				plugins: [ TableProperties, TablePropertiesUIExperimental, TableEditing, TableLayoutUI, TableLayoutEditing, TableUI ]
-			} );
-
-			const command = new TableTypeCommand( editor );
-			sinon.spy( command, 'execute' );
-			editor.commands.add( 'tableType', command );
-
-			tablePropertiesDropdown = editor.ui.componentFactory.create( 'tableProperties' );
-			tablePropertiesDropdown.render();
-
-			document.body.appendChild( tablePropertiesDropdown.element );
-
-			tablePropertiesDropdown.isOpen = true;
-		} );
-
-		afterEach( () => {
-			tablePropertiesDropdown?.element.remove();
-
-			return editor.destroy();
-		} );
-
-		it( 'should register tableProperties dropdown with a split button', () => {
-			expect( tablePropertiesDropdown.buttonView ).to.be.instanceOf( SplitButtonView );
-			expect( tablePropertiesDropdown.buttonView.tooltip ).to.equal( 'Choose table type' );
 		} );
 	} );
 


### PR DESCRIPTION
### 🚀 Summary

Backport of https://github.com/ckeditor/ckeditor5/pull/19554/changes

---

### 📌 Related issues

* Caused by #19553 

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [ ] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
