### PR TITLE
Mark LTS releases as non-latest

### DIFF
--- a/scripts/release/publishpackages.mjs
+++ b/scripts/release/publishpackages.mjs
@@ -96,7 +96,8 @@ const tasks = new Listr( [
 			const releaseUrl = await releaseTools.createGithubRelease( {
 				token: githubToken,
 				version: latestVersion,
-				description: versionChangelog
+				description: versionChangelog,
+				isLatest: false
 			} );
 
 			task.output = `Release page: ${ releaseUrl }`;


### PR DESCRIPTION
### 🚀 Summary

Mark LTS releases as non-latest.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-internal/issues/4403.