### PR TITLE
Fix: Menu bar stays open after clicking the "Fullscreen mode" item

### DIFF
--- a/.changelog/20260410084302_ck_20056.md
+++ b/.changelog/20260410084302_ck_20056.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-ui
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/20056
+---
+
+The menu bar no longer stays open after clicking the "Fullscreen mode" menu item when entering fullscreen mode.

--- a/packages/ckeditor5-ui/src/menubar/menubarview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarview.ts
@@ -168,6 +168,10 @@ export class MenuBarView extends View implements FocusableView {
 		for ( const topLevelCategoryMenuView of this.children ) {
 			topLevelCategoryMenuView.isOpen = false;
 		}
+
+		// Set isOpen synchronously to prevent deferred events (e.g. mouseenter fired by the browser
+		// after DOM manipulations) from re-opening menus via `toggleMenusAndFocusItemsOnHover`.
+		this.isOpen = false;
 	}
 
 	/**

--- a/packages/ckeditor5-ui/tests/menubar/menubarview.js
+++ b/packages/ckeditor5-ui/tests/menubar/menubarview.js
@@ -2198,6 +2198,41 @@ describe( 'MenuBarView', () => {
 			expect( getMenuByLabel( menuBarView, 'Edit' ).isOpen ).to.be.false;
 			expect( getMenuByLabel( menuBarView, 'Format' ).isOpen ).to.be.false;
 		} );
+
+		it( 'should synchronously set #isOpen to false without waiting for the timeout in _setupIsOpenUpdater', () => {
+			menuBarView.fillFromConfig( normalizeMenuBarConfig( {
+				items: [
+					{
+						menuId: 'edit',
+						label: 'Edit',
+						groups: [
+							{
+								groupId: '1',
+								items: [
+									'item1'
+								]
+							}
+						]
+					}
+				]
+			} ), factory );
+
+			menuBarView.render();
+
+			getMenuByLabel( menuBarView, 'Edit' ).isOpen = true;
+
+			// Wait for the _setupIsOpenUpdater timeout to update isOpen to true.
+			return wait( 0 ).then( () => {
+				expect( menuBarView.isOpen ).to.be.true;
+
+				menuBarView.close();
+
+				// isOpen must be false synchronously, before any pending timeouts fire.
+				// This prevents deferred browser mouseenter events (e.g. after a DOM move)
+				// from re-opening menus via toggleMenusAndFocusItemsOnHover.
+				expect( menuBarView.isOpen ).to.be.false;
+			} );
+		} );
 	} );
 
 	describe( 'disable()', () => {


### PR DESCRIPTION
### 🚀 Summary

`MenuBarView.close()` now synchronously sets `this.isOpen = false`, preventing a deferred browser `mouseenter` event (fired after a DOM move during fullscreen entry) from re-opening the previously open menu via `toggleMenusAndFocusItemsOnHover`.

Previously, when the user clicked **View → Fullscreen mode** in the Decoupled editor with the menu bar visible, the View menu remained open after entering fullscreen. The root cause: `_setupIsOpenUpdater` defers the `isOpen = false` update via `setTimeout(0)`. In that ~9 ms window, `moveToFullscreen` moves the menu bar DOM element, the browser fires a stale `mouseenter` event at its new position, and `toggleMenusAndFocusItemsOnHover` sees `menuBarView.isOpen === true` and re-opens the menu.

The fix forces `isOpen` to `false` immediately in `close()` so the deferred event finds the bar already closed.

---

### 📌 Related issues

* Closes #20056

---

### 💡 Additional information

The fix is in `MenuBarView.close()` (`ckeditor5-ui`). The priority change in `FullscreenUI` (`ckeditor5-fullscreen`) is a secondary safeguard but does not affect the open/external ckeditor5 repo scope.

A regression test was added to `menubarview.js` verifying that `menuBarView.isOpen` is `false` synchronously after `close()`, without waiting for the `_setupIsOpenUpdater` timeout.

---

### 🧾 Checklists

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [x] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [x] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.