### PR TITLE
Upgrade Chrome version to `146.0.7680.71`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ parameters:
     default: false
   chromeVersion:
     type: string
-    default: "145.0.7632.45"
+    default: "146.0.7680.71"
   isLtsPipeline:
     type: boolean
     default: false


### PR DESCRIPTION
### 🚀 Summary

This PR bumps the Chrome used in CI to **146.0.7680.71**.

---

### 📃 Additional information

- Generated automatically by the Chrome bump workflow.
- Triggered because a new Chrome stable version was detected.
