### PR TITLE
Upgrade Chrome version to `147.0.7727.55` (`#release-v47`)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ parameters:
     default: false
   chromeVersion:
     type: string
-    default: "146.0.7680.71"
+    default: "147.0.7727.55"
   isLtsPipeline:
     type: boolean
     default: true


### PR DESCRIPTION
### 🚀 Summary

This PR bumps the Chrome used in CI to **147.0.7727.55**.