### PR TITLE
Hide the menu bar when it gets disabled

### DIFF
--- a/.changelog/20260311141046_master.md
+++ b/.changelog/20260311141046_master.md
@@ -1,0 +1,11 @@
+---
+type: Fix
+
+scope:
+  - ckeditor5-ui
+
+closes:
+  - 18214
+---
+
+Disabling a menu bar menu now also closes it if it was open, preventing an open panel from remaining in a non-interactive state.

--- a/packages/ckeditor5-ui/src/menubar/menubarmenuview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenuview.ts
@@ -150,6 +150,7 @@ export class MenuBarMenuView extends View implements FocusableView {
 
 		MenuBarMenuBehaviors.closeOnEscKey( this );
 
+		this._closeOnDisabled();
 		this._repositionPanelOnOpen();
 	}
 
@@ -190,6 +191,17 @@ export class MenuBarMenuView extends View implements FocusableView {
 		this.keystrokes.set( 'arrowleft', ( data, cancel ) => {
 			this.fire( 'arrowleft' );
 			cancel();
+		} );
+	}
+
+	/**
+	 * Closes the menu whenever it gets disabled to avoid leaving an open panel in a non-interactive state.
+	 */
+	private _closeOnDisabled(): void {
+		this.on<ObservableChangeEvent<boolean>>( 'change:isEnabled', ( evt, name, isEnabled ) => {
+			if ( !isEnabled ) {
+				this.isOpen = false;
+			}
 		} );
 	}
 

--- a/packages/ckeditor5-ui/tests/menubar/menubarmenuview.js
+++ b/packages/ckeditor5-ui/tests/menubar/menubarmenuview.js
@@ -221,6 +221,25 @@ describe( 'MenuBarMenuView', () => {
 			sinon.assert.calledOnceWithExactly( spy, menuView );
 		} );
 
+		it( 'should close the menu when it gets disabled', () => {
+			menuView.render();
+			menuView.isOpen = true;
+
+			menuView.isEnabled = false;
+
+			expect( menuView.isOpen ).to.be.false;
+		} );
+
+		it( 'should not close the menu when it gets enabled', () => {
+			menuView.render();
+			menuView.isEnabled = false;
+			menuView.isOpen = true;
+
+			menuView.isEnabled = true;
+
+			expect( menuView.isOpen ).to.be.true;
+		} );
+
 		describe( 'panel repositioning upon open', () => {
 			let menuView, menuBarView, parentMenuView;
 


### PR DESCRIPTION
### 🚀 Summary

Disabling a menu bar menu now also closes it if it was open, preventing an open panel from remaining in a non-interactive state.

---

### 📌 Related issues

* Closes #18214.

---

### 💡 Additional information

**Before:**

https://github.com/user-attachments/assets/a4e53b04-f72f-44b0-8299-d64f5b52365a


**After:**

https://github.com/user-attachments/assets/00f37099-d995-425e-9b29-b264d5096eab


---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-state fix limited to menu bar menus; risk is low and mainly affects open/close behavior when `isEnabled` changes.
> 
> **Overview**
> Disabling a `MenuBarMenuView` now automatically closes it by forcing `isOpen = false` on `change:isEnabled`, preventing an open but non-interactive panel.
> 
> Adds regression coverage to ensure the menu closes on disable but does not close when re-enabled, and includes a `ckeditor5-ui` changelog entry for the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd47839c774a24d472c1de92b9a8a100df56aea3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->