### PR TITLE
Docs: Adjust bottom toolbar demo.

### DIFF
--- a/docs/_snippets/examples/bottom-toolbar-editor.html
+++ b/docs/_snippets/examples/bottom-toolbar-editor.html
@@ -54,7 +54,7 @@
 		</figure>
 		<h2 style="text-align: center;">Welcome to Fabulous Dummy App!</h2>
 		<hr />
-		<p>We are so glad to have you, <strong>{user_name}</strong>! But before you can explore all the features, please verify your email address.</p>
+		<p>We are so glad to have you! But before you can explore all the features, please verify your email address.</p>
 		<p>We use your email address to validate your account and to keep you updated. We respect your privacy and you can opt out of direct email marketing in your account <a href="https://fabulousdummyapp.com/preferences">preferences</a>.</p>
 		<p>If you did not create an account using this email address, please contact us at <a href="mailto:contact@fabulousdummyapp.com">contact@fabulousdummyapp.com</a>.</p>
 		<p style="text-align: center;">

--- a/docs/examples/custom/bottom-toolbar-editor.md
+++ b/docs/examples/custom/bottom-toolbar-editor.md
@@ -64,7 +64,6 @@ import {
 	IconFontColor,
 	registerIcon
 } from 'ckeditor5';
-import { EasyImage } from 'ckeditor5-premium-features';
 
 const fontColorIcon =/* #__PURE__ */ registerIcon( 'fontColor', IconFontColor );
 
@@ -170,7 +169,6 @@ DecoupledEditor
 			Autoformat,
 			BlockQuote,
 			Bold,
-			EasyImage,
 			Essentials,
 			Font,
 			Heading,
@@ -194,7 +192,6 @@ DecoupledEditor
 			Table,
 			TableToolbar,
 			Underline,
-
 			FormattingOptions
 		],
 		toolbar: [
@@ -260,14 +257,7 @@ DecoupledEditor
 				'tableRow',
 				'mergeTableCells'
 			]
-		},
-		cloudServices: {
-			// This editor configuration includes the Easy Image feature.
-			// Provide correct configuration values to use it.
-			tokenUrl: 'https://example.com/cs-token-endpoint',
-			uploadUrl: 'https://your-organization-id.cke-cs.com/easyimage/upload/'
-			// For other image upload methods see the guide - https://ckeditor.com/docs/ckeditor5/latest/features/images/image-upload/image-upload.html.
-		},
+		}
 	} )
 	.then( editor => {
 		window.editor = editor;


### PR DESCRIPTION
### 🚀 Summary

No longer import `EasyImage` from premium features in bottom toolbar demo. Remove merge field from it's content.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-commercial/issues/9427#issue-3999782046 https://github.com/ckeditor/ckeditor5-commercial/issues/9428

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [x] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [x] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
