### PR TITLE
Upgrade Chrome version to `144.0.7559.59`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ parameters:
     default: false
   chromeVersion:
     type: string
-    default: "143.0.7499.109"
+    default: "144.0.7559.59"
 
 orbs:
   continuation: circleci/continuation@0.1.2


### PR DESCRIPTION
### 🚀 Summary

This PR bumps the Chrome used in CI to **144.0.7559.59**.

---

### 📃 Additional information

- Generated automatically by the Chrome bump workflow.
- Triggered because a new Chrome stable version was detected.
