### PR TITLE
Fix GPL URL in the `ckeditor5-emoji` package

### DIFF
--- a/packages/ckeditor5-emoji/LICENSE.md
+++ b/packages/ckeditor5-emoji/LICENSE.md
@@ -6,7 +6,7 @@ Copyright (c) 2003–2026, [CKSource Holding sp. z o.o.](https://cksource.com) A
 
 Licensed under a dual-license model, this software is available under:
 
-* the [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html),
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
 * or commercial license terms from CKSource Holding sp. z o.o.
 
 For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-emoji/README.md
+++ b/packages/ckeditor5-emoji/README.md
@@ -31,7 +31,7 @@ See the [`@ckeditor/ckeditor5-emoji` package](https://ckeditor.com/docs/ckeditor
 
 Licensed under a dual-license model, this software is available under:
 
-* the [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html),
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
 * or commercial license terms from CKSource Holding sp. z o.o.
 
 For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).


### PR DESCRIPTION
### 🚀 Summary

Internal change, before this PR, there was an invalid URL (`http` instead of `https`).