### PR TITLE
Backport image styles changes to CKEditor v48

### DIFF
--- a/.changelog/20251230094930_ck_19521.md
+++ b/.changelog/20251230094930_ck_19521.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-image
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/19521
+---
+
+The editor and its UI now recognize the CSS `float` style on images (e.g. `style="float: left"` or `style="float: right"`) and map it to left/right image alignment. This applies to both inline and block images. If custom image styles are configured then the `float` style is ignored.

--- a/packages/ckeditor5-image/src/imagestyle/converters.ts
+++ b/packages/ckeditor5-image/src/imagestyle/converters.ts
@@ -3,9 +3,18 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import type { DowncastAttributeEvent, ModelElement, UpcastElementEvent } from 'ckeditor5/src/engine.js';
+import isEqual from 'es-toolkit/compat/isEqual';
+import type {
+	DowncastAttributeEvent,
+	ModelElement,
+	ModelItem,
+	UpcastConversionApi,
+	UpcastElementEvent,
+	ViewElement
+} from 'ckeditor5/src/engine.js';
 import { first, type GetCallback } from 'ckeditor5/src/utils.js';
 import type { ImageStyleOptionDefinition } from '../imageconfig.js';
+import { DEFAULT_OPTIONS } from './utils.js';
 
 /**
  * @module image/imagestyle/converters
@@ -82,7 +91,59 @@ export function viewToModelStyleAttribute( styles: Array<ImageStyleOptionDefinit
 				conversionApi.writer.setAttribute( 'imageStyle', style.name, modelImageElement );
 			}
 		}
+
+		// Normalize float styles (alignLeft, alignBlockLeft, alignRight, alignBlockRight).
+		normalizeFloatToDefinitionStyle( conversionApi, viewElement, modelImageElement, styles );
 	};
+}
+
+/**
+ * A helper function that attempts to convert the `float` CSS style into a corresponding `imageStyle` attribute.
+ *
+ * It maps `float: left` and `float: right` to standard alignment styles (e.g. `'alignLeft'`, `'alignBlockRight'`),
+ * but only if the target style definition matches one of the {@link module:image/image/utils~DEFAULT_OPTIONS default options}.
+ */
+function normalizeFloatToDefinitionStyle(
+	conversionApi: UpcastConversionApi,
+	viewElement: ViewElement,
+	modelElement: ModelItem,
+	styles: Array<ImageStyleOptionDefinition>
+) {
+	if ( !conversionApi.consumable.test( viewElement, { styles: [ 'float' ] } ) ) {
+		return;
+	}
+
+	let floatStyleName: string | null = null;
+	const blockStylePrefix = modelElement.is( 'element', 'imageBlock' ) ? 'Block' : '';
+
+	switch ( viewElement.getStyle( 'float' ) ) {
+		case 'left':
+			floatStyleName = `align${ blockStylePrefix }Left`;
+			break;
+
+		case 'right':
+			floatStyleName = `align${ blockStylePrefix }Right`;
+			break;
+	}
+
+	if ( !floatStyleName ) {
+		return;
+	}
+
+	const definition = getStyleDefinitionByName( floatStyleName, styles );
+
+	if ( !definition ) {
+		return;
+	}
+
+	const builtinDefinition = DEFAULT_OPTIONS[ definition.name ];
+
+	if ( !isEqual( definition, builtinDefinition ) ) {
+		return;
+	}
+
+	conversionApi.writer.setAttribute( 'imageStyle', floatStyleName, modelElement );
+	conversionApi.consumable.consume( viewElement, { styles: [ 'float' ] } );
 }
 
 /**

--- a/packages/ckeditor5-image/tests/manual/imagestyle.html
+++ b/packages/ckeditor5-image/tests/manual/imagestyle.html
@@ -4,9 +4,17 @@
 	<figure class="image">
 		<img src="sample.jpg" alt="" />
 	</figure>
+
 	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. </p>
 	<p></p>
 	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor<img src="100px-Run.svg.png" alt="Example image" style="width: 20px;"> in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+	<p>Image alignment:</p>
+	<p>
+		<img alt="Right align" src="game_boy.jpg" style="float:right; height:75px; width:75px" />
+		Curabitur consectetur lectus sit amet tellus mattis, non lobortis leo interdum.
+		<img alt="Left align" src="game_boy.jpg" style="float:left; height:75px; width:75px" />
+		Fusce euismod, urna eu tincidunt consectetur, nisi nisl lacinia mi,
+	</p>
 </div>
 
 <h2>Formatting–oriented images</h2>
@@ -18,6 +26,16 @@
 	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. </p>
 	<p></p>
 	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor<img class="image-style-align-left" src="100px-Run.svg.png" alt="Example image" style="width: 20px;"> in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+	<p>Image alignment:</p>
+	<figure class="image" style="float: right">
+		<img src="sample.jpg" alt="Right aligned block image" />
+	</figure>
+	<p>
+		<img alt="Right align" src="game_boy.jpg" style="float:right; height:75px; width:75px" />
+		Curabitur consectetur lectus sit amet tellus mattis, non lobortis leo interdum.
+		<img alt="Left align" src="game_boy.jpg" style="float:left; height:75px; width:75px" />
+		Fusce euismod, urna eu tincidunt consectetur, nisi nisl lacinia mi,
+	</p>
 </div>
 
 <h2>Declarative drop-downs</h2>
@@ -29,4 +47,14 @@
 	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. </p>
 	<p></p>
 	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor<img class="image-style-align-left" src="100px-Run.svg.png" alt="Example image" style="width: 20px;"> in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+	<p>Image alignment:</p>
+	<figure class="image" style="float: right">
+		<img src="sample.jpg" alt="Right aligned block image" />
+	</figure>
+	<p>
+		<img alt="Right align" src="game_boy.jpg" style="float:right; height:75px; width:75px" />
+		Curabitur consectetur lectus sit amet tellus mattis, non lobortis leo interdum.
+		<img alt="Left align" src="game_boy.jpg" style="float:left; height:75px; width:75px" />
+		Fusce euismod, urna eu tincidunt consectetur, nisi nisl lacinia mi,
+	</p>
 </div>


### PR DESCRIPTION
### 🚀 Summary

Backport image styles changes to CKEditor v48

---

### 📌 Related issues

* Caused by https://github.com/ckeditor/ckeditor5/pull/19561

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [x] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
