### PR TITLE
Tooltips in API docs should show the path to a publicly available import.

### DIFF
--- a/scripts/docs/getrealimportpath.mjs
+++ b/scripts/docs/getrealimportpath.mjs
@@ -4,7 +4,7 @@
  */
 
 export default function getRealImportPath( modulePath ) {
-	const moduleName = modulePath.split( '/' )[ 0 ];
+	const shortPackageName = modulePath.split( '/' )[ 0 ];
 
-	return moduleName ? `@ckeditor/ckeditor5-${ moduleName }` : modulePath;
+	return shortPackageName ? `@ckeditor/ckeditor5-${ shortPackageName }` : modulePath;
 }


### PR DESCRIPTION
### 🚀 Summary

Tooltips in API docs should show the path to a publicly available import.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-internal/issues/4249.

---

### 💡 Additional information

N/A

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [ ] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
