### PR TITLE
Reduce the `notify_ci_failure` resource class to `small`

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -254,7 +254,7 @@ jobs:
   notify_ci_failure:
     docker:
       - image: cimg/node:24.11.0
-    resource_class: medium
+    resource_class: small
     parameters:
       hideAuthor:
         type: string


### PR DESCRIPTION
### 🚀 Summary

As in the title, nothing more to add.

---

### 📌 Related issues

* See: https://github.com/ckeditor/ckeditor5-internal/issues/4292.