### PR TITLE
Reject unwanted hidden bookmark links from imported word content in paste from office.

### DIFF
--- a/.changelog/20260424115528_ck_18846.md
+++ b/.changelog/20260424115528_ck_18846.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-paste-from-office
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/18846
+---
+
+Pasting content from Word no longer inserts unwanted visible bookmarks into the editor.

--- a/packages/ckeditor5-paste-from-office/src/filters/bookmark.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/bookmark.ts
@@ -48,6 +48,17 @@ export function transformBookmarks(
 	}
 }
 
+/**
+ * Checks whether the given element is a hidden or auto-generated bookmark anchor.
+ *
+ * Editors like MS Word and Google Docs use the `name` attribute (rather than `id`)
+ * for bookmarks. Furthermore, they reserve `_`-prefixed bookmark names for
+ * auto-generated anchors (e.g., Table of Contents or internal hyperlinks) and
+ * do not allow users to manually create custom bookmarks starting with an underscore.
+ *
+ * @param element The element to check.
+ * @returns True if the element is a hidden bookmark anchor, false otherwise.
+ */
 function isHiddenBookmarkAnchor( element: ViewElement ) {
 	const name = element.getAttribute( 'name' );
 

--- a/packages/ckeditor5-paste-from-office/src/filters/bookmark.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/bookmark.ts
@@ -42,13 +42,13 @@ export function transformBookmarks(
 
 		writer.insertChild( index, children, element.parent! );
 
-		if ( isHiddenMsBookmarkAnchor( element ) ) {
+		if ( isHiddenBookmarkAnchor( element ) ) {
 			writer.remove( element );
 		}
 	}
 }
 
-function isHiddenMsBookmarkAnchor( element: ViewElement ) {
+function isHiddenBookmarkAnchor( element: ViewElement ) {
 	const name = element.getAttribute( 'name' );
 
 	return !!name && name.startsWith( '_' );

--- a/packages/ckeditor5-paste-from-office/src/filters/bookmark.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/bookmark.ts
@@ -7,9 +7,10 @@
  * @module paste-from-office/filters/bookmark
  */
 
-import {
-	type ViewUpcastWriter,
-	type ViewDocumentFragment
+import type {
+	ViewUpcastWriter,
+	ViewDocumentFragment,
+	ViewElement
 } from '@ckeditor/ckeditor5-engine';
 
 /**
@@ -40,5 +41,15 @@ export function transformBookmarks(
 		const children = element.getChildren();
 
 		writer.insertChild( index, children, element.parent! );
+
+		if ( isHiddenMsBookmarkAnchor( element ) ) {
+			writer.remove( element );
+		}
 	}
+}
+
+function isHiddenMsBookmarkAnchor( element: ViewElement ) {
+	const name = element.getAttribute( 'name' );
+
+	return !!name && name.startsWith( '_' );
 }

--- a/packages/ckeditor5-paste-from-office/tests/_data/list/styled-anchor/normalized.safari.word2016.html
+++ b/packages/ckeditor5-paste-from-office/tests/_data/list/styled-anchor/normalized.safari.word2016.html
@@ -1,6 +1,6 @@
 <p style="-webkit-text-size-adjust:auto;-webkit-text-stroke-width:0px;caret-color:rgb(0, 0, 0);color:rgb(0, 0, 0);font-family:Calibri, sans-serif;font-size:medium;font-style:normal;font-variant-caps:normal;font-weight:normal;letter-spacing:normal;margin:0cm;orphans:auto;text-align:start;text-decoration:none;text-indent:0px;text-transform:none;white-space:normal;widows:auto;word-spacing:0px"><span lang="FR" style="font-family:&quot;Times New Roman&quot;, serif;font-size:11pt">An example list with an error:</span></p>
 <ul style="list-style-type:square">
-  <li><p><a name="_heading=h.tyjcwt"></a><span lang="FR" style="font-family:Wingdings"></span><span lang="FR">List item 1.</span></p></li>
+  <li><p><span lang="FR" style="font-family:Wingdings"></span><span lang="FR">List item 1.</span></p></li>
   <li><p><span lang="FR" style="font-family:Wingdings"></span><span lang="FR">List item 2.</span></p></li>
   <li><p><span lang="FR" style="font-family:Wingdings"></span><span lang="FR">List item 3.</span></p></li>
 </ul>

--- a/packages/ckeditor5-paste-from-office/tests/_data/list/styled-anchor/normalized.word2016.html
+++ b/packages/ckeditor5-paste-from-office/tests/_data/list/styled-anchor/normalized.word2016.html
@@ -1,6 +1,6 @@
 <p><span lang="FR" style="font-family:&quot;Times New Roman&quot;,serif;font-size:11.0pt">An example list with an error:</span></p>
 <ul style="list-style-type:square">
-  <li><p><a name="_heading=h.tyjcwt"></a><span lang="FR" style="font-family:Wingdings"></span><span lang="FR">List item 1.</span></p></li>
+  <li><p><span lang="FR" style="font-family:Wingdings"></span><span lang="FR">List item 1.</span></p></li>
   <li><p><span lang="FR" style="font-family:Wingdings"></span><span lang="FR">List item 2.</span></p></li>
   <li><p><span lang="FR" style="font-family:Wingdings"></span><span lang="FR">List item 3.</span></p></li>
 </ul>

--- a/packages/ckeditor5-paste-from-office/tests/filters/bookmark.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/bookmark.js
@@ -221,6 +221,46 @@ describe( 'PasteFromOffice - filters - bookmark', () => {
 		);
 	} );
 
+	it( 'should extract text and remove the <a> element completely if its name starts with an underscore (hidden bookmark)', () => {
+		performTest(
+			'<a name="_GoBack">' +
+				'<span>text</span>' +
+			'</a>',
+
+			'<span>text</span>'
+		);
+	} );
+
+	it( 'should completely remove an empty <a> element if its name starts with an underscore', () => {
+		performTest(
+			'<p>paragraph</p>' +
+			'<a name="_Toc12345"></a>',
+
+			'<p>paragraph</p>'
+		);
+	} );
+
+	it( 'should remove the <a> element but keep content when both id and name are present and name starts with an underscore', () => {
+		performTest(
+			'<a id="some-id" name="_hiddenBookmark">' +
+				'<span>text</span>' +
+			'</a>',
+
+			'<span>text</span>'
+		);
+	} );
+
+	it( 'should NOT remove the <a> element if only its id starts with an underscore (since Word/GDocs use name)', () => {
+		performTest(
+			'<a id="_GoBack">' +
+				'<span>text</span>' +
+			'</a>',
+
+			'<a id="_GoBack"></a>' +
+			'<span>text</span>'
+		);
+	} );
+
 	function performTest( inputData, expectedData ) {
 		const documentFragment = htmlDataProcessor.toView( inputData );
 


### PR DESCRIPTION
### 🚀 Summary

Reject unwanted hidden bookmark links from imported word content in paste from office.

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5/issues/18846

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [x] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [x] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
