### PR TITLE
Add collaboration user colors refactor to upgrade guide for `v48`.

### DIFF
--- a/docs/updating/update-to-48.md
+++ b/docs/updating/update-to-48.md
@@ -49,31 +49,31 @@ If you use only the default user colors, no changes are required. However, if yo
 1. Remove the `@ckeditor/ckeditor5-collaboration-core/theme/usercolormixin.css` import.
 2. Replace `@mixin userColor` definitions with `--ck-user-colors--*` and `--ck-user-colors--*-alpha` CSS variables.
 
-The old and new approaches look like this:
+	The old and new approaches look like this:
 
-```css
-/* Before */
-@import "@ckeditor/ckeditor5-collaboration-core/theme/usercolormixin.css";
+	```css
+	/* Before */
+	@import "@ckeditor/ckeditor5-collaboration-core/theme/usercolormixin.css";
 
-@mixin userColor hsla(31, 90%, 43%, 1), hsla(31, 90%, 43%, 0.15), 8;
-@mixin userColor hsla(61, 90%, 43%, 1), hsla(61, 90%, 43%, 0.15), 9;
-```
+	@mixin userColor hsla(31, 90%, 43%, 1), hsla(31, 90%, 43%, 0.15), 8;
+	@mixin userColor hsla(61, 90%, 43%, 1), hsla(61, 90%, 43%, 0.15), 9;
+	```
 
-```css
-/* After */
-:root {
-	--ck-user-colors--8: hsla(31, 90%, 43%, 1);
-	--ck-user-colors--8-alpha: hsla(31, 90%, 43%, 0.15);
+	```css
+	/* After */
+	:root {
+		--ck-user-colors--8: hsla(31, 90%, 43%, 1);
+		--ck-user-colors--8-alpha: hsla(31, 90%, 43%, 0.15);
 
-	--ck-user-colors--9: hsla(61, 90%, 43%, 1);
-	--ck-user-colors--9-alpha: hsla(61, 90%, 43%, 0.15);
-}
-```
+		--ck-user-colors--9: hsla(61, 90%, 43%, 1);
+		--ck-user-colors--9-alpha: hsla(61, 90%, 43%, 0.15);
+	}
+	```
 
-The editor configuration `config.users.colorsCount` did not change and should be kept aligned with the total number of defined colors. For the example above (`0-9`), set:
+3. Keep the `config.users.colorsCount` option aligned with the total number of defined colors. For the example above (`0-9`), set:
 
-```js
-users: {
-	colorsCount: 10
-}
-```
+	```js
+	users: {
+		colorsCount: 10
+	}
+	```


### PR DESCRIPTION
### 🚀 Summary

Add collaboration user colors refactor to upgrade guide for `v48`.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5-commercial/issues/9438.

---

### 💡 Additional information

N/A

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [ ] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
