### PR TITLE
Upgrade Chrome version to `145.0.7632.45`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ parameters:
     default: false
   chromeVersion:
     type: string
-    default: "144.0.7559.59"
+    default: "145.0.7632.45"
 
 orbs:
   continuation: circleci/continuation@0.1.2


### PR DESCRIPTION
### 🚀 Summary

This PR bumps the Chrome used in CI to **145.0.7632.45**.

---

### 📃 Additional information

- Generated automatically by the Chrome bump workflow.
- Triggered because a new Chrome stable version was detected.
