### PR TITLE
Docs: Add `scripts/synchronize-translations.js` to `package-generator` outputs.

### DIFF
--- a/docs/framework/development-tools/package-generator/javascript-package.md
+++ b/docs/framework/development-tools/package-generator/javascript-package.md
@@ -22,7 +22,7 @@ An overview of the project's directory structure:
 │  ├─ index.html                   # The HTML file for the development sample.
 │  └─ index.js                     # Editor setup used when running the `start` command.
 ├─ scripts
-│  ├─ synchronize-translations.js  # Validates and synchronizes translation files.
+│  └─ synchronize-translations.js  # Validates and synchronizes translation files.
 ├─ src
 │  ├─ pluginname.js                # The plugin with example functionality.
 │  ├─ index.js                     # The modules exported by the package.

--- a/docs/framework/development-tools/package-generator/typescript-package.md
+++ b/docs/framework/development-tools/package-generator/typescript-package.md
@@ -22,7 +22,7 @@ An overview of the project's directory structure:
 │  ├─ index.html                   # The HTML file for the development sample.
 │  └─ index.ts                     # Editor setup used when running the `start` command.
 ├─ scripts
-│  ├─ synchronize-translations.js  # Validates and synchronizes translation files.
+│  └─ synchronize-translations.js  # Validates and synchronizes translation files.
 ├─ src
 │  ├─ pluginname.ts                # The plugin with example functionality.
 │  ├─ augmentation.ts              # Type augmentations for the `@ckeditor/ckeditor5-core` package.


### PR DESCRIPTION
### 🚀 Summary

Docs: Add `scripts/synchronize-translations.js` to `package-generator` outputs.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5-package-generator/issues/295.

---

### 💡 Additional information

N/A

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [ ] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
