### PR TITLE
Fix broken resizing of nested tables.

### DIFF
--- a/.changelog/20260115142632_ck_19609.md
+++ b/.changelog/20260115142632_ck_19609.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-table
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/19609
+---
+
+Fixed an issue where resizing columns in a nested table could break the parent table layout.

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -1799,6 +1799,57 @@ describe( 'TableColumnResizeEditing', () => {
 			} );
 
 			describe( 'nested table ', () => {
+				it( 'should produce correct column widths that sum up to 100% when resizing nested table', () => {
+					// Test-specific.
+					const columnToResizeIndex = 2;
+					const mouseMovementVector = { x: 20, y: 0 };
+
+					_setModelData( editor.model,
+						'<table tableWidth="100%">' +
+							'<tableRow>' +
+								'<tableCell>' +
+									'[<table tableWidth="30%">' +
+										'<tableRow>' +
+											'<tableCell>' +
+												'<paragraph>foo</paragraph>' +
+											'</tableCell>' +
+											'<tableCell>' +
+												'<paragraph>bar</paragraph>' +
+											'</tableCell>' +
+											'<tableCell>' +
+												'<paragraph>baz</paragraph>' +
+											'</tableCell>' +
+										'</tableRow>' +
+										'<tableColumnGroup>' +
+											'<tableColumn columnWidth="25%"></tableColumn>' +
+											'<tableColumn columnWidth="25%"></tableColumn>' +
+											'<tableColumn columnWidth="50%"></tableColumn>' +
+										'</tableColumnGroup>' +
+									'</table>]' +
+								'</tableCell>' +
+							'</tableRow>' +
+							'<tableColumnGroup>' +
+								'<tableColumn columnWidth="100%"></tableColumn>' +
+							'</tableColumnGroup>' +
+						'</table>'
+					);
+
+					const domNestedTable = getDomTable( view ).querySelectorAll( 'table' )[ 1 ];
+					const viewNestedTable = view.document.selection.getSelectedElement().getChild( 1 );
+
+					setInitialWidthsInPx( editor, viewNestedTable, null, 800 );
+
+					const domResizer = getDomResizer( domNestedTable, columnToResizeIndex, 0 );
+
+					tableColumnResizeMouseSimulator.down( editor, domResizer, {} );
+					tableColumnResizeMouseSimulator.move( editor, domResizer, mouseMovementVector );
+
+					const finalViewColumnWidthsPc = getViewColumnWidthsPc( viewNestedTable );
+					const widthsSum = finalViewColumnWidthsPc.reduce( ( sum, width ) => sum + Number.parseInt( width, 10 ), 0 );
+
+					expect( widthsSum ).to.be.closeTo( 100, 1 );
+				} );
+
 				it( 'correctly shrinks when the last column is dragged to the left', () => {
 					// Test-specific.
 					const columnToResizeIndex = 1;

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -56,7 +56,7 @@ import { Rect } from '@ckeditor/ckeditor5-utils';
 describe( 'TableColumnResizeEditing', () => {
 	let model, editor, view, editorElement, contentDirection, resizePlugin;
 	const PERCENTAGE_PRECISION = 0.001;
-	const PIXEL_PRECISION = 1;
+	const PIXEL_PRECISION = 6;
 
 	beforeEach( async () => {
 		editorElement = document.createElement( 'div' );
@@ -1963,8 +1963,8 @@ describe( 'TableColumnResizeEditing', () => {
 												'</tableCell>' +
 											'</tableRow>' +
 											'<tableColumnGroup>' +
-												'<tableColumn columnWidth="45\\.45%"></tableColumn>' +
-												'<tableColumn columnWidth="54\\.55%"></tableColumn>' +
+												'<tableColumn columnWidth="45\\.[\\d]+%"></tableColumn>' +
+												'<tableColumn columnWidth="54\\.[\\d]+%"></tableColumn>' +
 											'</tableColumnGroup>' +
 										'</table>' +
 									'</tableCell>' +

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -12,10 +12,6 @@
 	--ck-table-column-resizer-position-offset: calc(var(--ck-table-column-resizer-width) * -0.5 - 0.5px);
 }
 
-.ck-content .table .ck-table-resized {
-	table-layout: fixed;
-}
-
 .ck-content .table td,
 .ck-content .table th {
 	/* To prevent text overflowing beyond its cell when columns are resized by resize handler


### PR DESCRIPTION
### 🚀 Summary

Fix broken resizing of nested tables.

---

### 📌 Related issues

* Closes #19609 

---

### 💡 Additional information

The issue was resolved by updating the column width calculation logic. We ensured that the total sum of widths generated for the `colgroup` elements never exceeds 100%.

Previously, the `table-layout: fixed` nested table allowed column widths to accumulate beyond 100%, which forced the non-fixed parent table to expand and fill the entire editable area ("pushing" the parent). By strictly capping the cumulative col width calculation at 100%, the nested table remains contained within its parent, preventing the unwanted expansion behavior during resize.

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [x] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [x] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
