### PR TITLE
Migrate back to `es-toolkit/compat` barrel import to fix tree-shaking regression.

### DIFF
--- a/.changelog/20260313150054_ck_19962_optimize_es_toolkit_imports.md
+++ b/.changelog/20260313150054_ck_19962_optimize_es_toolkit_imports.md
@@ -1,5 +1,0 @@
----
-type: Other
----
-
-Optimize `es-toolkit/compat` imports to avoid barrel-file imports.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -112,8 +112,8 @@ export default defineConfig( [
 							message: disallowedPackageImportsMessage
 						},
 						{
-							regex: '^es-toolkit(/compat)?$', // `es-toolkit` and `es-toolkit/compat`
-							message: 'Import directly from the specific module file (e.g. `es-toolkit/compat/debounce`).'
+							regex: '^es-toolkit$',
+							message: 'Import from `es-toolkit/compat` instead.'
 						}
 					]
 				}
@@ -132,10 +132,16 @@ export default defineConfig( [
 
 		rules: {
 			'no-restricted-imports': [ 'error', {
-				patterns: [ {
-					regex: disallowedPackageImportsPattern,
-					message: disallowedPackageImportsMessage
-				} ]
+				patterns: [
+					{
+						regex: disallowedPackageImportsPattern,
+						message: disallowedPackageImportsMessage
+					},
+					{
+						regex: '^es-toolkit$',
+						message: 'Import from `es-toolkit/compat` instead.'
+					}
+				]
 			} ]
 		}
 	},
@@ -150,10 +156,16 @@ export default defineConfig( [
 
 		rules: {
 			'@typescript-eslint/no-restricted-imports': [ 'error', {
-				patterns: [ {
-					regex: disallowedPackageImportsPattern,
-					message: disallowedPackageImportsMessage
-				} ]
+				patterns: [
+					{
+						regex: disallowedPackageImportsPattern,
+						message: disallowedPackageImportsMessage
+					},
+					{
+						regex: '^es-toolkit$',
+						message: 'Import from `es-toolkit/compat` instead.'
+					}
+				]
 			} ]
 		}
 	},

--- a/packages/ckeditor5-autosave/src/autosave.ts
+++ b/packages/ckeditor5-autosave/src/autosave.ts
@@ -20,7 +20,7 @@ import { DomEmitterMixin, type DomEmitter } from '@ckeditor/ckeditor5-utils';
 
 import type { ModelDocumentChangeEvent } from '@ckeditor/ckeditor5-engine';
 
-import debounce from 'es-toolkit/compat/debounce';
+import { debounce } from 'es-toolkit/compat';
 
 /**
  * The {@link module:autosave/autosave~Autosave} plugin allows you to automatically save the data (e.g. send it to the server)

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
@@ -18,7 +18,7 @@ import {
 } from '@ckeditor/ckeditor5-utils';
 import type { ModelElement } from '@ckeditor/ckeditor5-engine';
 import { Notification } from '@ckeditor/ckeditor5-ui';
-import isEqual from 'es-toolkit/compat/isEqual';
+import { isEqual } from 'es-toolkit/compat';
 
 import { sendHttpRequest } from '../utils.js';
 import { prepareImageAssetAttributes } from '../ckboxcommand.js';

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
@@ -16,7 +16,7 @@ import { LinkEditing } from '@ckeditor/ckeditor5-link';
 import { _setModelData, _getModelData, _getViewData } from '@ckeditor/ckeditor5-engine';
 import { Notification } from '@ckeditor/ckeditor5-ui';
 import { TokenMock } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/tokenmock.js';
-import * as isEqualCompat from 'es-toolkit/compat/isEqual';
+import * as isEqualCompat from 'es-toolkit/compat';
 import { CloudServicesCoreMock } from '../_utils/cloudservicescoremock.js';
 import { CKBoxEditing } from '../../src/ckboxediting.js';
 import { CKBoxImageEditEditing } from '../../src/ckboximageedit/ckboximageeditediting.js';
@@ -632,7 +632,7 @@ describe( 'CKBoxImageEditCommand', () => {
 			it( 'should disable command for images being processed', async () => {
 				const clock = sinon.useFakeTimers();
 
-				sinon.stub( isEqualCompat, 'default' ).returns( true );
+				sinon.stub( isEqualCompat, 'isEqual' ).returns( true );
 
 				sinonXHR.respondWith( 'GET', CKBOX_API_URL + '/assets/image-id1', [
 					500,

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -6,7 +6,7 @@
 /**
  * @module clipboard/clipboardmarkersutils
  */
-import mapValues from 'es-toolkit/compat/mapValues';
+import { mapValues } from 'es-toolkit/compat';
 
 import { uid } from '@ckeditor/ckeditor5-utils';
 import { Plugin, type NonEmptyArray } from '@ckeditor/ckeditor5-core';

--- a/packages/ckeditor5-clipboard/src/dragdroptarget.ts
+++ b/packages/ckeditor5-clipboard/src/dragdroptarget.ts
@@ -34,7 +34,7 @@ import {
 
 import { LineView } from './lineview.js';
 
-import throttle from 'es-toolkit/compat/throttle';
+import { throttle } from 'es-toolkit/compat';
 
 /**
  * Part of the Drag and Drop handling. Responsible for finding and displaying the drop target.

--- a/packages/ckeditor5-core/src/editor/editor.ts
+++ b/packages/ckeditor5-core/src/editor/editor.ts
@@ -7,8 +7,7 @@
  * @module core/editor/editor
  */
 
-import set from 'es-toolkit/compat/set';
-import get from 'es-toolkit/compat/get';
+import { set, get } from 'es-toolkit/compat';
 
 import {
 	Config,

--- a/packages/ckeditor5-core/src/editor/utils/attachtoform.ts
+++ b/packages/ckeditor5-core/src/editor/utils/attachtoform.ts
@@ -7,7 +7,7 @@
  * @module core/editor/utils/attachtoform
  */
 
-import isFunction from 'es-toolkit/compat/isFunction';
+import { isFunction } from 'es-toolkit/compat';
 
 import { CKEditorError } from '@ckeditor/ckeditor5-utils';
 

--- a/packages/ckeditor5-core/tests/_utils/classictesteditor.js
+++ b/packages/ckeditor5-core/tests/_utils/classictesteditor.js
@@ -7,7 +7,7 @@ import { Editor } from '../../src/editor/editor.js';
 import { ElementApiMixin } from '../../src/editor/utils/elementapimixin.js';
 import { EditorUI, BoxedEditorUIView, InlineEditableUIView } from '@ckeditor/ckeditor5-ui';
 import { ElementReplacer, getDataFromElement, CKEditorError } from '@ckeditor/ckeditor5-utils';
-import isElement from 'es-toolkit/compat/isElement';
+import { isElement } from 'es-toolkit/compat';
 
 /**
  * A simplified classic editor. Useful for testing features.

--- a/packages/ckeditor5-core/tests/accessibility.js
+++ b/packages/ckeditor5-core/tests/accessibility.js
@@ -5,7 +5,7 @@
 
 import { Editor } from '@ckeditor/ckeditor5-core';
 import { expectToThrowCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils.js';
-import cloneDeep from 'es-toolkit/compat/cloneDeep';
+import { cloneDeep } from 'es-toolkit/compat';
 
 describe( 'Accessibility', () => {
 	let editor, accessibility;

--- a/packages/ckeditor5-editor-balloon/src/ballooneditor.ts
+++ b/packages/ckeditor5-editor-balloon/src/ballooneditor.ts
@@ -22,7 +22,7 @@ import { CKEditorError, getDataFromElement } from '@ckeditor/ckeditor5-utils';
 import { BalloonEditorUI } from './ballooneditorui.js';
 import { BalloonEditorUIView } from './ballooneditoruiview.js';
 
-import _isElement from 'es-toolkit/compat/isElement';
+import { isElement as _isElement } from 'es-toolkit/compat';
 
 /**
  * The balloon editor implementation (Medium-like editor).

--- a/packages/ckeditor5-editor-balloon/tests/ballooneditorui.js
+++ b/packages/ckeditor5-editor-balloon/tests/ballooneditorui.js
@@ -12,7 +12,7 @@ import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
 import { Heading } from '@ckeditor/ckeditor5-heading';
 
 import { keyCodes } from '@ckeditor/ckeditor5-utils';
-import isElement from 'es-toolkit/compat/isElement';
+import { isElement } from 'es-toolkit/compat';
 import { VirtualTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor.js';
 import { _setModelData } from '@ckeditor/ckeditor5-engine';
 import { assertBinding } from '@ckeditor/ckeditor5-utils/tests/_utils/utils.js';

--- a/packages/ckeditor5-editor-classic/src/classiceditor.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditor.ts
@@ -19,7 +19,7 @@ import {
 } from '@ckeditor/ckeditor5-core';
 import { getDataFromElement, CKEditorError } from '@ckeditor/ckeditor5-utils';
 
-import _isElement from 'es-toolkit/compat/isElement';
+import { isElement as _isElement } from 'es-toolkit/compat';
 
 /**
  * The classic editor implementation. It uses an inline editable and a sticky toolbar, all enclosed in a boxed UI.

--- a/packages/ckeditor5-editor-classic/tests/classiceditorui.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditorui.js
@@ -16,7 +16,7 @@ import { _setModelData } from '@ckeditor/ckeditor5-engine';
 import { keyCodes, env } from '@ckeditor/ckeditor5-utils';
 import { testUtils } from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
 import { assertBinding } from '@ckeditor/ckeditor5-utils/tests/_utils/utils.js';
-import isElement from 'es-toolkit/compat/isElement';
+import { isElement } from 'es-toolkit/compat';
 
 describe( 'ClassicEditorUI', () => {
 	let editor, view, ui, viewElement;

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitor.ts
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitor.ts
@@ -22,7 +22,7 @@ import {
 import { DecoupledEditorUI } from './decouplededitorui.js';
 import { DecoupledEditorUIView } from './decouplededitoruiview.js';
 
-import _isElement from 'es-toolkit/compat/isElement';
+import { isElement as _isElement } from 'es-toolkit/compat';
 
 /**
  * The decoupled editor implementation. It provides an inline editable and a toolbar. However, unlike other editors,

--- a/packages/ckeditor5-editor-decoupled/tests/decouplededitorui.js
+++ b/packages/ckeditor5-editor-decoupled/tests/decouplededitorui.js
@@ -15,7 +15,7 @@ import { VirtualTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/virtual
 import { keyCodes } from '@ckeditor/ckeditor5-utils';
 import { testUtils } from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
 import { assertBinding } from '@ckeditor/ckeditor5-utils/tests/_utils/utils.js';
-import isElement from 'es-toolkit/compat/isElement';
+import { isElement } from 'es-toolkit/compat';
 import { _setModelData } from '@ckeditor/ckeditor5-engine';
 
 describe( 'DecoupledEditorUI', () => {

--- a/packages/ckeditor5-editor-inline/src/inlineeditor.ts
+++ b/packages/ckeditor5-editor-inline/src/inlineeditor.ts
@@ -20,7 +20,7 @@ import { getDataFromElement, CKEditorError } from '@ckeditor/ckeditor5-utils';
 import { InlineEditorUI } from './inlineeditorui.js';
 import { InlineEditorUIView } from './inlineeditoruiview.js';
 
-import _isElement from 'es-toolkit/compat/isElement';
+import { isElement as _isElement } from 'es-toolkit/compat';
 
 /**
  * The inline editor implementation. It uses an inline editable and a floating toolbar.

--- a/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
@@ -15,7 +15,7 @@ import { VirtualTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/virtual
 import { keyCodes, env } from '@ckeditor/ckeditor5-utils';
 import { testUtils } from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
 import { assertBinding } from '@ckeditor/ckeditor5-utils/tests/_utils/utils.js';
-import isElement from 'es-toolkit/compat/isElement';
+import { isElement } from 'es-toolkit/compat';
 import { _setModelData } from '@ckeditor/ckeditor5-engine';
 
 describe( 'InlineEditorUI', () => {

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -28,7 +28,7 @@ import {
 import { MultiRootEditorUI } from './multirooteditorui.js';
 import { MultiRootEditorUIView } from './multirooteditoruiview.js';
 
-import _isElement from 'es-toolkit/compat/isElement';
+import { isElement as _isElement } from 'es-toolkit/compat';
 import {
 	type ModelRootElement,
 	type ViewRootEditableElement,

--- a/packages/ckeditor5-emoji/src/emojirepository.ts
+++ b/packages/ckeditor5-emoji/src/emojirepository.ts
@@ -8,7 +8,7 @@
  */
 
 import fuzzysort from 'fuzzysort';
-import groupBy from 'es-toolkit/compat/groupBy';
+import { groupBy } from 'es-toolkit/compat';
 
 import { type Editor, Plugin } from '@ckeditor/ckeditor5-core';
 import { logWarning, version as editorVersion } from '@ckeditor/ckeditor5-utils';

--- a/packages/ckeditor5-emoji/src/ui/emojisearchview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojisearchview.ts
@@ -7,7 +7,7 @@
  * @module emoji/ui/emojisearchview
  */
 
-import escapeRegExp from 'es-toolkit/compat/escapeRegExp';
+import { escapeRegExp } from 'es-toolkit/compat';
 import { createLabeledInputText, SearchTextView, View, type SearchTextViewSearchEvent, type SearchInfoView } from '@ckeditor/ckeditor5-ui';
 import type { Locale } from '@ckeditor/ckeditor5-utils';
 import { type EmojiGridView } from './emojigridview.js';

--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.ts
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.ts
@@ -56,7 +56,7 @@ import {
 	type PriorityString
 } from '@ckeditor/ckeditor5-utils';
 
-import cloneDeep from 'es-toolkit/compat/cloneDeep';
+import { cloneDeep } from 'es-toolkit/compat';
 
 /**
  * Downcast conversion helper functions.

--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.ts
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.ts
@@ -19,7 +19,7 @@ import { isParagraphable, wrapInParagraph } from '../model/utils/autoparagraphin
 
 import { priorities, type EventInfo, type PriorityString } from '@ckeditor/ckeditor5-utils';
 
-import cloneDeep from 'es-toolkit/compat/cloneDeep';
+import { cloneDeep } from 'es-toolkit/compat';
 
 /**
  * Contains the {@link module:engine/view/view view} to {@link module:engine/model/model model} converters for

--- a/packages/ckeditor5-engine/src/dev-utils/model.ts
+++ b/packages/ckeditor5-engine/src/dev-utils/model.ts
@@ -69,7 +69,7 @@ import { type ModelElement } from '../model/element.js';
 
 import { toMap, type EventInfo } from '@ckeditor/ckeditor5-utils';
 
-import isPlainObject from 'es-toolkit/compat/isPlainObject';
+import { isPlainObject } from 'es-toolkit/compat';
 
 /**
  * Writes the content of a model {@link module:engine/model/document~ModelDocument document} to an HTML-like string.

--- a/packages/ckeditor5-engine/src/dev-utils/utils.ts
+++ b/packages/ckeditor5-engine/src/dev-utils/utils.ts
@@ -11,7 +11,7 @@
  * @module engine/dev-utils/utils
  */
 
-// @if CK_DEBUG_TYPING // const debounce = require( 'es-toolkit/compat/debounce' );
+// @if CK_DEBUG_TYPING // const { debounce } = require( 'es-toolkit/compat' );
 
 /**
  * Helper function, converts a map to the 'key1="value1" key2="value1"' format.

--- a/packages/ckeditor5-engine/src/model/document.ts
+++ b/packages/ckeditor5-engine/src/model/document.ts
@@ -28,7 +28,7 @@ import {
 	isInsideCombinedSymbol
 } from '@ckeditor/ckeditor5-utils';
 
-import clone from 'es-toolkit/compat/clone';
+import { clone } from 'es-toolkit/compat';
 
 // @if CK_DEBUG_ENGINE // const { logDocument } = require( '../dev-utils/utils' );
 

--- a/packages/ckeditor5-engine/src/model/operation/attributeoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/attributeoperation.ts
@@ -14,7 +14,7 @@ import { ModelRange } from '../range.js';
 import { type ModelDocument } from '../document.js';
 
 import { CKEditorError } from '@ckeditor/ckeditor5-utils';
-import isEqual from 'es-toolkit/compat/isEqual';
+import { isEqual } from 'es-toolkit/compat';
 import type { ModelSelectable } from '../selection.js';
 
 /**

--- a/packages/ckeditor5-engine/src/view/downcastwriter.ts
+++ b/packages/ckeditor5-engine/src/view/downcastwriter.ts
@@ -24,7 +24,7 @@ import { CKEditorError, isIterable, type ArrayOrItem } from '@ckeditor/ckeditor5
 import { ViewDocumentFragment } from './documentfragment.js';
 import { ViewText } from './text.js';
 import { ViewEditableElement } from './editableelement.js';
-import isPlainObject from 'es-toolkit/compat/isPlainObject';
+import { isPlainObject } from 'es-toolkit/compat';
 
 import { type ViewDocument } from './document.js';
 import { type ViewNode } from './node.js';

--- a/packages/ckeditor5-engine/src/view/observer/domeventdata.ts
+++ b/packages/ckeditor5-engine/src/view/observer/domeventdata.ts
@@ -7,7 +7,7 @@
  * @module engine/view/observer/domeventdata
  */
 
-import extend from 'es-toolkit/compat/extend';
+import { extend } from 'es-toolkit/compat';
 
 import { type ViewDocument } from '../document.js';
 import { type ViewElement } from '../element.js';

--- a/packages/ckeditor5-engine/src/view/observer/fakeselectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/fakeselectionobserver.ts
@@ -17,7 +17,7 @@ import type {
 	ViewDocumentObserverSelectionEventData
 } from './selectionobserver.js';
 import { keyCodes } from '@ckeditor/ckeditor5-utils';
-import debounce from 'es-toolkit/compat/debounce';
+import { debounce } from 'es-toolkit/compat';
 
 /**
  * Fake selection observer class. If view selection is fake it is placed in dummy DOM container. This observer listens

--- a/packages/ckeditor5-engine/src/view/observer/mutationobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/mutationobserver.ts
@@ -9,7 +9,7 @@
 
 import { Observer } from './observer.js';
 import { startsWithFiller } from '../filler.js';
-import isEqualWith from 'es-toolkit/compat/isEqualWith';
+import { isEqualWith } from 'es-toolkit/compat';
 
 import { type ViewDomConverter } from '../domconverter.js';
 import { type EditingView } from '../view.js';

--- a/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
@@ -11,7 +11,7 @@ import { Observer } from './observer.js';
 import { MutationObserver } from './mutationobserver.js';
 import { FocusObserver } from './focusobserver.js';
 import { env, type ObservableChangeEvent } from '@ckeditor/ckeditor5-utils';
-import debounce from 'es-toolkit/compat/debounce';
+import { debounce } from 'es-toolkit/compat';
 
 import type { EditingView } from '../view.js';
 import type { ViewDocumentSelection } from '../documentselection.js';

--- a/packages/ckeditor5-engine/src/view/styles/background.ts
+++ b/packages/ckeditor5-engine/src/view/styles/background.ts
@@ -7,7 +7,7 @@
  * @module engine/view/styles/background
  */
 
-import isEmpty from 'es-toolkit/compat/isEmpty';
+import { isEmpty } from 'es-toolkit/compat';
 import type {
 	StylesProcessor,
 	StylesNormalizer,

--- a/packages/ckeditor5-engine/src/view/stylesmap.ts
+++ b/packages/ckeditor5-engine/src/view/stylesmap.ts
@@ -7,10 +7,7 @@
  * @module engine/view/stylesmap
  */
 
-import get from 'es-toolkit/compat/get';
-import isObject from 'es-toolkit/compat/isObject';
-import merge from 'es-toolkit/compat/merge';
-import set from 'es-toolkit/compat/set';
+import { get, isObject, merge, set } from 'es-toolkit/compat';
 import type { ViewElementAttributeValue } from './element.js';
 import { type ArrayOrItem, toArray } from '@ckeditor/ckeditor5-utils';
 import { isPatternMatched } from './matcher.js';

--- a/packages/ckeditor5-engine/src/view/upcastwriter.ts
+++ b/packages/ckeditor5-engine/src/view/upcastwriter.ts
@@ -10,7 +10,7 @@
 import { ViewDocumentFragment } from './documentfragment.js';
 import { ViewElement, type ViewElementAttributes } from './element.js';
 import { ViewText } from './text.js';
-import isPlainObject from 'es-toolkit/compat/isPlainObject';
+import { isPlainObject } from 'es-toolkit/compat';
 import { ViewPosition, type ViewPositionOffset } from './position.js';
 import { ViewRange } from './range.js';
 import {

--- a/packages/ckeditor5-engine/src/view/view.ts
+++ b/packages/ckeditor5-engine/src/view/view.ts
@@ -48,7 +48,7 @@ import {
 import { injectUiElementHandling } from './uielement.js';
 import { injectQuirksHandling } from './filler.js';
 
-import cloneDeep from 'es-toolkit/compat/cloneDeep';
+import { cloneDeep } from 'es-toolkit/compat';
 
 // type IfTrue<T> = T extends true ? true : never;
 type DomRange = globalThis.Range;

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceediting.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceediting.ts
@@ -25,7 +25,7 @@ import { FindAndReplaceState, type FindCallback } from './findandreplacestate.js
 import { FindAndReplaceUtils } from './findandreplaceutils.js';
 import type { FindResultType } from './findandreplace.js';
 
-import debounce from 'es-toolkit/compat/debounce';
+import { debounce } from 'es-toolkit/compat';
 
 import '../theme/findandreplace.css';
 

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceutils.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceutils.ts
@@ -10,7 +10,7 @@
 import type { ModelElement, ModelItem, Marker, Model, ModelRange } from '@ckeditor/ckeditor5-engine';
 import { Plugin } from '@ckeditor/ckeditor5-core';
 import { Collection, uid } from '@ckeditor/ckeditor5-utils';
-import escapeRegExp from 'es-toolkit/compat/escapeRegExp';
+import { escapeRegExp } from 'es-toolkit/compat';
 import type { FindResultType } from './findandreplace.js';
 
 /**

--- a/packages/ckeditor5-html-embed/tests/manual/htmlembed.js
+++ b/packages/ckeditor5-html-embed/tests/manual/htmlembed.js
@@ -4,7 +4,7 @@
  */
 
 import sanitizeHtml from 'sanitize-html';
-import clone from 'es-toolkit/compat/clone';
+import { clone } from 'es-toolkit/compat';
 import { ClassicEditor } from '@ckeditor/ckeditor5-editor-classic';
 import { ArticlePluginSet } from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset.js';
 import { MediaEmbed } from '@ckeditor/ckeditor5-media-embed';

--- a/packages/ckeditor5-html-support/src/datafilter.ts
+++ b/packages/ckeditor5-html-support/src/datafilter.ts
@@ -55,7 +55,7 @@ import {
 	type GHSViewAttributes
 } from './utils.js';
 
-import isPlainObject from 'es-toolkit/compat/isPlainObject';
+import { isPlainObject } from 'es-toolkit/compat';
 
 import '../theme/datafilter.css';
 

--- a/packages/ckeditor5-html-support/src/dataschema.ts
+++ b/packages/ckeditor5-html-support/src/dataschema.ts
@@ -10,7 +10,7 @@
 import { Plugin } from '@ckeditor/ckeditor5-core';
 import { toArray } from '@ckeditor/ckeditor5-utils';
 import { defaultConfig } from './schemadefinitions.js';
-import mergeWith from 'es-toolkit/compat/mergeWith';
+import { mergeWith } from 'es-toolkit/compat';
 import type { ModelAttributeProperties, ModelSchemaItemDefinition } from '@ckeditor/ckeditor5-engine';
 
 /**

--- a/packages/ckeditor5-html-support/src/integrations/list.ts
+++ b/packages/ckeditor5-html-support/src/integrations/list.ts
@@ -7,7 +7,7 @@
  * @module html-support/integrations/list
  */
 
-import isEqual from 'es-toolkit/compat/isEqual';
+import { isEqual } from 'es-toolkit/compat';
 import { Plugin } from '@ckeditor/ckeditor5-core';
 import type { UpcastElementEvent } from '@ckeditor/ckeditor5-engine';
 import type { GetCallback } from '@ckeditor/ckeditor5-utils';

--- a/packages/ckeditor5-html-support/src/utils.ts
+++ b/packages/ckeditor5-html-support/src/utils.ts
@@ -15,8 +15,7 @@ import type {
 	ViewElement,
 	ModelWriter
 } from '@ckeditor/ckeditor5-engine';
-import startCase from 'es-toolkit/compat/startCase';
-import cloneDeep from 'es-toolkit/compat/cloneDeep';
+import { startCase, cloneDeep } from 'es-toolkit/compat';
 
 export interface GHSViewAttributes {
 	attributes?: Record<string, unknown>;

--- a/packages/ckeditor5-html-support/tests/integrations/image.js
+++ b/packages/ckeditor5-html-support/tests/integrations/image.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import range from 'es-toolkit/compat/range';
+import { range } from 'es-toolkit/compat';
 
 import { ClassicTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
 import { Image, ImageCaption, ImageBlockEditing, ImageInlineEditing } from '@ckeditor/ckeditor5-image';

--- a/packages/ckeditor5-html-support/tests/integrations/mediaembed.js
+++ b/packages/ckeditor5-html-support/tests/integrations/mediaembed.js
@@ -8,7 +8,7 @@ import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
 import { MediaEmbed } from '@ckeditor/ckeditor5-media-embed';
 import { GeneralHtmlSupport } from '../../src/generalhtmlsupport.js';
 import { getModelDataWithAttributes } from '../_utils/utils.js';
-import range from 'es-toolkit/compat/range';
+import { range } from 'es-toolkit/compat';
 import { MediaEmbedElementSupport } from '../../src/integrations/mediaembed.js';
 
 describe( 'MediaEmbedElementSupport', () => {

--- a/packages/ckeditor5-html-support/tests/integrations/table.js
+++ b/packages/ckeditor5-html-support/tests/integrations/table.js
@@ -15,7 +15,7 @@ import { GeneralHtmlSupport } from '../../src/generalhtmlsupport.js';
 import { getModelDataWithAttributes } from '../_utils/utils.js';
 import { TableElementSupport } from '../../src/integrations/table.js';
 
-import range from 'es-toolkit/compat/range';
+import { range } from 'es-toolkit/compat';
 
 describe( 'TableElementSupport', () => {
 	let editor, model, editorElement, dataFilter;

--- a/packages/ckeditor5-image/src/imagestyle/converters.ts
+++ b/packages/ckeditor5-image/src/imagestyle/converters.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import isEqual from 'es-toolkit/compat/isEqual';
+import { isEqual } from 'es-toolkit/compat';
 import type {
 	DowncastAttributeEvent,
 	ModelElement,

--- a/packages/ckeditor5-image/src/imagestyle/imagestyleui.ts
+++ b/packages/ckeditor5-image/src/imagestyle/imagestyleui.ts
@@ -9,8 +9,7 @@
 
 import { Plugin } from '@ckeditor/ckeditor5-core';
 import { ButtonView, createDropdown, addToolbarToDropdown, SplitButtonView } from '@ckeditor/ckeditor5-ui';
-import isObject from 'es-toolkit/compat/isObject';
-import identity from 'es-toolkit/compat/identity';
+import { isObject, identity } from 'es-toolkit/compat';
 import { ImageStyleEditing } from './imagestyleediting.js';
 import { utils } from './utils.js';
 import type { ImageStyleDropdownDefinition, ImageStyleOptionDefinition } from '../imageconfig.js';

--- a/packages/ckeditor5-image/src/imagetoolbar.ts
+++ b/packages/ckeditor5-image/src/imagetoolbar.ts
@@ -13,7 +13,7 @@ import { WidgetToolbarRepository } from '@ckeditor/ckeditor5-widget';
 import { ImageUtils } from './imageutils.js';
 import type { ImageStyleDropdownDefinition } from './imageconfig.js';
 
-import isObject from 'es-toolkit/compat/isObject';
+import { isObject } from 'es-toolkit/compat';
 
 /**
  * The image toolbar plugin. It creates and manages the image toolbar (the toolbar displayed when an image is selected).

--- a/packages/ckeditor5-link/src/utils.ts
+++ b/packages/ckeditor5-link/src/utils.ts
@@ -25,7 +25,7 @@ import type {
 	LinkDecoratorManualDefinition
 } from './linkconfig.js';
 
-import upperFirst from 'es-toolkit/compat/upperFirst';
+import { upperFirst } from 'es-toolkit/compat';
 
 const ATTRIBUTE_WHITESPACES = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205f\u3000]/g; // eslint-disable-line no-control-regex
 

--- a/packages/ckeditor5-list/src/listproperties/utils/config.ts
+++ b/packages/ckeditor5-list/src/listproperties/utils/config.ts
@@ -7,7 +7,7 @@
  * @module list/listproperties/utils/config
  */
 
-import pick from 'es-toolkit/compat/pick';
+import { pick } from 'es-toolkit/compat';
 import { toArray } from '@ckeditor/ckeditor5-utils';
 import type { ListPropertiesConfig, ListPropertiesStyleListType } from '../../listconfig.js';
 

--- a/packages/ckeditor5-media-embed/tests/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedediting.js
@@ -8,7 +8,7 @@ import { MediaEmbedEditing } from '../src/mediaembedediting.js';
 import { _setModelData, _getModelData, _getViewData } from '@ckeditor/ckeditor5-engine';
 import { normalizeHtml } from '@ckeditor/ckeditor5-utils/tests/_utils/normalizehtml.js';
 import { testUtils } from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
-import escapeRegExp from 'es-toolkit/compat/escapeRegExp';
+import { escapeRegExp } from 'es-toolkit/compat';
 
 describe( 'MediaEmbedEditing', () => {
 	let editor, model, doc, view;

--- a/packages/ckeditor5-mention/src/mentionui.ts
+++ b/packages/ckeditor5-mention/src/mentionui.ts
@@ -36,7 +36,7 @@ import {
 
 import { TextWatcher, type TextWatcherMatchedEvent } from '@ckeditor/ckeditor5-typing';
 
-import debounce from 'es-toolkit/compat/debounce';
+import { debounce } from 'es-toolkit/compat';
 
 import { MentionsView } from './ui/mentionsview.js';
 import { MentionDomWrapperView } from './ui/domwrapperview.js';

--- a/packages/ckeditor5-mention/tests/_utils/asyncserver/index.js
+++ b/packages/ckeditor5-mention/tests/_utils/asyncserver/index.js
@@ -7,7 +7,7 @@ const http = require( 'node:http' );
 const fs = require( 'node:fs' );
 const querystring = require( 'node:querystring' );
 const url = require( 'node:url' );
-const upperFirst = require( 'es-toolkit/compat/upperFirst' );
+const { upperFirst } = require( 'es-toolkit/compat' );
 
 const hostname = '127.0.0.1';
 const port = 3000;

--- a/packages/ckeditor5-style/src/styleutils.ts
+++ b/packages/ckeditor5-style/src/styleutils.ts
@@ -20,7 +20,7 @@ import type {
 } from '@ckeditor/ckeditor5-html-support';
 
 import type { StyleDefinition } from './styleconfig.js';
-import isObject from 'es-toolkit/compat/isObject';
+import { isObject } from 'es-toolkit/compat';
 
 // These are intermediate element names that can't be rendered as style preview because they don't make sense standalone.
 const NON_PREVIEWABLE_ELEMENT_NAMES = [

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesui.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesui.ts
@@ -28,7 +28,7 @@ import {
 	lengthFieldValidator,
 	lineWidthFieldValidator
 } from '../utils/ui/table-properties.js';
-import debounce from 'es-toolkit/compat/debounce';
+import { debounce } from 'es-toolkit/compat';
 import { getSelectionAffectedTableWidget, getTableWidgetAncestor } from '../utils/ui/widget.js';
 import { getBalloonCellPositionData, repositionContextualBalloon } from '../utils/ui/contextualballoon.js';
 import {

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
@@ -7,8 +7,7 @@
  * @module table/tablecolumnresize/tablecolumnresizeediting
  */
 
-import throttle from 'es-toolkit/compat/throttle';
-import isEqual from 'es-toolkit/compat/isEqual';
+import { throttle, isEqual } from 'es-toolkit/compat';
 
 import {
 	global,

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesui.ts
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesui.ts
@@ -18,7 +18,7 @@ import {
 	type LabeledFieldView
 } from '@ckeditor/ckeditor5-ui';
 
-import debounce from 'es-toolkit/compat/debounce';
+import { debounce } from 'es-toolkit/compat';
 
 import { TablePropertiesView } from './ui/tablepropertiesview.js';
 import {

--- a/packages/ckeditor5-table/src/utils/table-properties.ts
+++ b/packages/ckeditor5-table/src/utils/table-properties.ts
@@ -8,7 +8,7 @@
  */
 
 import type { BoxStyleSides } from '@ckeditor/ckeditor5-engine';
-import isObject from 'es-toolkit/compat/isObject';
+import { isObject } from 'es-toolkit/compat';
 
 /**
  * Returns a string if all four values of box sides are equal.

--- a/packages/ckeditor5-table/tests/manual/tablemocking.js
+++ b/packages/ckeditor5-table/tests/manual/tablemocking.js
@@ -9,7 +9,7 @@ import { ClassicEditor } from '@ckeditor/ckeditor5-editor-classic';
 import { _setModelData } from '@ckeditor/ckeditor5-engine';
 
 import { diffString } from 'json-diff';
-import debounce from 'es-toolkit/compat/debounce';
+import { debounce } from 'es-toolkit/compat';
 import { ArticlePluginSet } from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset.js';
 import { TableWalker } from '../../src/tablewalker.js';
 

--- a/packages/ckeditor5-typing/src/input.ts
+++ b/packages/ckeditor5-typing/src/input.ts
@@ -30,7 +30,7 @@ import {
 	type ViewDocumentInputEvent
 } from '@ckeditor/ckeditor5-engine';
 
-import debounce from 'es-toolkit/compat/debounce';
+import { debounce } from 'es-toolkit/compat';
 
 // @if CK_DEBUG_TYPING // const { _debouncedLine, _buildLogMessage } = require( '@ckeditor/ckeditor5-engine/src/dev-utils/utils.js' );
 

--- a/packages/ckeditor5-typing/src/texttransformation.ts
+++ b/packages/ckeditor5-typing/src/texttransformation.ts
@@ -19,7 +19,7 @@ import type { TextTransformationConfig, TextTypingTransformationDescription } fr
 import { Delete } from './delete.js';
 import { Input } from './input.js';
 
-import escapeRegExp from 'es-toolkit/compat/escapeRegExp';
+import { escapeRegExp } from 'es-toolkit/compat';
 
 // All named transformations.
 const TRANSFORMATIONS: Record<string, TextTypingTransformationDescription> = {

--- a/packages/ckeditor5-typing/tests/manual/beforeinput-contenteditable.js
+++ b/packages/ckeditor5-typing/tests/manual/beforeinput-contenteditable.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import debounce from 'es-toolkit/compat/debounce';
+import { debounce } from 'es-toolkit/compat';
 
 if ( window.logNative === undefined ) {
 	window.logNative = true;

--- a/packages/ckeditor5-ui/src/badge/badge.ts
+++ b/packages/ckeditor5-ui/src/badge/badge.ts
@@ -18,7 +18,7 @@ import {
 import { type View } from '../view.js';
 import { BalloonPanelView } from '../panel/balloon/balloonpanelview.js';
 
-import throttle from 'es-toolkit/compat/throttle';
+import { throttle } from 'es-toolkit/compat';
 
 // ⚠ Note, whenever changing the threshold, make sure to update the docs/support/managing-ckeditor-logo.md docs
 // as this information is also mentioned there ⚠.

--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -11,7 +11,7 @@ import { convertColor, convertToHex, registerCustomElement, type ColorPickerView
 
 import type { HexColor } from '@ckeditor/ckeditor5-core';
 import { type Locale, global, env } from '@ckeditor/ckeditor5-utils';
-import debounce from 'es-toolkit/compat/debounce';
+import { debounce } from 'es-toolkit/compat';
 import { View } from '../view.js';
 import { type InputTextView } from '../inputtext/inputtextview.js';
 import { type ViewCollection } from '../viewcollection.js';

--- a/packages/ckeditor5-ui/src/highlightedtext/highlightedtextview.ts
+++ b/packages/ckeditor5-ui/src/highlightedtext/highlightedtextview.ts
@@ -8,7 +8,7 @@
  */
 
 import { View } from '../view.js';
-import escape from 'es-toolkit/compat/escape';
+import { escape } from 'es-toolkit/compat';
 
 import '../../theme/components/highlightedtext/highlightedtext.css';
 

--- a/packages/ckeditor5-ui/src/menubar/menubarview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarview.ts
@@ -15,7 +15,7 @@ import {
 } from '@ckeditor/ckeditor5-utils';
 import { type FocusableView } from '../focuscycler.js';
 import { View } from '../view.js';
-import isObject from 'es-toolkit/compat/isObject';
+import { isObject } from 'es-toolkit/compat';
 import { ListItemView } from '../list/listitemview.js';
 import { ListSeparatorView } from '../list/listseparatorview.js';
 import { type ViewCollection } from '../viewcollection.js';

--- a/packages/ckeditor5-ui/src/menubar/utils.ts
+++ b/packages/ckeditor5-ui/src/menubar/utils.ts
@@ -34,7 +34,7 @@ import {
 	type ObservableChangeEvent,
 	type PositioningFunction
 } from '@ckeditor/ckeditor5-utils';
-import cloneDeep from 'es-toolkit/compat/cloneDeep';
+import { cloneDeep } from 'es-toolkit/compat';
 
 const NESTED_PANEL_HORIZONTAL_OFFSET = 5;
 

--- a/packages/ckeditor5-ui/src/model.ts
+++ b/packages/ckeditor5-ui/src/model.ts
@@ -8,7 +8,7 @@
  */
 
 import { ObservableMixin } from '@ckeditor/ckeditor5-utils';
-import extend from 'es-toolkit/compat/extend';
+import { extend } from 'es-toolkit/compat';
 
 /**
  * The base MVC model class.

--- a/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
@@ -26,7 +26,7 @@ import {
 	type PositioningFunction
 } from '@ckeditor/ckeditor5-utils';
 
-import isElement from 'es-toolkit/compat/isElement';
+import { isElement } from 'es-toolkit/compat';
 import '../../../theme/components/panel/balloonpanel.css';
 
 const toPx = /* #__PURE__ */ toUnit( 'px' );

--- a/packages/ckeditor5-ui/src/search/text/searchtextview.ts
+++ b/packages/ckeditor5-ui/src/search/text/searchtextview.ts
@@ -13,7 +13,7 @@ import { SearchTextQueryView, type SearchTextQueryViewConfig } from './searchtex
 import { SearchInfoView } from '../searchinfoview.js';
 import { SearchResultsView } from '../searchresultsview.js';
 import { FocusCycler, type FocusableView } from '../../focuscycler.js';
-import escapeRegExp from 'es-toolkit/compat/escapeRegExp';
+import { escapeRegExp } from 'es-toolkit/compat';
 
 import { type FilteredView } from '../filteredview.js';
 import { type ViewCollection } from '../../viewcollection.js';

--- a/packages/ckeditor5-ui/src/template.ts
+++ b/packages/ckeditor5-ui/src/template.ts
@@ -21,8 +21,7 @@ import {
 	type ObservableChangeEvent
 } from '@ckeditor/ckeditor5-utils';
 
-import isObject from 'es-toolkit/compat/isObject';
-import cloneDeepWith from 'es-toolkit/compat/cloneDeepWith';
+import { isObject, cloneDeepWith } from 'es-toolkit/compat';
 
 const xhtmlNs = 'http://www.w3.org/1999/xhtml';
 

--- a/packages/ckeditor5-ui/src/toolbar/balloon/balloontoolbar.ts
+++ b/packages/ckeditor5-ui/src/toolbar/balloon/balloontoolbar.ts
@@ -40,7 +40,7 @@ import {
 	type ModelSchema
 } from '@ckeditor/ckeditor5-engine';
 
-import debounce from 'es-toolkit/compat/debounce';
+import { debounce } from 'es-toolkit/compat';
 
 const toPx = /* #__PURE__ */ toUnit( 'px' );
 

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.ts
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.ts
@@ -47,7 +47,7 @@ import {
 } from '@ckeditor/ckeditor5-icons';
 import type { ToolbarConfig, ToolbarConfigItem } from '@ckeditor/ckeditor5-core';
 
-import isObject from 'es-toolkit/compat/isObject';
+import { isObject } from 'es-toolkit/compat';
 
 import '../../theme/components/toolbar/toolbar.css';
 

--- a/packages/ckeditor5-ui/src/tooltipmanager.ts
+++ b/packages/ckeditor5-ui/src/tooltipmanager.ts
@@ -22,8 +22,7 @@ import {
 
 import type { Editor } from '@ckeditor/ckeditor5-core';
 
-import isElement from 'es-toolkit/compat/isElement';
-import debounce from 'es-toolkit/compat/debounce';
+import { isElement, debounce } from 'es-toolkit/compat';
 
 import '../theme/components/tooltip/tooltip.css';
 

--- a/packages/ckeditor5-utils/src/config.ts
+++ b/packages/ckeditor5-utils/src/config.ts
@@ -7,9 +7,7 @@
  * @module utils/config
  */
 
-import isPlainObject from 'es-toolkit/compat/isPlainObject';
-import isElement from 'es-toolkit/compat/isElement';
-import cloneDeepWith from 'es-toolkit/compat/cloneDeepWith';
+import { isPlainObject, isElement, cloneDeepWith } from 'es-toolkit/compat';
 
 /**
  * Handles a configuration dictionary.

--- a/packages/ckeditor5-utils/src/dom/createelement.ts
+++ b/packages/ckeditor5-utils/src/dom/createelement.ts
@@ -8,7 +8,7 @@
  */
 
 import { isIterable } from '../isiterable.js';
-import isString from 'es-toolkit/compat/isString';
+import { isString } from 'es-toolkit/compat';
 
 /**
  * Attributes to be applied to the HTML element.

--- a/packages/ckeditor5-utils/src/dom/position.ts
+++ b/packages/ckeditor5-utils/src/dom/position.ts
@@ -10,7 +10,7 @@
 import { global } from './global.js';
 import { Rect, type RectSource } from './rect.js';
 import { getPositionedAncestor } from './getpositionedancestor.js';
-import isFunction from 'es-toolkit/compat/isFunction';
+import { isFunction } from 'es-toolkit/compat';
 
 // @if CK_DEBUG_POSITION // const {
 // @if CK_DEBUG_POSITION // 	default: RectDrawer,

--- a/packages/ckeditor5-utils/src/focustracker.ts
+++ b/packages/ckeditor5-utils/src/focustracker.ts
@@ -11,7 +11,7 @@ import { DomEmitterMixin } from './dom/emittermixin.js';
 import { ObservableMixin } from './observablemixin.js';
 import { CKEditorError } from './ckeditorerror.js';
 import type { View } from '@ckeditor/ckeditor5-ui';
-import _isElement from 'es-toolkit/compat/isElement';
+import { isElement as _isElement } from 'es-toolkit/compat';
 
 /**
  * Allows observing a group of DOM `Element`s or {@link module:ui/view~View view instances} whether at least one of them (or their child)

--- a/packages/ckeditor5-utils/src/observablemixin.ts
+++ b/packages/ckeditor5-utils/src/observablemixin.ts
@@ -13,7 +13,7 @@ import { EmitterMixin, type Emitter } from './emittermixin.js';
 import { CKEditorError } from './ckeditorerror.js';
 import type { Constructor, Mixed } from './mix.js';
 
-import isObject from 'es-toolkit/compat/isObject';
+import { isObject } from 'es-toolkit/compat';
 
 const observablePropertiesSymbol = Symbol( 'observableProperties' );
 const boundObservablesSymbol = Symbol( 'boundObservables' );

--- a/packages/ckeditor5-utils/src/translation-service.ts
+++ b/packages/ckeditor5-utils/src/translation-service.ts
@@ -10,7 +10,7 @@
 import type { Translations } from './locale.js';
 import { CKEditorError } from './ckeditorerror.js';
 import { global } from './dom/global.js';
-import merge from 'es-toolkit/compat/merge';
+import { merge } from 'es-toolkit/compat';
 import { type ArrayOrItem } from './toarray.js';
 
 declare global {

--- a/packages/ckeditor5-utils/tests/lodash.js
+++ b/packages/ckeditor5-utils/tests/lodash.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import extend from 'es-toolkit/compat/extend';
+import { extend } from 'es-toolkit/compat';
 
 describe( 'utils', () => {
 	describe( 'extend()', () => {

--- a/packages/ckeditor5-watchdog/src/actionsrecorder.ts
+++ b/packages/ckeditor5-watchdog/src/actionsrecorder.ts
@@ -27,7 +27,7 @@ import type {
 	ActionsRecorderMaxEntriesCallback
 } from './actionsrecorderconfig.js';
 
-import isPlainObject from 'es-toolkit/compat/isPlainObject';
+import { isPlainObject } from 'es-toolkit/compat';
 
 /**
  * A plugin that records user actions and editor state changes for debugging purposes. It tracks commands execution, model operations,

--- a/packages/ckeditor5-watchdog/src/editorwatchdog.ts
+++ b/packages/ckeditor5-watchdog/src/editorwatchdog.ts
@@ -7,9 +7,7 @@
  * @module watchdog/editorwatchdog
  */
 
-import throttle from 'es-toolkit/compat/throttle';
-import cloneDeepWith from 'es-toolkit/compat/cloneDeepWith';
-import isElement from 'es-toolkit/compat/isElement';
+import { throttle, cloneDeepWith, isElement } from 'es-toolkit/compat';
 import { areConnectedThroughProperties } from './utils/areconnectedthroughproperties.js';
 import { Watchdog, type WatchdogConfig } from './watchdog.js';
 import type { CKEditorError } from '@ckeditor/ckeditor5-utils';

--- a/packages/ckeditor5-widget/src/widgetresize.ts
+++ b/packages/ckeditor5-widget/src/widgetresize.ts
@@ -40,7 +40,7 @@ import {
 	type EventInfo
 } from '@ckeditor/ckeditor5-utils';
 
-import throttle from 'es-toolkit/compat/throttle';
+import { throttle } from 'es-toolkit/compat';
 
 import '../theme/widgetresize.css';
 

--- a/packages/ckeditor5-word-count/src/wordcount.ts
+++ b/packages/ckeditor5-word-count/src/wordcount.ts
@@ -15,8 +15,7 @@ import { env } from '@ckeditor/ckeditor5-utils';
 import { modelElementToPlainText } from './utils.js';
 import type { WordCountConfig } from './wordcountconfig.js';
 
-import throttle from 'es-toolkit/compat/throttle';
-import isElement from 'es-toolkit/compat/isElement';
+import { throttle, isElement } from 'es-toolkit/compat';
 
 /**
  * The word count plugin.


### PR DESCRIPTION
### 🚀 Summary

Migrate back to `es-toolkit/compat` barrel import to fix tree-shaking regression.

---

### 📌 Related issues

N/A

---

### 💡 Additional information

Our automated monitoring reported tree-shaking regression caused by https://github.com/ckeditor/ckeditor5/pull/19963.

This PR partially reverts this PR. We still upgrade to `es-toolkit@1.45.1` but we are going back to the `es-toolkit/compat` imports. I also added an ESLint rule to prevent importing from `es-toolkit` as it's a different implementation from `es-toolkit/compat`.

I will work with the `es-toolkit` team to address this issue.
