### PR TITLE
Fix: Add missing vertical margin to code block content styles

### DIFF
--- a/.changelog/20260319120000_ck_19982.md
+++ b/.changelog/20260319120000_ck_19982.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-code-block
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/19982
+---
+
+Code block content styles now include an explicit `0.9em` vertical margin, consistent with other block widgets (image, table, media embed, HTML embed).

--- a/packages/ckeditor5-code-block/theme/codeblock.css
+++ b/packages/ckeditor5-code-block/theme/codeblock.css
@@ -36,6 +36,10 @@
 	border: 1px solid hsl(0, 0%, 77%);
 	border-radius: 2px;
 
+	/* The first value should be equal to --ck-spacing-large variable if used in the editor context
+	to avoid the content jumping (See https://github.com/ckeditor/ckeditor5/issues/9825). */
+	margin: 0.9em 0;
+
 	/* Code block are language direction–agnostic. */
 	text-align: left;
 	direction: ltr;


### PR DESCRIPTION
### 🚀 Summary

Code block (`<pre>`) content styles were missing an explicit vertical margin, unlike all other block widgets (image, table, media embed, HTML embed) which use `margin: 0.9em`. The `<pre>` element was relying on browser default margins instead.

This adds `margin: 0.9em 0` to `.ck-content pre` for consistency.

---

### 📌 Related issues

* Closes #19982

---

### 💡 Additional information

All other block widgets already set `0.9em` vertical margin with the same `--ck-spacing-large` / #9825 comment. This simply aligns code blocks with that convention.

---

### 🧾 Checklists

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?