### PR TITLE
Remove `pacote` from `minimumReleaseAgeExclude`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,6 @@ minimumReleaseAgeExclude:
   - '@cksource/*'
   - '*ckeditor5*'
   - 'umberto'
-  - pacote # Remove on or after 2026/03/13
 
 shellEmulator: true
 shamefullyHoist: true


### PR DESCRIPTION
### 🚀 Summary

Remove `pacote` from `minimumReleaseAgeExclude`.

---

### 📌 Related issues

N/A

---

### 💡 Additional information

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workspace config tweak that only affects pnpm's dependency release-age exclusion behavior (potentially allowing `pacote` to be held back by the minimum age policy).
> 
> **Overview**
> Removes `pacote` from `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`, so `pacote` updates are now subject to the workspace `minimumReleaseAge` delay rather than bypassing it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fb732386b7af09060c4219188cfcd25c0910a37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->