### PR TITLE
Remove format should now remove stored selection attributes.

### DIFF
--- a/.changelog/20260310134934_ck_19851.md
+++ b/.changelog/20260310134934_ck_19851.md
@@ -1,0 +1,9 @@
+---
+type: Feature
+scope:
+  - ckeditor5-remove-format
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/19851
+---
+
+The remove format feature will now clear inherited formatting from empty paragraphs and other block elements.

--- a/packages/ckeditor5-remove-format/src/removeformatcommand.ts
+++ b/packages/ckeditor5-remove-format/src/removeformatcommand.ts
@@ -83,9 +83,10 @@ export class RemoveFormatCommand extends Command {
 	 */
 	private _removeFormatting( attributeName: string, item: ModelItem, itemRange: ModelRange, writer: ModelWriter ) {
 		let customHandled = false;
+		const nonSelectionAttributeName = toNonSelectionAttribute( attributeName );
 
 		for ( const { isFormatting, removeFormatting } of this._customAttributesHandlers ) {
-			if ( isFormatting( attributeName, item ) ) {
+			if ( isFormatting( nonSelectionAttributeName, item ) ) {
 				removeFormatting( attributeName, itemRange, writer );
 				customHandled = true;
 			}
@@ -143,22 +144,31 @@ export class RemoveFormatCommand extends Command {
 	 * @returns The names of formatting attributes found in a given item.
 	 */
 	private* _getFormattingAttributes( item: ModelItem | ModelDocumentSelection ) {
-		const schema = this.editor.model.schema;
+		const { schema } = this.editor.model;
 
 		for ( const [ attributeName ] of item.getAttributes() ) {
+			const nonSelectionAttributeName = toNonSelectionAttribute( attributeName );
+
 			for ( const { isFormatting } of this._customAttributesHandlers ) {
-				if ( isFormatting( attributeName, item ) ) {
+				if ( isFormatting( nonSelectionAttributeName, item ) ) {
 					yield attributeName;
 				}
 			}
 
-			const attributeProperties = schema.getAttributeProperties( attributeName );
+			const attributeProperties = schema.getAttributeProperties( nonSelectionAttributeName );
 
 			if ( attributeProperties && attributeProperties.isFormatting ) {
 				yield attributeName;
 			}
 		}
 	}
+}
+
+/**
+ * Helper function that converts a selection attribute name to a non-selection one. E.g. `selection:bold` to `bold`.
+ */
+function toNonSelectionAttribute( attributeName: string ) {
+	return attributeName.replace( /^selection:/, '' );
 }
 
 /**

--- a/packages/ckeditor5-remove-format/tests/removeformatcommand.js
+++ b/packages/ckeditor5-remove-format/tests/removeformatcommand.js
@@ -129,6 +129,19 @@ describe( 'RemoveFormatCommand', () => {
 				assert: () => expectEnabledPropertyToBe( true )
 			},
 
+			'state with selection attribute markers on an element': {
+				input: '<p>fo[]o</p>',
+				beforeAssert: () => {
+					model.change( writer => {
+						const p = model.document.getRoot().getChild( 0 );
+						writer.setAttribute( 'selection:someBlockFormatting', 'foo', p );
+						writer.setAttribute( 'selection:fooA', 'bar', p );
+						writer.setAttribute( 'selection:irrelevant', 'true', p );
+					} );
+				},
+				assert: () => expectEnabledPropertyToBe( true )
+			},
+
 			'state with block formatting': {
 				input: '<p someBlockFormatting="foo">f[oo</p><p>]bar</p>',
 				assert: () => expectEnabledPropertyToBe( true )
@@ -189,7 +202,33 @@ describe( 'RemoveFormatCommand', () => {
 					expect( model.document.selection.hasAttribute( 'irrelevant' ) ).to.equal( true );
 				}
 			},
-
+			'state with formatted selection alone (selection attribute marker)': {
+				input: '<p>fo[]o</p>',
+				setDataOptions: {
+					selectionAttributes: {
+						'selection:someBlockFormatting': 'foo',
+						'selection:fooA': 'bar',
+						'selection:irrelevant': true
+					}
+				},
+				assert: () => {
+					expect( model.document.selection.hasAttribute( 'selection:someBlockFormatting' ) ).to.be.false;
+					expect( model.document.selection.hasAttribute( 'selection:fooA' ) ).to.be.false;
+					expect( model.document.selection.hasAttribute( 'selection:irrelevant' ) ).to.be.true;
+				}
+			},
+			'state with selection attribute markers on an element': {
+				input: '<p>fo[]o</p>',
+				beforeAssert: () => {
+					model.change( writer => {
+						const p = model.document.getRoot().getChild( 0 );
+						writer.setAttribute( 'selection:someBlockFormatting', 'foo', p );
+						writer.setAttribute( 'selection:fooA', 'bar', p );
+						writer.setAttribute( 'selection:irrelevant', 'true', p );
+					} );
+				},
+				assert: () => expectModelToBeEqual( '<p selection:fooA="BAR" selection:irrelevant="true">fo[]o</p>' )
+			},
 			'state with block formatting': {
 				input: '<p someBlockFormatting="foo">f[oo</p><p someBlockFormatting="bar">]bar</p>',
 				assert: () => expectModelToBeEqual( '<p>f[oo</p><p someBlockFormatting="bar">]bar</p>' )
@@ -305,6 +344,10 @@ describe( 'RemoveFormatCommand', () => {
 		for ( const [ key, testConfig ] of Object.entries( useCases ) ) {
 			it( key, () => {
 				_setModelData( model, testConfig.input, testConfig.setDataOptions );
+
+				if ( testConfig.beforeAssert ) {
+					testConfig.beforeAssert();
+				}
 
 				if ( options && options.beforeAssert ) {
 					options.beforeAssert();


### PR DESCRIPTION
### 🚀 Summary

Remove format should now remove stored selection attributes.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5/issues/19851

---

### 💡 Additional information

#### Before

https://github.com/user-attachments/assets/69a78e5a-5789-4220-9b82-22d8c95aa93e

#### After

https://github.com/user-attachments/assets/1c59b05c-42d7-45b9-8c45-61d93bb3b4f0

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [ ] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [x] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
