### PR TITLE
Fix for excessive word breaking in tables rendered in the content area.

### DIFF
--- a/.changelog/20260324102547_ck_19986.md
+++ b/.changelog/20260324102547_ck_19986.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-core
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/19986
+---
+
+Fixed excessive word breaking in tables rendered in the content area. Words will now only break when they genuinely overflow their container, preventing awkward splits in narrow table columns.

--- a/.changelog/20260324102741_ck_19986.md
+++ b/.changelog/20260324102741_ck_19986.md
@@ -1,0 +1,9 @@
+---
+type: Minor breaking change
+scope:
+  - ckeditor5-core
+see:
+  - https://github.com/ckeditor/ckeditor5/issues/19986
+---
+
+The default word breaking behavior in the content area has been updated to prevent unwanted breaks in tables. If you customized the `--ck-content-word-break` CSS variable in your integration, migrate to the new `--ck-content-overflow-wrap` variable to retain the same effect.

--- a/packages/ckeditor5-core/theme/core.css
+++ b/packages/ckeditor5-core/theme/core.css
@@ -9,7 +9,8 @@
 	/* stylelint-disable-next-line declaration-property-value-disallowed-list */
 	--ck-content-font-color: #000;
 	--ck-content-line-height: 1.5;
-	--ck-content-word-break: break-word;
+	--ck-content-word-break: normal;
+	--ck-content-overflow-wrap: break-word;
 }
 
 .ck-content {
@@ -18,4 +19,5 @@
 	color: var(--ck-content-font-color);
 	line-height: var(--ck-content-line-height);
 	word-break: var(--ck-content-word-break);
+	overflow-wrap: var(--ck-content-overflow-wrap);
 }


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

*This PR updates the word breaking behavior in the `.ck-content` area.
The `--ck-content-word-break` CSS variable has been reset to `normal` to prevent words from breaking unnecessarily in tables, particularly in layouts with many columns or a fixed 100% width.
A new `--ck-content-overflow-wrap` variable has been introduced as a spec-compliant replacement, ensuring words still break when they genuinely overflow their container; such as long URLs or unbreakable strings. Integrations overriding `--ck-content-word-break` should migrate to the new variable to retain the intended behavior.*

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes https://github.com/ckeditor/ckeditor5/issues/19986

---

### 💡 Additional information

⚠️ Target branch: `release` ⚠️ 

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [ ] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
