### PR TITLE
Update `circleci/browser-tools` orb to `v2.4.0`

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -5,7 +5,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@2.3.1
+  browser-tools: circleci/browser-tools@2.4.0
   codecov: codecov/codecov@5.4.3
 
 # List of parameters are automatically inherited from `config.yml`.


### PR DESCRIPTION
### 🚀 Summary

Update `circleci/browser-tools` orb to `v2.4.0`.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5/issues/19934.

---

### 💡 Additional information

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that updates a CircleCI orb version; impact is limited to CI runtime behavior if the orb has breaking/regressive changes.
> 
> **Overview**
> Updates the CircleCI config template to use `circleci/browser-tools@2.4.0` (from `2.3.1`) for jobs that install Chrome via the `browser-tools` orb.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7842faa35e8cdfd9973022a67a54feb850c2b620. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->