### PR TITLE
Fix whitespace loss in inlined docs demos

### DIFF
--- a/scripts/docs/snippetadapter.mjs
+++ b/scripts/docs/snippetadapter.mjs
@@ -276,22 +276,19 @@ async function buildDocuments( snippets, paths, constants, imports, getSnippetPl
 
 			documentContent = documentContent.replace(
 				getSnippetPlaceholder( snippet.snippetName ),
-				() => `
-					<div class="doc live-snippet ${ snippetSizeCssClass }">${ data }</div>
-					<script>
-						(function() {
-							const el = document.currentScript.previousElementSibling;
-
-							el.dispatchEvent( new CustomEvent( 'ck:snippet-transform', {
-								bubbles: true,
-								detail: { snippet: el }
-							} ) );
-						})();
-					</script>
-				`
-					.split( '\n' )
-					.map( line => line.trim() )
-					.join( '\n' )
+				() => [
+					`<div class="doc live-snippet ${ snippetSizeCssClass }">${ data }</div>`,
+					'<script>',
+					'(function() {',
+					'	const el = document.currentScript.previousElementSibling;',
+					'',
+					'\tel.dispatchEvent( new CustomEvent( \'ck:snippet-transform\', {',
+					'\t\tbubbles: true,',
+					'\t\tdetail: { snippet: el }',
+					'\t} ) );',
+					'})();',
+					'</script>'
+				].join( '\n' )
 			);
 
 			if ( await fileExists( upath.join( snippet.outputPath, snippet.snippetName, 'snippet.css' ) ) ) {

--- a/scripts/docs/snippetadapter.mjs
+++ b/scripts/docs/snippetadapter.mjs
@@ -280,12 +280,8 @@ async function buildDocuments( snippets, paths, constants, imports, getSnippetPl
 					`<div class="doc live-snippet ${ snippetSizeCssClass }">${ data }</div>`,
 					'<script>',
 					'(function() {',
-					'	const el = document.currentScript.previousElementSibling;',
-					'',
-					'\tel.dispatchEvent( new CustomEvent( \'ck:snippet-transform\', {',
-					'\t\tbubbles: true,',
-					'\t\tdetail: { snippet: el }',
-					'\t} ) );',
+					'  const snippet = document.currentScript.previousElementSibling;',
+					'  snippet.dispatchEvent( new CustomEvent( "ck:snippet-transform", { bubbles: true, detail: { snippet } } ) );',
 					'})();',
 					'</script>'
 				].join( '\n' )


### PR DESCRIPTION
### 🚀 Summary

* Preserve raw snippet HTML when inlining snippet placeholders in docs pages.
* Avoid stripping leading indentation from `<textarea>`-based demo sources, which restores formatting in generated code block demos.

---

### 📌 Related issues

* Closes https://github.com/cksource/umberto/issues/1455

---

### 💡 Additional information

:warning: PR targets the `stable` branch :warning:

Testing steps:

1. Run `pnpm run docs --skip-api && pnpm run docs:serve`
2. Open the editor example on https://127.0.0.1:8080/ckeditor5/latest/features/code-blocks.html

---

### 🧾 Checklists

#### Author checklist

- [x] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g., architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when performance, API, or UX is affected).
- [ ] The changelog entry is clear, user- or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [x] The target branch is correct.