### PR TITLE
Extend autoformat for lists to accept any number.

### DIFF
--- a/packages/ckeditor5-autoformat/src/autoformat.ts
+++ b/packages/ckeditor5-autoformat/src/autoformat.ts
@@ -73,7 +73,10 @@ export class Autoformat extends Plugin {
 	 *
 	 * When typed:
 	 * - `* ` or `- ` &ndash; A paragraph will be changed into a bulleted list.
-	 * - `1. ` or `1) ` &ndash; A paragraph will be changed into a numbered list ("1" can be any digit or a list of digits).
+	 * - `<number>. ` or `<number>) ` &ndash; A paragraph will be changed into a numbered list.
+	 * If the paragraph is adjacent to an existing list, the typed number is ignored and the item joins the list
+	 * as the next sequential item. Otherwise, a new list is created with the `listStart` attribute set to the typed number
+	 * (when the {@link module:list/listproperties~ListProperties start index feature} is enabled).
 	 * - `[] ` or `[ ] ` &ndash; A paragraph will be changed into a to-do list.
 	 * - `[x] ` or `[ x ] ` &ndash; A paragraph will be changed into a checked to-do list.
 	 */
@@ -85,7 +88,19 @@ export class Autoformat extends Plugin {
 		}
 
 		if ( commands.get( 'numberedList' ) ) {
-			blockAutoformatEditing( this.editor, this, /^1[.|)]\s$/, 'numberedList' );
+			const numberedListCommand = commands.get( 'numberedList' )!;
+			const hasStartIndexFeature = !!commands.get( 'listStart' );
+
+			blockAutoformatEditing( this.editor, this, /^(\d+)[.|)]\s$/, ( { match } ) => {
+				if ( !numberedListCommand.isEnabled || numberedListCommand.value === true ) {
+					return false;
+				}
+
+				this.editor.execute( 'numberedList', hasStartIndexFeature ?
+					{ additionalAttributes: { listStart: parseInt( match[ 1 ] ) } } :
+					undefined
+				);
+			} );
 		}
 
 		if ( commands.get( 'todoList' ) ) {

--- a/packages/ckeditor5-autoformat/tests/autoformat.js
+++ b/packages/ckeditor5-autoformat/tests/autoformat.js
@@ -6,7 +6,7 @@
 import { Autoformat } from '../src/autoformat.js';
 
 import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
-import { ListEditing, TodoListEditing } from '@ckeditor/ckeditor5-list';
+import { ListEditing, ListPropertiesEditing, TodoListEditing } from '@ckeditor/ckeditor5-list';
 import { HeadingEditing, HeadingCommand } from '@ckeditor/ckeditor5-heading';
 import { BoldEditing, StrikethroughEditing, CodeEditing, ItalicEditing } from '@ckeditor/ckeditor5-basic-styles';
 import { BlockQuoteEditing } from '@ckeditor/ckeditor5-block-quote';
@@ -278,11 +278,40 @@ describe( 'Autoformat', () => {
 				);
 			} );
 
-			it( 'should not replace digit with numbered list item when digit is different than "1"', () => {
+			it( 'should replace digit with numbered list item when digit is different than "1"', () => {
 				_setModelData( model, '<paragraph>3.[]</paragraph>' );
 				insertSpace();
 
-				expect( _getModelData( model ) ).to.equal( '<paragraph>3. []</paragraph>' );
+				expect( _getModelData( model ) ).to.equal(
+					'<paragraph listIndent="0" listItemId="a00" listType="numbered">[]</paragraph>'
+				);
+			} );
+
+			it( 'should replace multi-digit number with numbered list item', () => {
+				_setModelData( model, '<paragraph>12.[]</paragraph>' );
+				insertSpace();
+
+				expect( _getModelData( model ) ).to.equal(
+					'<paragraph listIndent="0" listItemId="a00" listType="numbered">[]</paragraph>'
+				);
+			} );
+
+			it( 'should replace digit with numbered list item using the parenthesis format when digit is not "1"', () => {
+				_setModelData( model, '<paragraph>5)[]</paragraph>' );
+				insertSpace();
+
+				expect( _getModelData( model ) ).to.equal(
+					'<paragraph listIndent="0" listItemId="a00" listType="numbered">[]</paragraph>'
+				);
+			} );
+
+			it( 'should not replace digit character when inside numbered list item (digit different than "1")', () => {
+				_setModelData( model, '<paragraph listIndent="0" listItemId="a00" listType="numbered">5.[]</paragraph>' );
+				insertSpace();
+
+				expect( _getModelData( model ) ).to.equal(
+					'<paragraph listIndent="0" listItemId="a00" listType="numbered">5. []</paragraph>'
+				);
 			} );
 
 			it( 'should not replace digit character after <softBreak>', () => {
@@ -1631,11 +1660,40 @@ describe( 'Autoformat', () => {
 				);
 			} );
 
-			it( 'should not replace digit with numbered list item when digit is different than "1"', () => {
+			it( 'should replace digit with numbered list item when digit is different than "1"', () => {
 				_setModelData( model, '<paragraph>3.[]</paragraph>' );
 				insertSpace();
 
-				expect( _getModelData( model ) ).to.equal( '<paragraph>3. []</paragraph>' );
+				expect( _getModelData( model ) ).to.equal(
+					'<listItem listIndent="0" listItemId="a00" listType="numbered">[]</listItem>'
+				);
+			} );
+
+			it( 'should replace multi-digit number with numbered list item', () => {
+				_setModelData( model, '<paragraph>12.[]</paragraph>' );
+				insertSpace();
+
+				expect( _getModelData( model ) ).to.equal(
+					'<listItem listIndent="0" listItemId="a00" listType="numbered">[]</listItem>'
+				);
+			} );
+
+			it( 'should replace digit with numbered list item using the parenthesis format when digit is not "1"', () => {
+				_setModelData( model, '<paragraph>5)[]</paragraph>' );
+				insertSpace();
+
+				expect( _getModelData( model ) ).to.equal(
+					'<listItem listIndent="0" listItemId="a00" listType="numbered">[]</listItem>'
+				);
+			} );
+
+			it( 'should not replace digit character when inside numbered list item (digit different than "1")', () => {
+				_setModelData( model, '<listItem listIndent="0" listItemId="a00" listType="numbered">5.[]</listItem>' );
+				insertSpace();
+
+				expect( _getModelData( model ) ).to.equal(
+					'<listItem listIndent="0" listItemId="a00" listType="numbered">5. []</listItem>'
+				);
 			} );
 
 			it( 'should not replace digit character after <softBreak>', () => {
@@ -2695,6 +2753,192 @@ describe( 'Autoformat', () => {
 						return editor.destroy();
 					} );
 			} );
+		} );
+	} );
+
+	describe( 'with list properties (startIndex)', () => {
+		beforeEach( async () => {
+			editor = await VirtualTestEditor.create( {
+				plugins: [
+					Enter,
+					Paragraph,
+					Autoformat,
+					ListEditing,
+					ListPropertiesEditing,
+					HeadingEditing,
+					UndoEditing
+				],
+				list: {
+					properties: {
+						startIndex: true,
+						reversed: false,
+						styles: false
+					}
+				}
+			} );
+
+			model = editor.model;
+			doc = model.document;
+
+			stubUid();
+		} );
+
+		afterEach( () => {
+			return editor.destroy();
+		} );
+
+		it( 'should set listStart attribute to 1 when typing "1. "', () => {
+			_setModelData( model, '<paragraph>1.[]</paragraph>' );
+			insertSpace();
+
+			expect( _getModelData( model ) ).to.equal(
+				'<paragraph listIndent="0" listItemId="a00" listStart="1" listType="numbered">[]</paragraph>'
+			);
+		} );
+
+		it( 'should set listStart attribute to the typed number when typing "5. "', () => {
+			_setModelData( model, '<paragraph>5.[]</paragraph>' );
+			insertSpace();
+
+			expect( _getModelData( model ) ).to.equal(
+				'<paragraph listIndent="0" listItemId="a00" listStart="5" listType="numbered">[]</paragraph>'
+			);
+		} );
+
+		it( 'should set listStart attribute to the typed number for multi-digit "12. "', () => {
+			_setModelData( model, '<paragraph>12.[]</paragraph>' );
+			insertSpace();
+
+			expect( _getModelData( model ) ).to.equal(
+				'<paragraph listIndent="0" listItemId="a00" listStart="12" listType="numbered">[]</paragraph>'
+			);
+		} );
+
+		it( 'should set listStart attribute to 0 when typing "0. "', () => {
+			_setModelData( model, '<paragraph>0.[]</paragraph>' );
+			insertSpace();
+
+			expect( _getModelData( model ) ).to.equal(
+				'<paragraph listIndent="0" listItemId="a00" listStart="0" listType="numbered">[]</paragraph>'
+			);
+		} );
+
+		it( 'should set listStart attribute to the typed number for the parenthesis format "5) "', () => {
+			_setModelData( model, '<paragraph>5)[]</paragraph>' );
+			insertSpace();
+
+			expect( _getModelData( model ) ).to.equal(
+				'<paragraph listIndent="0" listItemId="a00" listStart="5" listType="numbered">[]</paragraph>'
+			);
+		} );
+
+		it( 'should ignore typed number and inherit listStart from adjacent numbered list above', () => {
+			_setModelData( model,
+				'<paragraph listIndent="0" listItemId="a01" listStart="1" listType="numbered">Item 1</paragraph>' +
+				'<paragraph>5.[]</paragraph>'
+			);
+			insertSpace();
+
+			expect( _getModelData( model ) ).to.equal(
+				'<paragraph listIndent="0" listItemId="a01" listStart="1" listType="numbered">Item 1</paragraph>' +
+				'<paragraph listIndent="0" listItemId="a00" listStart="1" listType="numbered">[]</paragraph>'
+			);
+		} );
+
+		it( 'should start a new numbered list with typed listStart when adjacent list is bulleted', () => {
+			_setModelData( model,
+				'<paragraph listIndent="0" listItemId="a01" listType="bulleted">Item 1</paragraph>' +
+				'<paragraph>5.[]</paragraph>'
+			);
+			insertSpace();
+
+			expect( _getModelData( model ) ).to.equal(
+				'<paragraph listIndent="0" listItemId="a01" listType="bulleted">Item 1</paragraph>' +
+				'<paragraph listIndent="0" listItemId="a00" listStart="5" listType="numbered">[]</paragraph>'
+			);
+		} );
+	} );
+
+	describe( 'with list properties but startIndex disabled', () => {
+		beforeEach( async () => {
+			editor = await VirtualTestEditor.create( {
+				plugins: [
+					Enter,
+					Paragraph,
+					Autoformat,
+					ListEditing,
+					ListPropertiesEditing,
+					HeadingEditing,
+					UndoEditing
+				],
+				list: {
+					properties: {
+						startIndex: false,
+						reversed: false,
+						styles: false
+					}
+				}
+			} );
+
+			model = editor.model;
+			doc = model.document;
+
+			stubUid();
+		} );
+
+		afterEach( () => {
+			return editor.destroy();
+		} );
+
+		it( 'should not set listStart attribute when typing "5. "', () => {
+			_setModelData( model, '<paragraph>5.[]</paragraph>' );
+			insertSpace();
+
+			expect( _getModelData( model ) ).to.equal(
+				'<paragraph listIndent="0" listItemId="a00" listType="numbered">[]</paragraph>'
+			);
+		} );
+	} );
+
+	describe( 'with single-block lists plugin and list properties (startIndex)', () => {
+		beforeEach( async () => {
+			editor = await VirtualTestEditor.create( {
+				plugins: [
+					Enter,
+					Paragraph,
+					Autoformat,
+					ListEditing,
+					ListPropertiesEditing,
+					HeadingEditing,
+					UndoEditing
+				],
+				list: {
+					multiBlock: false,
+					properties: {
+						startIndex: true,
+						reversed: false,
+						styles: false
+					}
+				}
+			} );
+
+			model = editor.model;
+			doc = model.document;
+
+			stubUid();
+		} );
+
+		afterEach( () => {
+			return editor.destroy();
+		} );
+
+		it( 'should set listStart attribute to the typed number when typing "5. "', () => {
+			_setModelData( model, '<paragraph>5.[]</paragraph>' );
+			insertSpace();
+
+			expect( _getModelData( model ) ).to.equal(
+				'<listItem listIndent="0" listItemId="a00" listStart="5" listType="numbered">[]</listItem>'
+			);
 		} );
 	} );
 

--- a/packages/ckeditor5-list/tests/manual/documentlist-skip-levels.js
+++ b/packages/ckeditor5-list/tests/manual/documentlist-skip-levels.js
@@ -22,6 +22,7 @@ import { Indent, IndentBlock } from '@ckeditor/ckeditor5-indent';
 import { MediaEmbed } from '@ckeditor/ckeditor5-media-embed';
 import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
 import { PasteFromOffice } from '@ckeditor/ckeditor5-paste-from-office';
+import { Autoformat } from '@ckeditor/ckeditor5-autoformat';
 import { TodoList } from '../../src/todolist.js';
 
 import { List } from '../../src/list.js';
@@ -45,7 +46,7 @@ function getEditorConfig() {
 		Essentials, BlockQuote, Bold, Heading, Image, ImageCaption, ImageStyle, ImageToolbar, Indent, Italic, Link,
 		MediaEmbed, Paragraph, Table, TableToolbar, CodeBlock, TableCaption, ImageResize, LinkImage,
 		HtmlEmbed, HtmlComment, Alignment, PageBreak, HorizontalLine, ImageUpload,
-		SourceEditing, List, TodoList
+		SourceEditing, List, TodoList, Autoformat
 	];
 
 	if ( controls.indentBlock.checked ) {


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

*A brief summary of what this PR changes.*

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes https://github.com/ckeditor/ckeditor5-commercial/issues/9705.

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [ ] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
