### PR TITLE
The emoji panel now renders correctly on narrow screens.

### DIFF
--- a/.changelog/20260408075851_ck_18552.md
+++ b/.changelog/20260408075851_ck_18552.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-emoji
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/18552
+---
+
+The emoji panel now renders correctly on narrow screens.

--- a/packages/ckeditor5-emoji/src/ui/emojipickerformview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojipickerformview.ts
@@ -95,8 +95,7 @@ export class EmojiPickerFormView extends View {
 				class: [
 					'ck',
 					'ck-form',
-					'ck-emoji-picker-form',
-					'ck-responsive-form'
+					'ck-emoji-picker-form'
 				],
 
 				// https://github.com/ckeditor/ckeditor5-link/issues/90

--- a/packages/ckeditor5-emoji/tests/ui/emojipickerformview.js
+++ b/packages/ckeditor5-emoji/tests/ui/emojipickerformview.js
@@ -30,7 +30,6 @@ describe( 'EmojiPickerFormView', () => {
 			expect( view.element.classList.contains( 'ck' ) ).to.be.true;
 			expect( view.element.classList.contains( 'ck-form' ) ).to.be.true;
 			expect( view.element.classList.contains( 'ck-emoji-picker-form' ) ).to.be.true;
-			expect( view.element.classList.contains( 'ck-responsive-form' ) ).to.be.true;
 		} );
 
 		it( 'should create child views', () => {


### PR DESCRIPTION
### 🚀 Summary

The emoji panel now renders correctly on narrow screens.

---

### 📌 Related issues

* Closes #18552

---

### 💡 Additional information

#### Before

<img width="489" height="635" alt="image" src="https://github.com/user-attachments/assets/b83c8e30-d8a2-4eb6-9067-8d637ffec4cb" />

#### After

<img width="489" height="635" alt="image" src="https://github.com/user-attachments/assets/2650bee8-98e2-4985-b04d-56792be09641" />

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [x] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
