### PR TITLE
Reverted changes to editor destroy method signature.

### DIFF
--- a/packages/ckeditor5-core/src/editor/editor.ts
+++ b/packages/ckeditor5-core/src/editor/editor.ts
@@ -885,7 +885,7 @@ export abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 	 * @fires destroy
 	 * @returns A promise that resolves once the editor instance is fully destroyed.
 	 */
-	public async destroy(): Promise<void> {
+	public async destroy(): Promise<unknown> {
 		if ( this.state == 'initializing' ) {
 			await new Promise( resolve => this.once<EditorReadyEvent>( 'ready', resolve ) );
 		}
@@ -904,6 +904,10 @@ export abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 		// Remove the editor from the context.
 		// When the context was created by this editor, the context will be destroyed.
 		await this._context._removeEditor( this );
+
+		// To satisfy the return type and to keep it backward compatible.
+		// eslint-disable-next-line no-useless-return
+		return;
 	}
 
 	/**

--- a/packages/ckeditor5-core/src/editor/editorconfig.ts
+++ b/packages/ckeditor5-core/src/editor/editorconfig.ts
@@ -1249,7 +1249,7 @@ export interface RootConfig {
 	 * need a root with different schema rules — for example, a root that restricts or extends what content is allowed
 	 * at the top level.
 	 *
-	 * The element name must be registered in the {@link module:engine/model/schema~Schema schema} before or during
+	 * The element name must be registered in the {@link module:engine/model/schema~ModelSchema schema} before or during
 	 * editor initialization. See the {@glink framework/deep-dive/schema "Schema"} guide for more information about
 	 * generic items like `$root` and `$inlineRoot`.
 	 *

--- a/packages/ckeditor5-editor-balloon/src/ballooneditor.ts
+++ b/packages/ckeditor5-editor-balloon/src/ballooneditor.ts
@@ -122,7 +122,7 @@ export class BalloonEditor extends /* #__PURE__ */ ElementApiMixin( Editor ) {
 	 * {@link module:core/editor/editorconfig~EditorConfig#updateSourceElementOnDestroy `updateSourceElementOnDestroy`}
 	 * configuration option is set to `true`.
 	 */
-	public override async destroy(): Promise<void> {
+	public override async destroy(): Promise<unknown> {
 		// Cache the data, then destroy.
 		// It's safe to assume that the model->view conversion will not work after super.destroy().
 		const data = this.getData();
@@ -134,6 +134,10 @@ export class BalloonEditor extends /* #__PURE__ */ ElementApiMixin( Editor ) {
 		if ( this.sourceElement ) {
 			this.updateSourceElement( data );
 		}
+
+		// To satisfy the return type and to keep it backward compatible.
+		// eslint-disable-next-line no-useless-return
+		return;
 	}
 
 	/**

--- a/packages/ckeditor5-editor-classic/src/classiceditor.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditor.ts
@@ -124,7 +124,7 @@ export class ClassicEditor extends /* #__PURE__ */ ElementApiMixin( Editor ) {
 	 * {@link module:core/editor/editorconfig~EditorConfig#updateSourceElementOnDestroy `updateSourceElementOnDestroy`}
 	 * configuration option is set to `true`.
 	 */
-	public override async destroy(): Promise<void> {
+	public override async destroy(): Promise<unknown> {
 		if ( this.sourceElement ) {
 			this.updateSourceElement();
 		}
@@ -132,6 +132,10 @@ export class ClassicEditor extends /* #__PURE__ */ ElementApiMixin( Editor ) {
 		this.ui.destroy();
 
 		await super.destroy();
+
+		// To satisfy the return type and to keep it backward compatible.
+		// eslint-disable-next-line no-useless-return
+		return;
 	}
 
 	/**

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitor.ts
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitor.ts
@@ -141,7 +141,7 @@ export class DecoupledEditor extends /* #__PURE__ */ ElementApiMixin( Editor ) {
 	 * 	} );
 	 * ```
 	 */
-	public override async destroy(): Promise<void> {
+	public override async destroy(): Promise<unknown> {
 		// Cache the data, then destroy.
 		// It's safe to assume that the model->view conversion will not work after super.destroy().
 		const data = this.getData();
@@ -153,6 +153,10 @@ export class DecoupledEditor extends /* #__PURE__ */ ElementApiMixin( Editor ) {
 		if ( this.sourceElement ) {
 			this.updateSourceElement( data );
 		}
+
+		// To satisfy the return type and to keep it backward compatible.
+		// eslint-disable-next-line no-useless-return
+		return;
 	}
 
 	/**

--- a/packages/ckeditor5-editor-inline/src/inlineeditor.ts
+++ b/packages/ckeditor5-editor-inline/src/inlineeditor.ts
@@ -123,7 +123,7 @@ export class InlineEditor extends /* #__PURE__ */ ElementApiMixin( Editor ) {
 	 * {@link module:core/editor/editorconfig~EditorConfig#updateSourceElementOnDestroy `updateSourceElementOnDestroy`}
 	 * configuration option is set to `true`.
 	 */
-	public override async destroy(): Promise<void> {
+	public override async destroy(): Promise<unknown> {
 		// Cache the data, then destroy.
 		// It's safe to assume that the model->view conversion will not work after super.destroy().
 		const data = this.getData();
@@ -135,6 +135,10 @@ export class InlineEditor extends /* #__PURE__ */ ElementApiMixin( Editor ) {
 		if ( this.sourceElement ) {
 			this.updateSourceElement( data );
 		}
+
+		// To satisfy the return type and to keep it backward compatible.
+		// eslint-disable-next-line no-useless-return
+		return;
 	}
 
 	/**

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -327,7 +327,7 @@ export class MultiRootEditor extends Editor {
 	 * } );
 	 * ```
 	 */
-	public override async destroy(): Promise<void> {
+	public override async destroy(): Promise<unknown> {
 		const shouldUpdateSourceElement = this.config.get( 'updateSourceElementOnDestroy' );
 		// Cache the data and editable DOM elements, then destroy.
 		// It's safe to assume that the model->view conversion will not work after `super.destroy()`,
@@ -345,6 +345,10 @@ export class MultiRootEditor extends Editor {
 		for ( const rootName of Object.keys( this.sourceElements ) ) {
 			setDataInElement( this.sourceElements[ rootName ], data[ rootName ] );
 		}
+
+		// To satisfy the return type and to keep it backward compatible.
+		// eslint-disable-next-line no-useless-return
+		return;
 	}
 
 	/**


### PR DESCRIPTION
### 🚀 Summary

Reverted changes to the editor destroy method signature to avoid breaking change.

---

### 📌 Related issues

* See #20026

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [ ] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
