### PR TITLE
Bring back the MathType demo in a manual test

### DIFF
--- a/packages/ckeditor5/package.json
+++ b/packages/ckeditor5/package.json
@@ -109,6 +109,9 @@
     "@ckeditor/ckeditor5-widget": "workspace:*",
     "@ckeditor/ckeditor5-word-count": "workspace:*"
   },
+  "devDependencies": {
+    "@wiris/mathtype-ckeditor5": "^8.13.1"
+  },
   "scripts": {
     "build": "node ../../scripts/nim/build-ckeditor5.mjs"
   },

--- a/packages/ckeditor5/tests/manual/mathtype.js
+++ b/packages/ckeditor5/tests/manual/mathtype.js
@@ -17,8 +17,7 @@ import { RemoveFormat } from '@ckeditor/ckeditor5-remove-format';
 import { ImageUpload } from '@ckeditor/ckeditor5-image';
 import { CloudServices } from '@ckeditor/ckeditor5-cloud-services';
 
-// TODO: https://github.com/ckeditor/ckeditor5-commercial/issues/9079.
-// import MathType from '@wiris/mathtype-ckeditor5';
+import MathType from '@wiris/mathtype-ckeditor5/dist/index.js';
 
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config.js';
 
@@ -41,9 +40,8 @@ ClassicEditor
 			Indent,
 			Mention,
 			PasteFromOffice,
-			RemoveFormat
-			// TODO: https://github.com/ckeditor/ckeditor5-commercial/issues/9079.
-			// MathType
+			RemoveFormat,
+			MathType
 		],
 		toolbar: [
 			'MathType', 'ChemType', '|', 'heading', 'fontFamily', 'fontSize', 'fontColor', 'fontBackgroundColor',

--- a/packages/ckeditor5/tests/manual/memory/memory-semi-automated.js
+++ b/packages/ckeditor5/tests/manual/memory/memory-semi-automated.js
@@ -32,7 +32,7 @@ import { TextTransformation } from '@ckeditor/ckeditor5-typing';
 import { TextPartLanguage } from '@ckeditor/ckeditor5-language';
 import { WordCount } from '@ckeditor/ckeditor5-word-count';
 import { CloudServices } from '@ckeditor/ckeditor5-cloud-services';
-// import { MathType } from '@wiris/mathtype-ckeditor5';
+// import { MathType } from '@wiris/mathtype-ckeditor5/dist/index.js';
 
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config.js';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,6 +367,10 @@ importers:
       '@ckeditor/ckeditor5-word-count':
         specifier: workspace:*
         version: link:../ckeditor5-word-count
+    devDependencies:
+      '@wiris/mathtype-ckeditor5':
+        specifier: ^8.13.1
+        version: 8.14.0(ckeditor5@packages+ckeditor5)
 
   packages/ckeditor5-adapter-ckfinder:
     dependencies:


### PR DESCRIPTION
### 🚀 Summary

> [!CAUTION]
> This PR targets the `#ci/4233-exports` branch as changes from this branch are needed to enable this PR.

- This PR restores the `MathType` integration in a manual test.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-internal/issues/4232.

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [ ] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
