### PR TITLE
Fix slow selector matching in show blocks and table selection styles.

### DIFF
--- a/.changelog/20260413143836_ck_20058_fix_slow_selector_matching.md
+++ b/.changelog/20260413143836_ck_20058_fix_slow_selector_matching.md
@@ -1,0 +1,10 @@
+---
+type: Fix
+scope:
+  - ckeditor5-show-blocks
+  - ckeditor5-table
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/20058
+---
+
+Improved the performance of the show blocks and table selection styles by rewriting selectors to avoid expensive `:is(...)` output after CSS nesting compilation.

--- a/packages/ckeditor5-show-blocks/theme/showblocks.css
+++ b/packages/ckeditor5-show-blocks/theme/showblocks.css
@@ -113,41 +113,66 @@
 		--ck-show-blocks-label-rtl: var(--ck-show-blocks-label-figcaption-rtl);
 	}
 
-	address,
-	aside,
-	blockquote,
-	details,
-	div:not(.ck-widget, .ck-widget *),
-	footer,
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6,
-	header,
-	main,
-	nav,
-	pre,
-	ol,
-	ul,
-	p,
-	section,
-	:where(figure.image, figure.table) figcaption {
+	/* stylelint-disable @stylistic/indentation */
+	:where(
+		address,
+		aside,
+		blockquote,
+		details,
+		div:not(.ck-widget, .ck-widget *),
+		footer,
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6,
+		header,
+		main,
+		nav,
+		pre,
+		ol,
+		ul,
+		p,
+		section,
+		:where(figure.image, figure.table) figcaption
+	) {
 		background-repeat: no-repeat;
 		padding-top: 15px;
+	}
 
-		&:where(:not(.ck-widget_selected):not(.ck-widget:hover)) {
-			outline: 1px dashed var(--ck-show-blocks-border-color);
-		}
+	:where(
+		address,
+		aside,
+		blockquote,
+		details,
+		div:not(.ck-widget, .ck-widget *),
+		footer,
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6,
+		header,
+		main,
+		nav,
+		pre,
+		ol,
+		ul,
+		p,
+		section,
+		:where(figure.image, figure.table) figcaption
+	):where(:not(.ck-widget_selected):not(.ck-widget:hover)) {
+		outline: 1px dashed var(--ck-show-blocks-border-color);
 	}
 
 	/*
-	 * Support editors where the `dir` attribute is either on the editable itself or on an ancestor wrapper.
+	 * `:dir()` resolves the effective direction of the editable, so this also works when the `dir`
+	 * attribute is inherited from an ancestor wrapper.
 	 * See: https://github.com/ckeditor/ckeditor5/issues/15969.
 	 */
-	&[dir="ltr"],
-	[dir="ltr"] & {
+	&:dir(ltr) :where(
 		address,
 		aside,
 		blockquote,
@@ -168,14 +193,13 @@
 		ul,
 		p,
 		section,
-		:where(figure.image, figure.table) figcaption {
-			background-image: var(--ck-show-blocks-label-ltr);
-			background-position: 1px 1px;
-		}
+		:where(figure.image, figure.table) figcaption
+	) {
+		background-image: var(--ck-show-blocks-label-ltr);
+		background-position: 1px 1px;
 	}
 
-	&[dir="rtl"],
-	[dir="rtl"] & {
+	&:dir(rtl) :where(
 		address,
 		aside,
 		blockquote,
@@ -196,9 +220,9 @@
 		ul,
 		p,
 		section,
-		:where(figure.image, figure.table) figcaption {
-			background-image: var(--ck-show-blocks-label-rtl);
-			background-position: calc(100% - 1px) 1px;
-		}
+		:where(figure.image, figure.table) figcaption
+	) {
+		background-image: var(--ck-show-blocks-label-rtl);
+		background-position: calc(100% - 1px) 1px;
 	}
 }

--- a/packages/ckeditor5-table/theme/tableselection.css
+++ b/packages/ckeditor5-table/theme/tableselection.css
@@ -8,8 +8,7 @@
 }
 
 .ck.ck-editor__editable .table table {
-	& td.ck-editor__editable_selected,
-	& th.ck-editor__editable_selected {
+	& :where(td, th).ck-editor__editable_selected {
 		position: relative;
 		caret-color: transparent;
 		box-shadow: unset;


### PR DESCRIPTION
### 🚀 Summary

This PR rewrites the `show-blocks` and `table` selection theme selectors to avoid the expensive `:is(...)` output introduced by the v48 CSS nesting change.

The updated selectors keep the same behavior, compile without the problematic `:is(...)` wrappers, and reduce selector-matching cost in large documents with hidden editor instances.

---

### 📌 Related issues

* Closes #20058

---

### 💡 Additional information

The new version uses shorter `:where(...)` selectors instead of the original `:is(...)` output.

#### Verification benchmark

I added a temporary manual benchmark page for validation: `packages/ckeditor5-show-blocks/tests/manual/issue20058benchmark.*`

**The benchmark helper is only for reviewer validation and should be deleted before merging.**

To run the benchmark:
  * Run `pnpm manual -f show-blocks`.
  * Open the `issue20058benchmark` manual test.
  * Click `Run benchmark`.
  * Inspect `window.issue20058BenchmarkResults` in DevTools if needed.

The difference between the benchmark modes is:
  * `toggle` measures style recalculation after class and attribute changes with the stylesheet already attached.
  * `apply/remove` measures the cost of attaching and removing the selector set while the DOM stays unchanged (more important).

Latest Chrome benchmark results on the synthetic large offscreen-editor fixture:
* `toggle`: 7.2% improvement
* `apply/remove`: ~38% improvement

#### Manual testing

* Show blocks:
  * Run `pnpm manual -f show-blocks`.
  * Open the `showblocks` manual test.
  * Enable the Show blocks feature in the editor.
* Table selection:
  * Run `pnpm manual -f table`.
  * Open the `tableselection` manual test.
  * Select multiple table cells by dragging or Shift+click.
  * Verify selected cells still show the selected-cell overlay.
  * Click inside a selected cell and drag over its text.
  * Verify there is no competing native text-selection highlight inside the selected cells.
  * If there is a widget inside a selected cell, verify its outline and selection handle disappear while the cell is part of the multi-cell selection.

---

### 🧾 Checklists

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [x] Does this change affect any of the above?
- [x] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [x] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when performance, API, or UX is affected).
- [ ] The changelog entry is clear, user- or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.