### PR TITLE
Fix wrong upcast of `border="0"` attribute if cell has non-default attributes.

### DIFF
--- a/packages/ckeditor5-table/src/converters/tableproperties.ts
+++ b/packages/ckeditor5-table/src/converters/tableproperties.ts
@@ -259,8 +259,11 @@ export function upcastBorderStyles(
 
 				const modelElement = modelRange?.start?.nodeAfter;
 
-				// If model element has already border style attribute, skip the conversion.
-				if ( !modelElement || modelElement.hasAttribute( modelAttributes.style ) ) {
+				// If model element has any non-default border attribute, skip the conversion.
+				if (
+					!modelElement ||
+					Object.values( modelAttributes ).some( attributeName => modelElement.hasAttribute( attributeName ) )
+				) {
 					return;
 				}
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -330,7 +330,24 @@ describe( 'table cell properties', () => {
 						);
 
 						const cell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
 						expect( cell.getAttribute( 'tableCellBorderStyle' ) ).to.equal( 'dashed' );
+					} );
+
+					it( 'should not override table cell custom border color and width', () => {
+						editor.setData(
+							'<table border="0">' +
+								'<tr>' +
+									'<td style="border: 2px solid #f00;">foo</td>' +
+								'</tr>' +
+							'</table>'
+						);
+
+						const cell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+						expect( cell.getAttribute( 'tableCellBorderColor' ) ).to.equal( '#f00' );
+						expect( cell.getAttribute( 'tableCellBorderWidth' ) ).to.equal( '2px' );
+						expect( cell.hasAttribute( 'tableCellBorderStyle' ) ).to.be.false;
 					} );
 				} );
 			} );

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -679,6 +679,31 @@ describe( 'table properties', () => {
 						);
 					} );
 
+					it( 'should not override existing tableBorderStyle if there is also ' +
+							'border-color and border-width defined on the table', () => {
+						editor.setData(
+							'<table border="0" style="border-style: solid; border-color: #f00; border-width: 2px;">' +
+							'<tr>' +
+								'<td>foo</td>' +
+							'</tr>' +
+						'</table>'
+						);
+
+						expectModel(
+							'<table ' +
+								'tableBorderColor="#f00" ' +
+								'tableBorderStyle="solid" ' +
+								'tableBorderWidth="2px"' +
+							'>' +
+								'<tableRow>' +
+									'<tableCell>' +
+										'<paragraph>foo</paragraph>' +
+									'</tableCell>' +
+								'</tableRow>' +
+							'</table>'
+						);
+					} );
+
 					it( 'should work with tables in figures', () => {
 						editor.setData(
 							'<figure class="table">' +


### PR DESCRIPTION
### 🚀 Summary

Fix wrong upcast of `border="0"` attribute if cell has non-default attributes.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-commercial/issues/9231

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [x] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [x] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
