### PR TITLE
Fixed parsing units of deprecated table width attribute.

### DIFF
--- a/.changelog/20260123163001_ck_19665.md
+++ b/.changelog/20260123163001_ck_19665.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-table
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/19665
+---
+
+Fixed parsing units of deprecated table width attribute.

--- a/packages/ckeditor5-table/src/converters/tableproperties.ts
+++ b/packages/ckeditor5-table/src/converters/tableproperties.ts
@@ -112,8 +112,8 @@ export function upcastStyleToAttribute(
 					const localDefaultValue = getDefaultValueAdjusted( defaultValue, '', data );
 					let value = viewElement.getAttribute( attributeName );
 
-					if ( value && attributeType == 'length' && !value.endsWith( 'px' ) ) {
-						value += 'px';
+					if ( value && attributeType == 'length' ) {
+						value = parseFloat( value ) + ( value.endsWith( '%' ) ? '%' : 'px' );
 					}
 
 					if ( localDefaultValue !== value ) {

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -1437,6 +1437,35 @@ describe( 'table cell properties', () => {
 					expect( tableCell.getAttribute( 'tableCellHeight' ) ).to.equal( '20px' );
 				} );
 
+				it( 'should upcast height attribute on table cell', () => {
+					editor.setData( '<table><tr><td height="100.5">foo</td></tr></table>' );
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					expect( tableCell.getAttribute( 'tableCellHeight' ) ).to.equal( '100.5px' );
+				} );
+
+				it( 'should upcast height (px) attribute on table cell', () => {
+					editor.setData( '<table><tr><td height="100.5px">foo</td></tr></table>' );
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					expect( tableCell.getAttribute( 'tableCellHeight' ) ).to.equal( '100.5px' );
+				} );
+
+				it( 'should upcast height (%) attribute on table cell', () => {
+					editor.setData( '<table><tr><td height="100.5%">foo</td></tr></table>' );
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					expect( tableCell.getAttribute( 'tableCellHeight' ) ).to.equal( '100.5%' );
+				} );
+
+				it( 'should upcast height (em) attribute on table cell', () => {
+					editor.setData( '<table><tr><td height="100.5em">foo</td></tr></table>' );
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					// Normalize to px as other units are not supported by browsers.
+					expect( tableCell.getAttribute( 'tableCellHeight' ) ).to.equal( '100.5px' );
+				} );
+
 				it( 'should consume height style even if it is default', async () => {
 					const editor = await VirtualTestEditor.create( {
 						plugins: [ TableCellPropertiesEditing, Paragraph, TableEditing ],

--- a/packages/ckeditor5-table/tests/tablecellwidth/tablecellwidthediting.js
+++ b/packages/ckeditor5-table/tests/tablecellwidth/tablecellwidthediting.js
@@ -66,6 +66,35 @@ describe( 'TableCellWidthEditing', () => {
 				expect( tableCell.getAttribute( 'tableCellWidth' ) ).to.equal( '20px' );
 			} );
 
+			it( 'should upcast width attribute on table cell', () => {
+				editor.setData( '<table><tr><td width="50.5">foo</td></tr></table>' );
+				const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+				expect( tableCell.getAttribute( 'tableCellWidth' ) ).to.equal( '50.5px' );
+			} );
+
+			it( 'should upcast width (px) attribute on table cell', () => {
+				editor.setData( '<table><tr><td width="50.5px">foo</td></tr></table>' );
+				const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+				expect( tableCell.getAttribute( 'tableCellWidth' ) ).to.equal( '50.5px' );
+			} );
+
+			it( 'should upcast width (%) attribute on table cell', () => {
+				editor.setData( '<table><tr><td width="50.5%">foo</td></tr></table>' );
+				const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+				expect( tableCell.getAttribute( 'tableCellWidth' ) ).to.equal( '50.5%' );
+			} );
+
+			it( 'should upcast width (em) attribute on table cell', () => {
+				editor.setData( '<table><tr><td width="50.5em">foo</td></tr></table>' );
+				const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+				// Normalize to px as other units are not supported by browsers.
+				expect( tableCell.getAttribute( 'tableCellWidth' ) ).to.equal( '50.5px' );
+			} );
+
 			// #12426
 			it( 'should upcast correct width attribute values on multiple table cells', () => {
 				editor.setData(

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -1278,10 +1278,32 @@ describe( 'table properties', () => {
 				} );
 
 				it( 'should upcast width attribute from <table>', () => {
-					editor.setData( '<table width="1337"><tr><td>foo</td></tr></table>' );
+					editor.setData( '<table width="1337.3"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'tableWidth' ) ).to.equal( '1337px' );
+					expect( table.getAttribute( 'tableWidth' ) ).to.equal( '1337.3px' );
+				} );
+
+				it( 'should upcast width (px) attribute from <table>', () => {
+					editor.setData( '<table width="1337.3px"><tr><td>foo</td></tr></table>' );
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableWidth' ) ).to.equal( '1337.3px' );
+				} );
+
+				it( 'should upcast width (%) attribute from <table>', () => {
+					editor.setData( '<table width="37.3%"><tr><td>foo</td></tr></table>' );
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableWidth' ) ).to.equal( '37.3%' );
+				} );
+
+				it( 'should upcast width (em) attribute from <table>', () => {
+					editor.setData( '<table width="1337.3em"><tr><td>foo</td></tr></table>' );
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					// Normalize to px as other units are not supported by browsers.
+					expect( table.getAttribute( 'tableWidth' ) ).to.equal( '1337.3px' );
 				} );
 
 				it( 'should upcast width from style not <table> attribute', () => {
@@ -1477,10 +1499,32 @@ describe( 'table properties', () => {
 				} );
 
 				it( 'should upcast height attribute from <table>', () => {
-					editor.setData( '<table height="1337"><tr><td>foo</td></tr></table>' );
+					editor.setData( '<table height="1337.3"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'tableHeight' ) ).to.equal( '1337px' );
+					expect( table.getAttribute( 'tableHeight' ) ).to.equal( '1337.3px' );
+				} );
+
+				it( 'should upcast height (px) attribute from <table>', () => {
+					editor.setData( '<table height="1337.3px"><tr><td>foo</td></tr></table>' );
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableHeight' ) ).to.equal( '1337.3px' );
+				} );
+
+				it( 'should upcast height (%) attribute from <table>', () => {
+					editor.setData( '<table height="1337.3%"><tr><td>foo</td></tr></table>' );
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableHeight' ) ).to.equal( '1337.3%' );
+				} );
+
+				it( 'should upcast height (em) attribute from <table>', () => {
+					editor.setData( '<table height="1337.3em"><tr><td>foo</td></tr></table>' );
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					// Normalize to px as other units are not supported by browsers.
+					expect( table.getAttribute( 'tableHeight' ) ).to.equal( '1337.3px' );
 				} );
 
 				it( 'should upcast height from style not <table> attribute', () => {


### PR DESCRIPTION
### 🚀 Summary

Fixed parsing units of the deprecated table width attribute.

---

### 📌 Related issues

* Closes #19665

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [x] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
