### PR TITLE
Use the `${configDir}` template variable in TypeScript to reduce redundancy.

### DIFF
--- a/packages/ckeditor5-adapter-ckfinder/tsconfig.json
+++ b/packages/ckeditor5-adapter-ckfinder/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-alignment/tsconfig.json
+++ b/packages/ckeditor5-alignment/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-autoformat/tsconfig.json
+++ b/packages/ckeditor5-autoformat/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-autosave/tsconfig.json
+++ b/packages/ckeditor5-autosave/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-basic-styles/tsconfig.json
+++ b/packages/ckeditor5-basic-styles/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-block-quote/tsconfig.json
+++ b/packages/ckeditor5-block-quote/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-bookmark/tsconfig.json
+++ b/packages/ckeditor5-bookmark/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-ckbox/tsconfig.json
+++ b/packages/ckeditor5-ckbox/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-ckfinder/tsconfig.json
+++ b/packages/ckeditor5-ckfinder/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-clipboard/tsconfig.json
+++ b/packages/ckeditor5-clipboard/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-cloud-services/tsconfig.json
+++ b/packages/ckeditor5-cloud-services/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-code-block/tsconfig.json
+++ b/packages/ckeditor5-code-block/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-core/tsconfig.json
+++ b/packages/ckeditor5-core/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-easy-image/tsconfig.json
+++ b/packages/ckeditor5-easy-image/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-editor-balloon/tsconfig.json
+++ b/packages/ckeditor5-editor-balloon/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-editor-classic/tsconfig.json
+++ b/packages/ckeditor5-editor-classic/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-editor-decoupled/tsconfig.json
+++ b/packages/ckeditor5-editor-decoupled/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-editor-inline/tsconfig.json
+++ b/packages/ckeditor5-editor-inline/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-editor-multi-root/tsconfig.json
+++ b/packages/ckeditor5-editor-multi-root/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-emoji/tsconfig.json
+++ b/packages/ckeditor5-emoji/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-engine/tsconfig.json
+++ b/packages/ckeditor5-engine/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-enter/tsconfig.json
+++ b/packages/ckeditor5-enter/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-essentials/tsconfig.json
+++ b/packages/ckeditor5-essentials/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-find-and-replace/tsconfig.json
+++ b/packages/ckeditor5-find-and-replace/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-font/tsconfig.json
+++ b/packages/ckeditor5-font/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-fullscreen/tsconfig.json
+++ b/packages/ckeditor5-fullscreen/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-heading/tsconfig.json
+++ b/packages/ckeditor5-heading/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-highlight/tsconfig.json
+++ b/packages/ckeditor5-highlight/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-horizontal-line/tsconfig.json
+++ b/packages/ckeditor5-horizontal-line/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-html-embed/tsconfig.json
+++ b/packages/ckeditor5-html-embed/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-html-support/tsconfig.json
+++ b/packages/ckeditor5-html-support/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-icons/tsconfig.json
+++ b/packages/ckeditor5-icons/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-image/tsconfig.json
+++ b/packages/ckeditor5-image/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-indent/tsconfig.json
+++ b/packages/ckeditor5-indent/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-language/tsconfig.json
+++ b/packages/ckeditor5-language/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-link/tsconfig.json
+++ b/packages/ckeditor5-link/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-list/tsconfig.json
+++ b/packages/ckeditor5-list/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-markdown-gfm/tsconfig.json
+++ b/packages/ckeditor5-markdown-gfm/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-media-embed/tsconfig.json
+++ b/packages/ckeditor5-media-embed/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-mention/tsconfig.json
+++ b/packages/ckeditor5-mention/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-minimap/tsconfig.json
+++ b/packages/ckeditor5-minimap/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-page-break/tsconfig.json
+++ b/packages/ckeditor5-page-break/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-paragraph/tsconfig.json
+++ b/packages/ckeditor5-paragraph/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-paste-from-office/tsconfig.json
+++ b/packages/ckeditor5-paste-from-office/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-remove-format/tsconfig.json
+++ b/packages/ckeditor5-remove-format/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-restricted-editing/tsconfig.json
+++ b/packages/ckeditor5-restricted-editing/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-select-all/tsconfig.json
+++ b/packages/ckeditor5-select-all/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-show-blocks/tsconfig.json
+++ b/packages/ckeditor5-show-blocks/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-source-editing/tsconfig.json
+++ b/packages/ckeditor5-source-editing/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-special-characters/tsconfig.json
+++ b/packages/ckeditor5-special-characters/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-style/tsconfig.json
+++ b/packages/ckeditor5-style/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-table/tsconfig.json
+++ b/packages/ckeditor5-table/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-typing/tsconfig.json
+++ b/packages/ckeditor5-typing/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-ui/tsconfig.json
+++ b/packages/ckeditor5-ui/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-undo/tsconfig.json
+++ b/packages/ckeditor5-undo/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-upload/tsconfig.json
+++ b/packages/ckeditor5-upload/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-utils/tsconfig.json
+++ b/packages/ckeditor5-utils/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-watchdog/tsconfig.json
+++ b/packages/ckeditor5-watchdog/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-widget/tsconfig.json
+++ b/packages/ckeditor5-widget/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5-word-count/tsconfig.json
+++ b/packages/ckeditor5-word-count/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/packages/ckeditor5/tsconfig.json
+++ b/packages/ckeditor5/tsconfig.json
@@ -1,12 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "./src",
-		"types": [
-			"../../typings/types"
-		]
-	},
-	"include": [
-		"src"
-	]
+	"extends": "../../tsconfig.packages.json"
 }

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": [
+      "${configDir}/../../typings/types"
+    ],
+    "rootDir": "${configDir}/src",
+  },
+  "include": [
+    "${configDir}/src"
+  ]
+}


### PR DESCRIPTION
### 🚀 Summary

Internal: Use the `${configDir}` template variable in TypeScript to reduce redundancy.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5/issues/19629.

---

### 💡 Additional information

N/A

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [ ] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
