### PR TITLE
Fix memleak in svelte demo. Add example of two-way binding.

### DIFF
--- a/docs/getting-started/integrations-cdn/svelte.md
+++ b/docs/getting-started/integrations-cdn/svelte.md
@@ -151,6 +151,10 @@ Create a new file `src/lib/Editor.svelte` with the following content:
 <div bind:this={editorContainer}></div>
 ```
 
+<info-box>
+	To listen for editor content changes, use the `change:data` event on `editor.model.document` as shown above. Do not use `editor.on( 'change:data', ... )` directly on the editor instance &ndash; that listens for observable property changes on the editor object, not for content edits made by the user.
+</info-box>
+
 ### Using the Editor component
 
 Now, modify the main `App.svelte` file to use our editor component:

--- a/docs/getting-started/integrations/svelte.md
+++ b/docs/getting-started/integrations/svelte.md
@@ -131,6 +131,10 @@ Create a new file `src/lib/Editor.svelte` with the following content:
 <div bind:this={editorContainer}></div>
 ```
 
+<info-box>
+	To listen for editor content changes, use the `change:data` event on `editor.model.document` as shown above. Do not use `editor.on( 'change:data', ... )` directly on the editor instance &ndash; that listens for observable property changes on the editor object, not for content edits made by the user.
+</info-box>
+
 ### Using the Editor component
 
 Now, modify the main `App.svelte` file to use our editor component:


### PR DESCRIPTION
### 🚀 Summary

Fix mem-leak in svelte demo. Add example of two-way binding.

---

### 📌 Related issues

* Closes #19005 

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [ ] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
