### PR TITLE
The ClipboardPipeline and PasteFromOffice should allow for common HTML string normalisation before conversion to view

### DIFF
--- a/.changelog/20260428091249_ck_17309_new.md
+++ b/.changelog/20260428091249_ck_17309_new.md
@@ -1,0 +1,10 @@
+---
+type: Fix
+scope:
+  - ckeditor5-table
+  - ckeditor5-clipboard
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/17309
+---
+
+The `ClipboardPipeline` and `PasteFromOffice` should allow for common HTML string normalization before conversion to view.

--- a/.changelog/20260428091249_ck_17309_new.md
+++ b/.changelog/20260428091249_ck_17309_new.md
@@ -1,7 +1,7 @@
 ---
 type: Fix
 scope:
-  - ckeditor5-table
+  - ckeditor5-paste-from-office
   - ckeditor5-clipboard
 closes:
   - https://github.com/ckeditor/ckeditor5/issues/17309

--- a/packages/ckeditor5-clipboard/src/clipboardobserver.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardobserver.ts
@@ -19,6 +19,8 @@ import {
 	type ViewRange
 } from '@ckeditor/ckeditor5-engine';
 
+import { plainTextToHtml } from './utils/plaintexttohtml.js';
+
 /**
  * Clipboard events observer.
  *
@@ -63,10 +65,20 @@ export class ClipboardObserver extends DomEventObserver<
 				data.preventDefault();
 
 				const targetRanges = data.dropRange ? [ data.dropRange ] : null;
+				const dataTransfer = data.dataTransfer;
 				const eventInfo = new EventInfo( viewDocument, type );
 
+				let content = '';
+
+				if ( dataTransfer.getData( 'text/html' ) ) {
+					content = dataTransfer.getData( 'text/html' );
+				} else if ( dataTransfer.getData( 'text/plain' ) ) {
+					content = plainTextToHtml( dataTransfer.getData( 'text/plain' ) );
+				}
+
 				viewDocument.fire( eventInfo, {
-					dataTransfer: data.dataTransfer,
+					dataTransfer,
+					content,
 					method: evt.name,
 					targetRanges,
 					target: data.target,
@@ -173,9 +185,15 @@ export interface ClipboardInputEventData {
 	targetRanges: Array<ViewRange> | null;
 
 	/**
-	 * The content of clipboard input.
+	 * The content of clipboard input. Defaults to `text/html`. Falls-back to `text/plain`.
 	 */
-	content?: ViewDocumentFragment;
+	content: string | ViewDocumentFragment;
+
+	/**
+	 * Custom data stored by the `clipboardInput` event handlers. Custom properties of this object can be defined and use to
+	 * pass parameters between listeners. Content of this property is passed to the `inputTransformation` event.
+	 */
+	extraContent?: unknown;
 }
 
 /**

--- a/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
@@ -30,7 +30,6 @@ import {
 	type ViewDocumentClipboardInputEvent
 } from './clipboardobserver.js';
 
-import { plainTextToHtml } from './utils/plaintexttohtml.js';
 import { normalizeClipboardData } from './utils/normalizeclipboarddata.js';
 import { viewToPlainText } from './utils/viewtoplaintext.js';
 import { ClipboardMarkersUtils } from './clipboardmarkersutils.js';
@@ -219,30 +218,20 @@ export class ClipboardPipeline extends Plugin {
 
 		this.listenTo<ViewDocumentClipboardInputEvent>( viewDocument, 'clipboardInput', ( evt, data ) => {
 			const dataTransfer = data.dataTransfer;
-			let content: ViewDocumentFragment;
-
-			// Some feature could already inject content in the higher priority event handler (i.e., codeBlock).
-			if ( data.content ) {
-				content = data.content;
-			} else {
-				let contentData = '';
-
-				if ( dataTransfer.getData( 'text/html' ) ) {
-					contentData = normalizeClipboardData( dataTransfer.getData( 'text/html' ) );
-				} else if ( dataTransfer.getData( 'text/plain' ) ) {
-					contentData = plainTextToHtml( dataTransfer.getData( 'text/plain' ) );
-				}
-
-				content = this.editor.data.htmlProcessor.toView( contentData );
-			}
 
 			const eventInfo = new EventInfo( this, 'inputTransformation' );
 			const sourceEditorId = dataTransfer.getData( 'application/ckeditor5-editor-id' ) || null;
+
+			// Some feature could already inject content in the higher priority event handler (i.e., codeBlock, paste from office).
+			const content = typeof data.content == 'string' ?
+				this.editor.data.htmlProcessor.toView( normalizeClipboardData( data.content ) ) :
+				data.content;
 
 			this.fire<ClipboardInputTransformationEvent>( eventInfo, {
 				content,
 				dataTransfer,
 				sourceEditorId,
+				extraContent: data.extraContent,
 				targetRanges: data.targetRanges,
 				method: data.method as 'paste' | 'drop'
 			} );
@@ -379,6 +368,11 @@ export interface ClipboardInputTransformationData {
 	 * the {@glink framework/deep-dive/clipboard clipboard deep-dive} guide.
 	 */
 	content: ViewDocumentFragment;
+
+	/**
+	 * Custom data stored by the `clipboardInput` event handlers. Content of this property is passed from the `clipboardInput` event.
+	 */
+	extraContent?: unknown;
 
 	/**
 	 * The data transfer instance.

--- a/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
@@ -318,6 +318,7 @@ describe( 'ClipboardPipeline feature', () => {
 
 			viewDocument.fire( 'clipboardInput', {
 				dataTransfer: dataTransferMock,
+				content: dataTransferMock.getData( 'text/html' ),
 				method: 'paste'
 			} );
 
@@ -326,7 +327,8 @@ describe( 'ClipboardPipeline feature', () => {
 			editor.disableReadOnlyMode( 'unit-test' );
 
 			viewDocument.fire( 'clipboardInput', {
-				dataTransfer: dataTransferMock
+				dataTransfer: dataTransferMock,
+				content: dataTransferMock.getData( 'text/html' )
 			} );
 
 			sinon.assert.calledOnce( spy );

--- a/packages/ckeditor5-clipboard/tests/dragdrop.js
+++ b/packages/ckeditor5-clipboard/tests/dragdrop.js
@@ -2579,6 +2579,7 @@ describe( 'Drag and Drop', () => {
 			...prepareEventData( modelPositionOrRange ),
 			method: 'dragging',
 			dataTransfer: dataTransferMock,
+			content: dataTransferMock.getData( 'text/html' ),
 			stopPropagation: () => {},
 			preventDefault: () => {}
 		} );
@@ -2589,6 +2590,7 @@ describe( 'Drag and Drop', () => {
 			...prepareEventData( modelPosition ),
 			method: 'drop',
 			dataTransfer: dataTransferMock,
+			content: dataTransferMock.getData( 'text/html' ),
 			stopPropagation: () => {},
 			preventDefault: () => {}
 		} );

--- a/packages/ckeditor5-clipboard/tests/pasteplaintext.js
+++ b/packages/ckeditor5-clipboard/tests/pasteplaintext.js
@@ -193,6 +193,7 @@ describe( 'PastePlainText', () => {
 
 		viewDocument.fire( 'clipboardInput', {
 			dataTransfer: dataTransferMock,
+			content: dataTransferMock.getData( 'text/html' ),
 			stopPropagation() {},
 			preventDefault() {}
 		} );
@@ -221,6 +222,7 @@ describe( 'PastePlainText', () => {
 
 		viewDocument.fire( 'clipboardInput', {
 			dataTransfer: dataTransferMock,
+			content: dataTransferMock.getData( 'text/html' ),
 			stopPropagation() {},
 			preventDefault() {}
 		} );
@@ -236,6 +238,7 @@ describe( 'PastePlainText', () => {
 				'text/html': 'foo',
 				'text/plain': 'foo'
 			} ),
+			content: 'foo',
 			stopPropagation() {},
 			preventDefault() {}
 		} );
@@ -251,6 +254,7 @@ describe( 'PastePlainText', () => {
 				'text/html': 'foo',
 				'text/plain': 'foo'
 			} ),
+			content: 'foo',
 			stopPropagation() {},
 			preventDefault() {}
 		} );
@@ -269,6 +273,7 @@ describe( 'PastePlainText', () => {
 				'text/html': 'foo',
 				'text/plain': 'foo'
 			} ),
+			content: 'foo',
 			stopPropagation() {},
 			preventDefault() {}
 		} );
@@ -292,6 +297,7 @@ describe( 'PastePlainText', () => {
 				'text/html': '<obj></obj>',
 				'text/plain': 'foo'
 			} ),
+			content: 'foo',
 			stopPropagation() {},
 			preventDefault() {}
 		} );

--- a/packages/ckeditor5-clipboard/tests/pasteplaintext.js
+++ b/packages/ckeditor5-clipboard/tests/pasteplaintext.js
@@ -297,7 +297,7 @@ describe( 'PastePlainText', () => {
 				'text/html': '<obj></obj>',
 				'text/plain': 'foo'
 			} ),
-			content: 'foo',
+			content: '<obj></obj>',
 			stopPropagation() {},
 			preventDefault() {}
 		} );

--- a/packages/ckeditor5-code-block/src/codeblockediting.ts
+++ b/packages/ckeditor5-code-block/src/codeblockediting.ts
@@ -22,7 +22,11 @@ import {
 	type ModelElement,
 	type ModelSelectionChangeRangeEvent
 } from '@ckeditor/ckeditor5-engine';
-import { ClipboardPipeline, type ClipboardContentInsertionEvent } from '@ckeditor/ckeditor5-clipboard';
+import {
+	ClipboardPipeline,
+	type ViewDocumentClipboardInputEvent,
+	type ClipboardContentInsertionEvent
+} from '@ckeditor/ckeditor5-clipboard';
 
 import { CodeBlockCommand } from './codeblockcommand.js';
 import { IndentCodeBlockCommand } from './indentcodeblockcommand.js';
@@ -179,7 +183,7 @@ export class CodeBlockEditing extends Plugin {
 		// Intercept the clipboard input (paste) when the selection is anchored in the code block and force the clipboard
 		// data to be pasted as a single plain text. Otherwise, the code lines will split the code block and
 		// "spill out" as separate paragraphs.
-		this.listenTo( editor.editing.view.document, 'clipboardInput', ( evt, data ) => {
+		this.listenTo<ViewDocumentClipboardInputEvent>( editor.editing.view.document, 'clipboardInput', ( evt, data ) => {
 			let insertionRange = model.createRange( model.document.selection.anchor! );
 
 			// Use target ranges in case this is a drop.

--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -1687,7 +1687,7 @@ describe( 'CodeBlockEditing', () => {
 					'[]o' +
 				'</codeBlock>' );
 
-			sinon.assert.calledTwice( dataTransferMock.getData );
+			expect( dataTransferMock.getData ).to.be.called;
 
 			// Make sure that ClipboardPipeline was not interrupted.
 			sinon.assert.calledOnce( contentInsertionSpy );
@@ -1729,7 +1729,7 @@ describe( 'CodeBlockEditing', () => {
 				'<paragraph>bar</paragraph>'
 			);
 
-			sinon.assert.calledTwice( dataTransferMock.getData );
+			expect( dataTransferMock.getData ).to.be.called;
 
 			// Make sure that ClipboardPipeline was not interrupted.
 			sinon.assert.calledOnce( contentInsertionSpy );

--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -1649,6 +1649,7 @@ describe( 'CodeBlockEditing', () => {
 			};
 
 			viewDoc.fire( 'clipboardInput', {
+				content: dataTransferMock.getData( 'text/plain' ),
 				dataTransfer: dataTransferMock,
 				stop: sinon.spy()
 			} );
@@ -1672,6 +1673,7 @@ describe( 'CodeBlockEditing', () => {
 			};
 
 			viewDoc.fire( 'clipboardInput', {
+				content: dataTransferMock.getData( 'text/plain' ),
 				dataTransfer: dataTransferMock,
 				stop: sinon.spy()
 			} );
@@ -1708,6 +1710,7 @@ describe( 'CodeBlockEditing', () => {
 
 			viewDoc.fire( 'clipboardInput', {
 				method: 'drop',
+				content: dataTransferMock.getData( 'text/plain' ),
 				dataTransfer: dataTransferMock,
 				targetRanges: [ targetViewRange ],
 				target: targetViewRange.start.parent.parent,
@@ -1754,6 +1757,7 @@ describe( 'CodeBlockEditing', () => {
 
 			viewDoc.fire( 'clipboardInput', {
 				dataTransfer: dataTransferMock,
+				content: dataTransferMock.getData( 'text/plain' ),
 				stop: sinon.spy()
 			} );
 

--- a/packages/ckeditor5-engine/src/view/view.ts
+++ b/packages/ckeditor5-engine/src/view/view.ts
@@ -22,6 +22,7 @@ import {
 
 import type { Observer, ObserverConstructor } from './observer/observer.js';
 import type { ViewDocumentSelectionChangeEvent } from './documentselection.js';
+import type { ViewDocumentFragment } from './documentfragment.js';
 import type { StylesProcessor } from './stylesmap.js';
 import { type ViewElement } from './element.js';
 import type { ViewNode, ViewNodeChangeEvent } from './node.js';
@@ -682,7 +683,7 @@ export class EditingView extends /* #__PURE__ */ ObservableMixin() {
 	 *
 	 * @param element Element which is a parent for the range.
 	 */
-	public createRangeIn( element: ViewElement ): ViewRange {
+	public createRangeIn( element: ViewElement | ViewDocumentFragment ): ViewRange {
 		return ViewRange._createIn( element );
 	}
 

--- a/packages/ckeditor5-image/src/autoimage.ts
+++ b/packages/ckeditor5-image/src/autoimage.ts
@@ -8,7 +8,11 @@
  */
 
 import { Plugin, type Editor } from '@ckeditor/ckeditor5-core';
-import { Clipboard, type ClipboardPipeline } from '@ckeditor/ckeditor5-clipboard';
+import {
+	Clipboard,
+	type ClipboardInputTransformationEvent,
+	type ClipboardPipeline
+} from '@ckeditor/ckeditor5-clipboard';
 import { ModelLivePosition, ModelLiveRange } from '@ckeditor/ckeditor5-engine';
 import { Undo } from '@ckeditor/ckeditor5-undo';
 import { Delete } from '@ckeditor/ckeditor5-typing';
@@ -82,7 +86,7 @@ export class AutoImage extends Plugin {
 		// We need to listen on `Clipboard#inputTransformation` because we need to save positions of selection.
 		// After pasting, the content between those positions will be checked for a URL that could be transformed
 		// into an image.
-		this.listenTo( clipboardPipeline, 'inputTransformation', () => {
+		this.listenTo<ClipboardInputTransformationEvent>( clipboardPipeline, 'inputTransformation', () => {
 			const firstRange = modelDocument.selection.getFirstRange()!;
 
 			const leftLivePosition = ModelLivePosition.fromPosition( firstRange.start );

--- a/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
@@ -22,7 +22,11 @@ import {
 } from '@ckeditor/ckeditor5-engine';
 
 import { Notification } from '@ckeditor/ckeditor5-ui';
-import { ClipboardPipeline, type ViewDocumentClipboardInputEvent } from '@ckeditor/ckeditor5-clipboard';
+import {
+	ClipboardPipeline,
+	type ViewDocumentClipboardInputEvent,
+	type ClipboardInputTransformationEvent
+} from '@ckeditor/ckeditor5-clipboard';
 import { FileRepository, type UploadResponse, type FileLoader } from '@ckeditor/ckeditor5-upload';
 import { env } from '@ckeditor/ckeditor5-utils';
 
@@ -197,7 +201,7 @@ export class ImageUploadEditing extends Plugin {
 		// For every image file, a new file loader is created and a placeholder image is
 		// inserted into the content. Then, those images are uploaded once they appear in the model
 		// (see Document#change listener below).
-		this.listenTo( clipboardPipeline, 'inputTransformation', ( evt, data ) => {
+		this.listenTo<ClipboardInputTransformationEvent>( clipboardPipeline, 'inputTransformation', ( evt, data ) => {
 			const fetchableImages = Array.from( editor.editing.view.createRangeIn( data.content ) )
 				.map( value => value.item as ViewElement )
 				.filter( viewElement =>

--- a/packages/ckeditor5-image/tests/image/imageblockediting.js
+++ b/packages/ckeditor5-image/tests/image/imageblockediting.js
@@ -619,7 +619,10 @@ describe( 'ImageBlockEditing', () => {
 
 			_setModelData( model, '<paragraph>[]</paragraph>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData()
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'[<imageBlock src="/assets/sample.png"></imageBlock>]'
@@ -634,7 +637,10 @@ describe( 'ImageBlockEditing', () => {
 
 			_setModelData( model, '[<imageBlock src="/assets/sample.png?id=B"></imageBlock>]' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData()
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'[<imageBlock src="/assets/sample.png?id=A"></imageBlock>]'
@@ -649,7 +655,10 @@ describe( 'ImageBlockEditing', () => {
 
 			_setModelData( model, '<paragraph>f[]oo</paragraph>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData()
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'<paragraph>f</paragraph>' +
@@ -677,7 +686,8 @@ describe( 'ImageBlockEditing', () => {
 				target: viewElement,
 				dataTransfer,
 				targetRanges: [ targetViewRange ],
-				domEvent: sinon.spy()
+				domEvent: sinon.spy(),
+				content: dataTransfer.getData()
 			} );
 
 			expect( _getModelData( model ) ).to.equal(
@@ -693,7 +703,10 @@ describe( 'ImageBlockEditing', () => {
 
 			_setModelData( model, '<paragraph>foo[]</paragraph>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData()
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'<paragraph>foo<imageInline src="/assets/sample.png"></imageInline>[]</paragraph>'
@@ -708,7 +721,10 @@ describe( 'ImageBlockEditing', () => {
 
 			_setModelData( model, '<paragraph>[]</paragraph>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData()
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'[<imageBlock alt="abc" src="/assets/sample.png"></imageBlock>]'
@@ -723,7 +739,11 @@ describe( 'ImageBlockEditing', () => {
 
 			_setModelData( model, '<paragraph>[]</paragraph>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer, method: 'paste' } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData(),
+				method: 'paste'
+			} );
 
 			setTimeout( () => {
 				expect( _getModelData( model ) ).to.equal(
@@ -742,7 +762,11 @@ describe( 'ImageBlockEditing', () => {
 
 			_setModelData( model, '<paragraph>[]</paragraph>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer, method: 'foo' } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData(),
+				method: 'foo'
+			} );
 
 			setTimeout( () => {
 				expect( _getModelData( model ) ).to.equal(

--- a/packages/ckeditor5-image/tests/image/imageinlineediting.js
+++ b/packages/ckeditor5-image/tests/image/imageinlineediting.js
@@ -662,7 +662,10 @@ describe( 'ImageInlineEditing', () => {
 
 			_setModelData( model, '<paragraph>f[]oo</paragraph>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'<paragraph>f<imageInline src="/assets/sample.png"></imageInline>[]oo</paragraph>'
@@ -677,7 +680,10 @@ describe( 'ImageInlineEditing', () => {
 
 			_setModelData( model, '<paragraph listIndent="0" listItemId="000" listType="bulleted"></paragraph>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'[<imageBlock listIndent="0" listItemId="a00" listType="bulleted" src="/assets/sample.png"></imageBlock>]'
@@ -692,7 +698,10 @@ describe( 'ImageInlineEditing', () => {
 
 			_setModelData( model, '<paragraph>f[]oo</paragraph>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'<paragraph>f</paragraph>' +
@@ -720,7 +729,8 @@ describe( 'ImageInlineEditing', () => {
 				target: viewElement,
 				dataTransfer,
 				targetRanges: [ targetViewRange ],
-				domEvent: sinon.spy()
+				domEvent: sinon.spy(),
+				content: dataTransfer.getData( 'text/html' )
 			} );
 
 			expect( _getModelData( model ) ).to.equal(
@@ -736,7 +746,10 @@ describe( 'ImageInlineEditing', () => {
 
 			_setModelData( model, '<paragraph>f[]oo</paragraph>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'<paragraph>f</paragraph>' +
@@ -753,7 +766,10 @@ describe( 'ImageInlineEditing', () => {
 
 			_setModelData( model, '<paragraph>[]</paragraph>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'[<imageBlock src="/assets/sample.png"></imageBlock>]'
@@ -768,7 +784,10 @@ describe( 'ImageInlineEditing', () => {
 
 			_setModelData( model, '[<imageBlock src="/assets/sample.png?id=B"></imageBlock>]' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'[<imageBlock src="/assets/sample.png?id=A"></imageBlock>]'
@@ -783,7 +802,10 @@ describe( 'ImageInlineEditing', () => {
 
 			_setModelData( model, '<paragraph>f[]oo</paragraph>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'<paragraph>f<imageInline alt="abc" src="/assets/sample.png"></imageInline>[]oo</paragraph>'
@@ -798,7 +820,10 @@ describe( 'ImageInlineEditing', () => {
 
 			_setModelData( model, '<paragraph>f[]oo</paragraph>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'<paragraph>f<imageInline linkHref="https://cksource.com" src="/assets/sample.png"></imageInline>[]oo</paragraph>'
@@ -819,7 +844,10 @@ describe( 'ImageInlineEditing', () => {
 			} );
 
 			_setModelData( model, '<paragraph>f[]oo</paragraph>' );
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'<paragraph>f<imageInline foo="bar" src="/assets/sample.png"></imageInline>[]oo</paragraph>'
@@ -837,7 +865,10 @@ describe( 'ImageInlineEditing', () => {
 			} );
 
 			_setModelData( model, '<paragraph>f[]oo</paragraph>' );
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'<paragraph>f<imageInline resizedWidth="25%" src="/assets/sample.png"></imageInline>[]oo</paragraph>'
@@ -852,7 +883,11 @@ describe( 'ImageInlineEditing', () => {
 
 			_setModelData( model, '<paragraph>f[]oo</paragraph>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer, method: 'paste' } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				method: 'paste',
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			setTimeout( () => {
 				expect( _getModelData( model ) ).to.equal(
@@ -871,7 +906,11 @@ describe( 'ImageInlineEditing', () => {
 
 			_setModelData( model, '<paragraph>f[]oo</paragraph>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer, method: 'foo' } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				method: 'foo',
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			setTimeout( () => {
 				expect( _getModelData( model ) ).to.equal(
@@ -946,7 +985,10 @@ describe( 'ImageInlineEditing', () => {
 
 			_setModelData( model, '<imageBlock src="/assets/sample.png"><caption>foo[]bar</caption></imageBlock>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'<imageBlock src="/assets/sample.png"><caption>foo[]bar</caption></imageBlock>'
@@ -961,7 +1003,10 @@ describe( 'ImageInlineEditing', () => {
 
 			_setModelData( model, '<imageBlock src="/assets/sample.png"><caption>foo[]bar</caption></imageBlock>' );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			expect( _getModelData( model ) ).to.equal(
 				'<imageBlock src="/assets/sample.png"><caption>foo[]bar</caption></imageBlock>'

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
@@ -170,7 +170,7 @@ describe( 'ImageUploadEditing', () => {
 
 	it( 'should insert image when is dropped', () => {
 		const fileMock = createNativeFileMock();
-		const dataTransfer = new ViewDataTransfer( { files: [ fileMock ], types: [ 'Files' ] } );
+		const dataTransfer = new ViewDataTransfer( { files: [ fileMock ], types: [ 'Files' ], getData: () => '' } );
 		_setModelData( model, '<paragraph>[]foo</paragraph>' );
 
 		const targetRange = model.createRange( model.createPositionAt( doc.getRoot(), 1 ), model.createPositionAt( doc.getRoot(), 1 ) );
@@ -188,14 +188,18 @@ describe( 'ImageUploadEditing', () => {
 
 	it( 'should insert image at optimized position when is pasted', () => {
 		const fileMock = createNativeFileMock();
-		const dataTransfer = new ViewDataTransfer( { files: [ fileMock ], types: [ 'Files' ] } );
+		const dataTransfer = new ViewDataTransfer( { files: [ fileMock ], types: [ 'Files' ], getData: () => '' } );
 		_setModelData( model, '<paragraph>[]foo</paragraph>' );
 
 		const paragraph = doc.getRoot().getChild( 0 );
 		const targetRange = model.createRange( model.createPositionAt( paragraph, 1 ), model.createPositionAt( paragraph, 1 ) ); // f[]oo
 		const targetViewRange = editor.editing.mapper.toViewRange( targetRange );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			targetRanges: [ targetViewRange ],
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		const id = fileRepository.getLoader( fileMock ).id;
 		expect( _getModelData( model ) ).to.equal(
@@ -205,7 +209,7 @@ describe( 'ImageUploadEditing', () => {
 
 	it( 'should insert multiple image files when are pasted (inline image type)', () => {
 		const files = [ createNativeFileMock(), createNativeFileMock() ];
-		const dataTransfer = new ViewDataTransfer( { files, types: [ 'Files' ] } );
+		const dataTransfer = new ViewDataTransfer( { files, types: [ 'Files' ], getData: () => '' } );
 		_setModelData( model, '<paragraph>[]foo</paragraph>' );
 
 		const targetRange = model.createRange(
@@ -214,7 +218,11 @@ describe( 'ImageUploadEditing', () => {
 		);
 		const targetViewRange = editor.editing.mapper.toViewRange( targetRange );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			targetRanges: [ targetViewRange ],
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		const id1 = fileRepository.getLoader( files[ 0 ] ).id;
 		const id2 = fileRepository.getLoader( files[ 1 ] ).id;
@@ -336,7 +344,11 @@ describe( 'ImageUploadEditing', () => {
 		const targetViewRange = editor.editing.mapper.toViewRange( targetRange );
 
 		const eventInfo = new EventInfo( viewDocument, 'clipboardInput' );
-		viewDocument.fire( eventInfo, { dataTransfer, targetRanges: [ targetViewRange ] } );
+		viewDocument.fire( eventInfo, {
+			dataTransfer,
+			targetRanges: [ targetViewRange ],
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		expect( _getModelData( model ) ).to.equal( '<paragraph>foo[]</paragraph>' );
 		expect( eventInfo.stop.called ).to.be.undefined;
@@ -360,7 +372,11 @@ describe( 'ImageUploadEditing', () => {
 		const targetViewRange = editor.editing.mapper.toViewRange( targetRange );
 
 		const eventInfo = new EventInfo( viewDocument, 'clipboardInput' );
-		viewDocument.fire( eventInfo, { dataTransfer, targetRanges: [ targetViewRange ] } );
+		viewDocument.fire( eventInfo, {
+			dataTransfer,
+			targetRanges: [ targetViewRange ],
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		expect( _getModelData( model ) ).to.equal( '<paragraph>foo[]</paragraph>' );
 		expect( eventInfo.stop.called ).to.be.undefined;
@@ -368,14 +384,18 @@ describe( 'ImageUploadEditing', () => {
 
 	it( 'should not insert image when file is null', () => {
 		const viewDocument = editor.editing.view.document;
-		const dataTransfer = new ViewDataTransfer( { files: [ null ], types: [ 'Files' ], getData: () => null } );
+		const dataTransfer = new ViewDataTransfer( { files: [ null ], types: [ 'Files' ], getData: () => '' } );
 
 		_setModelData( model, '<paragraph>foo[]</paragraph>' );
 
 		const targetRange = doc.selection.getFirstRange();
 		const targetViewRange = editor.editing.mapper.toViewRange( targetRange );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			targetRanges: [ targetViewRange ],
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		expect( _getModelData( model ) ).to.equal( '<paragraph>foo[]</paragraph>' );
 	} );
@@ -392,7 +412,11 @@ describe( 'ImageUploadEditing', () => {
 		const targetRange = model.createRange( model.createPositionAt( doc.getRoot(), 1 ), model.createPositionAt( doc.getRoot(), 1 ) );
 		const targetViewRange = editor.editing.mapper.toViewRange( targetRange );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			targetRanges: [ targetViewRange ],
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		expect( _getModelData( model ) ).to.equal( '<paragraph>SomeData[]foo</paragraph>' );
 	} );
@@ -461,7 +485,11 @@ describe( 'ImageUploadEditing', () => {
 		const targetRange = doc.selection.getFirstRange();
 		const targetViewRange = editor.editing.mapper.toViewRange( targetRange );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			targetRanges: [ targetViewRange ],
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		// Well, there's no clipboard plugin, so nothing happens.
 		expect( _getModelData( model ) ).to.equal( '<paragraph>SomeData[]foo</paragraph>' );
@@ -555,7 +583,11 @@ describe( 'ImageUploadEditing', () => {
 		const targetRange = model.createRange( model.createPositionAt( doc.getRoot(), 1 ), model.createPositionAt( doc.getRoot(), 1 ) );
 		const targetViewRange = editor.editing.mapper.toViewRange( targetRange );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			targetRanges: [ targetViewRange ],
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		await new Promise( res => {
 			model.document.once( 'change', res );
@@ -583,7 +615,11 @@ describe( 'ImageUploadEditing', () => {
 		const targetRange = model.createRange( model.createPositionAt( doc.getRoot(), 1 ), model.createPositionAt( doc.getRoot(), 1 ) );
 		const targetViewRange = editor.editing.mapper.toViewRange( targetRange );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			targetRanges: [ targetViewRange ],
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		await new Promise( res => {
 			model.document.once( 'change', res );
@@ -1069,8 +1105,11 @@ describe( 'ImageUploadEditing', () => {
 
 	it( 'should prevent from browser redirecting when an image is dropped on another image', () => {
 		const spy = sinon.spy();
+		const dataTransfer = mockDataTransfer( '' );
 
 		editor.editing.view.document.fire( 'dragover', {
+			dataTransfer,
+			content: dataTransfer.getData( 'text/html' ),
 			preventDefault: spy
 		} );
 
@@ -1086,7 +1125,11 @@ describe( 'ImageUploadEditing', () => {
 		const targetRange = model.createRange( model.createPositionAt( doc.getRoot(), 1 ), model.createPositionAt( doc.getRoot(), 1 ) );
 		const targetViewRange = editor.editing.mapper.toViewRange( targetRange );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			targetRanges: [ targetViewRange ],
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		const id = adapterMocks[ 0 ].loader.id;
 		const expected =
@@ -1104,7 +1147,10 @@ describe( 'ImageUploadEditing', () => {
 		const clipboardHtml = `<img src=${ base64ToBlobUrl( base64Sample ) } />`;
 		const dataTransfer = mockDataTransfer( clipboardHtml );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		const id = adapterMocks[ 0 ].loader.id;
 		const expected =
@@ -1123,7 +1169,10 @@ describe( 'ImageUploadEditing', () => {
 		const clipboardHtml = `<img src=${ base64Sample } />`;
 		const dataTransfer = mockDataTransfer( clipboardHtml );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		const expected = `<paragraph><imageInline src="${ base64Sample }"></imageInline>[]foo</paragraph>`;
 
@@ -1153,7 +1202,10 @@ describe( 'ImageUploadEditing', () => {
 			content = data.content;
 		} );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		expectData(
 			'<img src="" uploadId="#loader1_id" uploadProcessed="true"></img>',
@@ -1215,7 +1267,11 @@ describe( 'ImageUploadEditing', () => {
 			content = data.content;
 		} );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			targetRanges: [ targetViewRange ],
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		expectData(
 			'',
@@ -1251,7 +1307,11 @@ describe( 'ImageUploadEditing', () => {
 			content = data.content;
 		} );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			targetRanges: [ targetViewRange ],
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		expectData(
 			'<img src="" uploadId="#loader1_id" uploadProcessed="true"></img><p>baz</p>',
@@ -1291,7 +1351,11 @@ describe( 'ImageUploadEditing', () => {
 			content = data.content;
 		} );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			targetRanges: [ targetViewRange ],
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		expectData(
 			'<p>baz</p><img src="" uploadId="#loader1_id" uploadProcessed="true"></img>',
@@ -1322,7 +1386,11 @@ describe( 'ImageUploadEditing', () => {
 			} ) );
 		} );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			targetRanges: [ targetViewRange ],
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		tryExpect( done, () => {
 			loader.file.then( file => expect( file.name.split( '.' ).pop() ).to.equal( 'png' ) );
@@ -1347,7 +1415,11 @@ describe( 'ImageUploadEditing', () => {
 			} ) );
 		} );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			targetRanges: [ targetViewRange ],
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		tryExpect( done, () => {
 			loader.file.then( file => expect( file.name.split( '.' ).pop() ).to.equal( 'jpeg' ) );
@@ -1375,7 +1447,11 @@ describe( 'ImageUploadEditing', () => {
 		// Stub `fetch` in a way that it always fails.
 		sinon.stub( window, 'fetch' ).callsFake( () => Promise.reject() );
 
-		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+		viewDocument.fire( 'clipboardInput', {
+			dataTransfer,
+			targetRanges: [ targetViewRange ],
+			content: dataTransfer.getData( 'text/html' )
+		} );
 
 		adapterMocks[ 0 ].loader.file.then( () => {
 			expect.fail( 'Promise should be rejected.' );
@@ -1484,7 +1560,11 @@ describe( 'ImageUploadEditing', () => {
 			const targetRange = model.createRange( model.createPositionAt( doc.getRoot(), 1 ), model.createPositionAt( doc.getRoot(), 1 ) );
 			const targetViewRange = editor.editing.mapper.toViewRange( targetRange );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				targetRanges: [ targetViewRange ],
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			adapterMocks[ 0 ].loader.file.then( () => {
 				setTimeout( () => {
@@ -1512,7 +1592,10 @@ describe( 'ImageUploadEditing', () => {
 				content = data.content;
 			} );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			expectData(
 				'<img src="" uploadId="#loader1_id" uploadProcessed="true"></img>',
@@ -1541,7 +1624,11 @@ describe( 'ImageUploadEditing', () => {
 			const targetRange = model.createRange( model.createPositionAt( doc.getRoot(), 1 ), model.createPositionAt( doc.getRoot(), 1 ) );
 			const targetViewRange = editor.editing.mapper.toViewRange( targetRange );
 
-			viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				targetRanges: [ targetViewRange ],
+				content: dataTransfer.getData( 'text/html' )
+			} );
 
 			adapterMocks[ 0 ].loader.file.then( () => {
 				expect.fail( 'Promise should be rejected.' );

--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -8,7 +8,7 @@
  */
 
 import { Plugin } from '@ckeditor/ckeditor5-core';
-import type { ClipboardInputTransformationData } from '@ckeditor/ckeditor5-clipboard';
+import type { ClipboardInputTransformationEvent } from '@ckeditor/ckeditor5-clipboard';
 import type { ModelDocumentSelectionChangeEvent, Model, ModelPosition, ModelRange, ModelWriter } from '@ckeditor/ckeditor5-engine';
 import { Delete, TextWatcher, getLastTextLine, findAttributeRange, type TextWatcherMatchedDataEvent } from '@ckeditor/ckeditor5-typing';
 import type { EnterCommand, ShiftEnterCommand } from '@ckeditor/ckeditor5-enter';
@@ -163,7 +163,7 @@ export class AutoLink extends Plugin {
 		const clipboardPipeline = editor.plugins.get( 'ClipboardPipeline' );
 		const linkCommand = editor.commands.get( 'link' )!;
 
-		clipboardPipeline.on( 'inputTransformation', ( evt, data: ClipboardInputTransformationData ) => {
+		clipboardPipeline.on<ClipboardInputTransformationEvent>( 'inputTransformation', ( evt, data ) => {
 			if ( !this.isEnabled || !linkCommand.isEnabled || selection.isCollapsed || data.method !== 'paste' ) {
 				// Abort if we are disabled or the selection is collapsed.
 				return;

--- a/packages/ckeditor5-list/tests/listformatting/listitemboldintegration.js
+++ b/packages/ckeditor5-list/tests/listformatting/listitemboldintegration.js
@@ -588,7 +588,8 @@ describe( 'ListItemBoldIntegration', () => {
 			const spy = sinon.stub( editor.model, 'insertContent' );
 
 			editor.editing.view.document.fire( 'clipboardInput', {
-				dataTransfer: dataTransferMock
+				dataTransfer: dataTransferMock,
+				content: dataTransferMock.getData( 'text/html' )
 			} );
 
 			sinon.assert.calledOnce( spy );

--- a/packages/ckeditor5-list/tests/listformatting/listitemfontcolorintegration.js
+++ b/packages/ckeditor5-list/tests/listformatting/listitemfontcolorintegration.js
@@ -541,7 +541,8 @@ describe( 'ListItemFontColorIntegration', () => {
 			const spy = sinon.stub( editor.model, 'insertContent' );
 
 			editor.editing.view.document.fire( 'clipboardInput', {
-				dataTransfer: dataTransferMock
+				dataTransfer: dataTransferMock,
+				content: dataTransferMock.getData( 'text/html' )
 			} );
 
 			sinon.assert.calledOnce( spy );

--- a/packages/ckeditor5-list/tests/listformatting/listitemfontfamilyintegration.js
+++ b/packages/ckeditor5-list/tests/listformatting/listitemfontfamilyintegration.js
@@ -544,7 +544,8 @@ describe( 'ListItemFontFamilyIntegration', () => {
 			const spy = sinon.stub( editor.model, 'insertContent' );
 
 			editor.editing.view.document.fire( 'clipboardInput', {
-				dataTransfer: dataTransferMock
+				dataTransfer: dataTransferMock,
+				content: dataTransferMock.getData( 'text/html' )
 			} );
 
 			sinon.assert.calledOnce( spy );

--- a/packages/ckeditor5-list/tests/listformatting/listitemfontsizeintegration.js
+++ b/packages/ckeditor5-list/tests/listformatting/listitemfontsizeintegration.js
@@ -624,7 +624,8 @@ describe( 'ListItemFontSizeIntegration', () => {
 				const spy = sinon.stub( editor.model, 'insertContent' );
 
 				editor.editing.view.document.fire( 'clipboardInput', {
-					dataTransfer: dataTransferMock
+					dataTransfer: dataTransferMock,
+					content: dataTransferMock.getData( 'text/html' )
 				} );
 
 				sinon.assert.calledOnce( spy );
@@ -1110,7 +1111,8 @@ describe( 'ListItemFontSizeIntegration', () => {
 				const spy = sinon.stub( editor.model, 'insertContent' );
 
 				editor.editing.view.document.fire( 'clipboardInput', {
-					dataTransfer: dataTransferMock
+					dataTransfer: dataTransferMock,
+					content: dataTransferMock.getData( 'text/html' )
 				} );
 
 				sinon.assert.calledOnce( spy );

--- a/packages/ckeditor5-list/tests/listformatting/listitemitalicintegration.js
+++ b/packages/ckeditor5-list/tests/listformatting/listitemitalicintegration.js
@@ -572,7 +572,8 @@ describe( 'ListItemItalicIntegration', () => {
 			const spy = sinon.stub( editor.model, 'insertContent' );
 
 			editor.editing.view.document.fire( 'clipboardInput', {
-				dataTransfer: dataTransferMock
+				dataTransfer: dataTransferMock,
+				content: dataTransferMock.getData( 'text/html' )
 			} );
 
 			sinon.assert.calledOnce( spy );

--- a/packages/ckeditor5-media-embed/src/automediaembed.ts
+++ b/packages/ckeditor5-media-embed/src/automediaembed.ts
@@ -9,7 +9,7 @@
 
 import { type Editor, Plugin } from '@ckeditor/ckeditor5-core';
 import { ModelLiveRange, ModelLivePosition } from '@ckeditor/ckeditor5-engine';
-import { Clipboard, type ClipboardPipeline } from '@ckeditor/ckeditor5-clipboard';
+import { Clipboard, type ClipboardInputTransformationEvent, type ClipboardPipeline } from '@ckeditor/ckeditor5-clipboard';
 import { Delete } from '@ckeditor/ckeditor5-typing';
 import { Undo, type UndoCommand } from '@ckeditor/ckeditor5-undo';
 import { global } from '@ckeditor/ckeditor5-utils';
@@ -79,7 +79,7 @@ export class AutoMediaEmbed extends Plugin {
 		// After pasting, the content between those positions will be checked for a URL that could be transformed
 		// into media.
 		const clipboardPipeline: ClipboardPipeline = editor.plugins.get( 'ClipboardPipeline' );
-		this.listenTo( clipboardPipeline, 'inputTransformation', () => {
+		this.listenTo<ClipboardInputTransformationEvent>( clipboardPipeline, 'inputTransformation', () => {
 			const firstRange = modelDocument.selection.getFirstRange()!;
 
 			const leftLivePosition = ModelLivePosition.fromPosition( firstRange.start );

--- a/packages/ckeditor5-paste-from-office/package.json
+++ b/packages/ckeditor5-paste-from-office/package.json
@@ -37,7 +37,8 @@
   "dependencies": {
     "@ckeditor/ckeditor5-clipboard": "workspace:*",
     "@ckeditor/ckeditor5-core": "workspace:*",
-    "@ckeditor/ckeditor5-engine": "workspace:*"
+    "@ckeditor/ckeditor5-engine": "workspace:*",
+    "@ckeditor/ckeditor5-utils": "workspace:*"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "workspace:*",
@@ -56,8 +57,7 @@
     "@ckeditor/ckeditor5-list": "workspace:*",
     "@ckeditor/ckeditor5-page-break": "workspace:*",
     "@ckeditor/ckeditor5-paragraph": "workspace:*",
-    "@ckeditor/ckeditor5-table": "workspace:*",
-    "@ckeditor/ckeditor5-utils": "workspace:*"
+    "@ckeditor/ckeditor5-table": "workspace:*"
   },
   "scripts": {
     "build": "node ../../scripts/nim/build-package.mjs"

--- a/packages/ckeditor5-paste-from-office/src/index.ts
+++ b/packages/ckeditor5-paste-from-office/src/index.ts
@@ -8,7 +8,7 @@
  */
 
 export { PasteFromOffice } from './pastefromoffice.js';
-export type { PasteFromOfficeNormalizer, PasteFromOfficeNormalizerData } from './normalizer.js';
+export type { PasteFromOfficeNormalizer } from './normalizer.js';
 export { PasteFromOfficeMSWordNormalizer } from './normalizers/mswordnormalizer.js';
 export { parsePasteOfficeHtml, type PasteOfficeHtmlParseResult } from './filters/parse.js';
 

--- a/packages/ckeditor5-paste-from-office/src/normalizer.ts
+++ b/packages/ckeditor5-paste-from-office/src/normalizer.ts
@@ -8,7 +8,6 @@
  */
 
 import type { ClipboardInputTransformationData } from '@ckeditor/ckeditor5-clipboard';
-import type { PasteOfficeHtmlParseResult } from './filters/parse.js';
 
 /**
  * Interface defining a content transformation pasted from an external editor.
@@ -27,10 +26,5 @@ export interface PasteFromOfficeNormalizer {
 	/**
 	 * Executes the normalization of a given data.
 	 */
-	execute( data: PasteFromOfficeNormalizerData ): void;
-}
-
-export interface PasteFromOfficeNormalizerData extends ClipboardInputTransformationData {
-	_isTransformedWithPasteFromOffice?: boolean;
-	_parsedData: PasteOfficeHtmlParseResult;
+	execute( data: ClipboardInputTransformationData ): void;
 }

--- a/packages/ckeditor5-paste-from-office/src/normalizers/googledocsnormalizer.ts
+++ b/packages/ckeditor5-paste-from-office/src/normalizers/googledocsnormalizer.ts
@@ -8,12 +8,13 @@
  */
 
 import { ViewUpcastWriter, type ViewDocument } from '@ckeditor/ckeditor5-engine';
+import type { ClipboardInputTransformationData } from '@ckeditor/ckeditor5-clipboard';
 
 import { removeBoldWrapper } from '../filters/removeboldwrapper.js';
 import { transformBlockBrsToParagraphs } from '../filters/br.js';
 import { unwrapParagraphInListItem } from '../filters/list.js';
 import { replaceTabsWithinPreWithSpaces } from '../filters/replacetabswithinprewithspaces.js';
-import type { PasteFromOfficeNormalizer, PasteFromOfficeNormalizerData } from '../normalizer.js';
+import type { PasteFromOfficeNormalizer } from '../normalizer.js';
 
 const googleDocsMatch = /id=("|')docs-internal-guid-[-0-9a-f]+("|')/i;
 
@@ -44,15 +45,12 @@ export class GoogleDocsNormalizer implements PasteFromOfficeNormalizer {
 	/**
 	 * @inheritDoc
 	 */
-	public execute( data: PasteFromOfficeNormalizerData ): void {
+	public execute( data: ClipboardInputTransformationData ): void {
 		const writer = new ViewUpcastWriter( this.document );
-		const { body: documentFragment } = data._parsedData;
 
-		removeBoldWrapper( documentFragment, writer );
-		unwrapParagraphInListItem( documentFragment, writer );
-		transformBlockBrsToParagraphs( documentFragment, writer );
-		replaceTabsWithinPreWithSpaces( documentFragment, writer, 8 );
-
-		data.content = documentFragment;
+		removeBoldWrapper( data.content, writer );
+		unwrapParagraphInListItem( data.content, writer );
+		transformBlockBrsToParagraphs( data.content, writer );
+		replaceTabsWithinPreWithSpaces( data.content, writer, 8 );
 	}
 }

--- a/packages/ckeditor5-paste-from-office/src/normalizers/googlesheetsnormalizer.ts
+++ b/packages/ckeditor5-paste-from-office/src/normalizers/googlesheetsnormalizer.ts
@@ -8,12 +8,13 @@
  */
 
 import { ViewUpcastWriter, type ViewDocument } from '@ckeditor/ckeditor5-engine';
+import type { ClipboardInputTransformationData } from '@ckeditor/ckeditor5-clipboard';
 
 import { removeXmlns } from '../filters/removexmlns.js';
 import { removeGoogleSheetsTag } from '../filters/removegooglesheetstag.js';
 import { removeInvalidTableWidth } from '../filters/removeinvalidtablewidth.js';
 import { removeStyleBlock } from '../filters/removestyleblock.js';
-import type { PasteFromOfficeNormalizer, PasteFromOfficeNormalizerData } from '../normalizer.js';
+import type { PasteFromOfficeNormalizer } from '../normalizer.js';
 
 const googleSheetsMatch = /<google-sheets-html-origin/i;
 
@@ -44,15 +45,12 @@ export class GoogleSheetsNormalizer implements PasteFromOfficeNormalizer {
 	/**
 	 * @inheritDoc
 	 */
-	public execute( data: PasteFromOfficeNormalizerData ): void {
+	public execute( data: ClipboardInputTransformationData ): void {
 		const writer = new ViewUpcastWriter( this.document );
-		const { body: documentFragment } = data._parsedData;
 
-		removeGoogleSheetsTag( documentFragment, writer );
-		removeXmlns( documentFragment, writer );
-		removeInvalidTableWidth( documentFragment, writer );
-		removeStyleBlock( documentFragment, writer );
-
-		data.content = documentFragment;
+		removeGoogleSheetsTag( data.content, writer );
+		removeXmlns( data.content, writer );
+		removeInvalidTableWidth( data.content, writer );
+		removeStyleBlock( data.content, writer );
 	}
 }

--- a/packages/ckeditor5-paste-from-office/src/normalizers/mswordnormalizer.ts
+++ b/packages/ckeditor5-paste-from-office/src/normalizers/mswordnormalizer.ts
@@ -7,6 +7,8 @@
  * @module paste-from-office/normalizers/mswordnormalizer
  */
 
+import type { ClipboardInputTransformationData } from '@ckeditor/ckeditor5-clipboard';
+
 import { transformBookmarks } from '../filters/bookmark.js';
 import { transformListItemLikeElementsIntoLists } from '../filters/list.js';
 import { replaceImagesSourceWithBase64 } from '../filters/image.js';
@@ -15,7 +17,7 @@ import { transformTables } from '../filters/table.js';
 import { removeInvalidTableWidth } from '../filters/removeinvalidtablewidth.js';
 import { replaceMSFootnotes } from '../filters/replacemsfootnotes.js';
 import { ViewUpcastWriter, type ViewDocument } from '@ckeditor/ckeditor5-engine';
-import type { PasteFromOfficeNormalizer, PasteFromOfficeNormalizerData } from '../normalizer.js';
+import type { PasteFromOfficeNormalizer } from '../normalizer.js';
 
 const msWordMatch1 = /<meta\s*name="?generator"?\s*content="?microsoft\s*word\s*\d+"?\/?>/i;
 const msWordMatch2 = /xmlns:o="urn:schemas-microsoft-com/i;
@@ -55,18 +57,16 @@ export class PasteFromOfficeMSWordNormalizer implements PasteFromOfficeNormalize
 	/**
 	 * @inheritDoc
 	 */
-	public execute( data: PasteFromOfficeNormalizerData ): void {
+	public execute( data: ClipboardInputTransformationData ): void {
 		const writer = new ViewUpcastWriter( this.document );
-		const { body: documentFragment, stylesString } = data._parsedData;
+		const stylesString = ( data.extraContent as { stylesString: string } ).stylesString;
 
-		transformBookmarks( documentFragment, writer );
-		transformListItemLikeElementsIntoLists( documentFragment, stylesString, this.hasMultiLevelListPlugin );
-		replaceImagesSourceWithBase64( documentFragment, data.dataTransfer.getData( 'text/rtf' ) );
-		transformTables( documentFragment, writer, this.hasTablePropertiesPlugin );
-		removeInvalidTableWidth( documentFragment, writer );
-		replaceMSFootnotes( documentFragment, writer );
-		removeMSAttributes( documentFragment );
-
-		data.content = documentFragment;
+		transformBookmarks( data.content, writer );
+		transformListItemLikeElementsIntoLists( data.content, stylesString, this.hasMultiLevelListPlugin );
+		replaceImagesSourceWithBase64( data.content, data.dataTransfer.getData( 'text/rtf' ) );
+		transformTables( data.content, writer, this.hasTablePropertiesPlugin );
+		removeInvalidTableWidth( data.content, writer );
+		replaceMSFootnotes( data.content, writer );
+		removeMSAttributes( data.content );
 	}
 }

--- a/packages/ckeditor5-paste-from-office/src/pastefromoffice.ts
+++ b/packages/ckeditor5-paste-from-office/src/pastefromoffice.ts
@@ -8,15 +8,20 @@
  */
 
 import { Plugin } from '@ckeditor/ckeditor5-core';
+import { insertToPriorityArray, priorities, type PriorityString } from '@ckeditor/ckeditor5-utils';
 
-import { ClipboardPipeline } from '@ckeditor/ckeditor5-clipboard';
+import {
+	ClipboardPipeline,
+	type ClipboardInputTransformationEvent,
+	type ViewDocumentClipboardInputEvent
+} from '@ckeditor/ckeditor5-clipboard';
 
 import { PasteFromOfficeMSWordNormalizer } from './normalizers/mswordnormalizer.js';
 import { GoogleDocsNormalizer } from './normalizers/googledocsnormalizer.js';
 import { GoogleSheetsNormalizer } from './normalizers/googlesheetsnormalizer.js';
 
 import { parsePasteOfficeHtml } from './filters/parse.js';
-import type { PasteFromOfficeNormalizer, PasteFromOfficeNormalizerData } from './normalizer.js';
+import type { PasteFromOfficeNormalizer } from './normalizer.js';
 
 /**
  * The Paste from Office plugin.
@@ -32,6 +37,14 @@ import type { PasteFromOfficeNormalizer, PasteFromOfficeNormalizerData } from '.
  * For more information about this feature check the {@glink api/paste-from-office package page}.
  */
 export class PasteFromOffice extends Plugin {
+	/**
+	 * The priority array of registered normalizers.
+	 */
+	private _normalizers = [] as Array<{
+		normalizer: PasteFromOfficeNormalizer;
+		priority: PriorityString;
+	}>;
+
 	/**
 	 * @inheritDoc
 	 */
@@ -75,47 +88,61 @@ export class PasteFromOffice extends Plugin {
 		const editor = this.editor;
 		const clipboardPipeline: ClipboardPipeline = editor.plugins.get( 'ClipboardPipeline' );
 		const viewDocument = editor.editing.view.document;
-		const normalizers: Array<PasteFromOfficeNormalizer> = [];
 		const hasMultiLevelListPlugin = this.editor.plugins.has( 'MultiLevelListEditing' );
 		const hasTablePropertiesPlugin = this.editor.plugins.has( 'TablePropertiesEditing' );
 
-		normalizers.push(
+		this.registerNormalizer(
 			new PasteFromOfficeMSWordNormalizer(
 				viewDocument,
 				hasMultiLevelListPlugin,
 				hasTablePropertiesPlugin
 			)
 		);
-		normalizers.push( new GoogleDocsNormalizer( viewDocument ) );
-		normalizers.push( new GoogleSheetsNormalizer( viewDocument ) );
 
-		clipboardPipeline.on(
-			'inputTransformation',
-			( evt, data: PasteFromOfficeNormalizerData ) => {
-				if ( data._isTransformedWithPasteFromOffice ) {
-					return;
-				}
+		this.registerNormalizer( new GoogleDocsNormalizer( viewDocument ) );
+		this.registerNormalizer( new GoogleSheetsNormalizer( viewDocument ) );
 
-				const codeBlock = editor.model.document.selection.getFirstPosition()!.parent;
+		viewDocument.on<ViewDocumentClipboardInputEvent>( 'clipboardInput', ( evt, data ) => {
+			if ( typeof data.content != 'string' ) {
+				return;
+			}
 
-				if ( codeBlock.is( 'element', 'codeBlock' ) ) {
-					return;
-				}
+			const htmlString = data.dataTransfer.getData( 'text/html' );
+			const activeNormalizer = this._normalizers.find( ( { normalizer } ) => normalizer.isActive( htmlString ) );
 
-				const htmlString = data.dataTransfer.getData( 'text/html' );
-				const activeNormalizer = normalizers.find( normalizer => normalizer.isActive( htmlString ) );
+			if ( activeNormalizer ) {
+				const parsedData = parsePasteOfficeHtml( data.content, viewDocument.stylesProcessor );
 
-				if ( activeNormalizer ) {
-					if ( !data._parsedData ) {
-						data._parsedData = parsePasteOfficeHtml( htmlString, viewDocument.stylesProcessor );
-					}
+				data.content = parsedData.body;
+				data.extraContent = { ...parsedData, isTransformedWithPasteFromOffice: true };
+			}
+		}, { priority: priorities.low + 10 } );
 
-					activeNormalizer.execute( data );
+		clipboardPipeline.on<ClipboardInputTransformationEvent>( 'inputTransformation', ( evt, data ) => {
+			if ( !data.extraContent || !( data.extraContent as any ).isTransformedWithPasteFromOffice ) {
+				return;
+			}
 
-					data._isTransformedWithPasteFromOffice = true;
-				}
-			},
-			{ priority: 'high' }
-		);
+			const htmlString = data.dataTransfer.getData( 'text/html' );
+			const normalizers = this._normalizers.filter( ( { normalizer } ) => normalizer.isActive( htmlString ) );
+
+			for ( const { normalizer } of normalizers ) {
+				normalizer.execute( data );
+			}
+		},
+		{ priority: 'high' } );
+	}
+
+	/**
+	 * Registers a normalizer with the given priority.
+	 */
+	public registerNormalizer(
+		normalizer: PasteFromOfficeNormalizer,
+		priority?: PriorityString
+	): void {
+		insertToPriorityArray( this._normalizers, {
+			normalizer,
+			priority: priorities.get( priority )
+		} );
 	}
 }

--- a/packages/ckeditor5-paste-from-office/src/pastefromoffice.ts
+++ b/packages/ckeditor5-paste-from-office/src/pastefromoffice.ts
@@ -107,6 +107,8 @@ export class PasteFromOffice extends Plugin {
 				return;
 			}
 
+			// The `htmlString` is used only to detect (match) the active normalizer.
+			// The actual content processing is happening on `data.content` below.
 			const htmlString = data.dataTransfer.getData( 'text/html' );
 			const activeNormalizer = this._normalizers.find( ( { normalizer } ) => normalizer.isActive( htmlString ) );
 
@@ -123,6 +125,7 @@ export class PasteFromOffice extends Plugin {
 				return;
 			}
 
+			// The `htmlString` is used only to detect (match) the active normalizers, not for processing.
 			const htmlString = data.dataTransfer.getData( 'text/html' );
 			const normalizers = this._normalizers.filter( ( { normalizer } ) => normalizer.isActive( htmlString ) );
 

--- a/packages/ckeditor5-paste-from-office/tests/_utils/utils.js
+++ b/packages/ckeditor5-paste-from-office/tests/_utils/utils.js
@@ -6,18 +6,12 @@
 import { VirtualTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor.js';
 import { ClassicTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
 import {
-	ViewDocument,
-	HtmlDataProcessor,
 	_setModelData,
 	_stringifyModel,
-	_stringifyView,
-	StylesProcessor
+	_stringifyView
 } from '@ckeditor/ckeditor5-engine';
 
-import { _normalizeClipboardData } from '@ckeditor/ckeditor5-clipboard';
 import { normalizeHtml } from '@ckeditor/ckeditor5-utils/tests/_utils/normalizehtml.js';
-
-const htmlDataProcessor = new HtmlDataProcessor( new ViewDocument( new StylesProcessor() ) );
 
 /**
  * Mocks dataTransfer object which can be used for simulating paste.
@@ -156,9 +150,13 @@ function generateNormalizationTests( title, fixtures, editorConfig, skip, only )
 
 		beforeEach( async () => {
 			editor = await VirtualTestEditor.create( await editorConfig() );
+
+			// Stub `editor.editing.view.scrollToTheSelection` as it will fail on VirtualTestEditor without DOM.
+			sinon.stub( editor.editing.view, 'scrollToTheSelection' );
 		} );
 
 		afterEach( async () => {
+			sinon.restore();
 			await editor.destroy();
 		} );
 
@@ -174,16 +172,23 @@ function generateNormalizationTests( title, fixtures, editorConfig, skip, only )
 			testRunner( name, () => {
 				// Simulate data from Clipboard event
 				const clipboardPlugin = editor.plugins.get( 'ClipboardPipeline' );
-				const content = htmlDataProcessor.toView( _normalizeClipboardData( fixtures.input[ name ] ) );
 				const dataTransfer = createDataTransfer( {
 					'text/html': fixtures.input[ name ],
 					'text/rtf': fixtures.inputRtf && fixtures.inputRtf[ name ]
 				} );
 
 				// data.content might be completely overwritten with a new object, so we need obtain final result for comparison.
-				const data = { content, dataTransfer };
-				clipboardPlugin.fire( 'inputTransformation', data );
-				const transformedContent = data.content;
+				let inputTransformationData;
+
+				clipboardPlugin.on( 'inputTransformation', ( evt, data ) => {
+					inputTransformationData = data;
+				} );
+
+				const clipboardInputData = { dataTransfer, content: fixtures.input[ name ] };
+
+				editor.editing.view.document.fire( 'clipboardInput', clipboardInputData );
+
+				const transformedContent = inputTransformationData.content;
 
 				expectNormalized(
 					transformedContent,

--- a/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
+++ b/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
@@ -7,22 +7,17 @@ import { PasteFromOffice } from '../src/pastefromoffice.js';
 import { ClipboardPipeline } from '@ckeditor/ckeditor5-clipboard';
 import { ClassicTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
 import {
-	HtmlDataProcessor,
-	StylesProcessor,
-	ViewDocument,
 	ViewDocumentFragment,
-	_setModelData,
-	ViewDomConverter
+	_getModelData,
+	_setModelData
 } from '@ckeditor/ckeditor5-engine';
 import { createDataTransfer } from './_utils/utils.js';
 import { testUtils } from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
 import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
 import { CodeBlockUI, CodeBlockEditing } from '@ckeditor/ckeditor5-code-block';
-import { priorities } from '@ckeditor/ckeditor5-utils';
 
 describe( 'PasteFromOffice', () => {
-	const htmlDataProcessor = new HtmlDataProcessor( new ViewDocument( new StylesProcessor() ) );
-	let editor, pasteFromOffice, clipboard, element;
+	let editor, pasteFromOffice, clipboard, element, viewDocument;
 
 	testUtils.createSinonSandbox();
 
@@ -35,6 +30,7 @@ describe( 'PasteFromOffice', () => {
 		} );
 		pasteFromOffice = editor.plugins.get( 'PasteFromOffice' );
 		clipboard = editor.plugins.get( 'ClipboardPipeline' );
+		viewDocument = editor.editing.view.document;
 	} );
 
 	afterEach( () => {
@@ -67,38 +63,7 @@ describe( 'PasteFromOffice', () => {
 		expect( editor.plugins.get( ClipboardPipeline ) ).to.be.instanceOf( ClipboardPipeline );
 	} );
 
-	it( 'should work on already parsed data if another plugin hooked into #inputTransformation with a higher priority', () => {
-		const clipboardPipeline = editor.plugins.get( 'ClipboardPipeline' );
-		const viewDocument = editor.editing.view.document;
-
-		// Simulate a plugin that hooks into the pipeline earlier and parses the data.
-		clipboardPipeline.on( 'inputTransformation', ( evt, data ) => {
-			const domParser = new DOMParser();
-			const htmlDocument = domParser.parseFromString( '<p>Existing data</p>', 'text/html' );
-			const domConverter = new ViewDomConverter( viewDocument, { renderingMode: 'data' } );
-			const fragment = htmlDocument.createDocumentFragment();
-
-			data._parsedData = {
-				body: domConverter.domToView( fragment, { skipComments: true } ),
-				bodyString: '<body>Already parsed data</body>',
-				styles: [],
-				stylesString: ''
-			};
-		}, { priority: priorities.get( 'high' ) + 1 } );
-
-		const eventData = {
-			content: htmlDataProcessor.toView( '<meta name=Generator content="Microsoft Word 15">' ),
-			dataTransfer: createDataTransfer( { 'text/html': '<meta name=Generator content="Microsoft Word 15">' } )
-		};
-
-		// Trigger some event that would normally trigger the paste from office plugin.
-		clipboard.fire( 'inputTransformation', eventData );
-
-		// Verify if the PFO plugin works on an already parsed data.
-		expect( eventData._parsedData.bodyString ).to.equal( '<body>Already parsed data</body>' );
-	} );
-
-	describe( 'isTransformedWithPasteFromOffice - flag', () => {
+	describe( 'parsed with extraContent property set', () => {
 		describe( 'data which should be marked with flag', () => {
 			it( 'should process data with microsoft word header', () => {
 				checkCorrectData( '<meta name=Generator content="Microsoft Word 15">' );
@@ -130,7 +95,13 @@ describe( 'PasteFromOffice', () => {
 				const data = setUpData( inputString );
 				const getDataSpy = sinon.spy( data.dataTransfer, 'getData' );
 
-				clipboard.fire( 'inputTransformation', data );
+				viewDocument.fire( 'clipboardInput', data );
+
+				expect( data.extraContent ).to.have.property( 'body' );
+				expect( data.extraContent ).to.have.property( 'bodyString' );
+				expect( data.extraContent ).to.have.property( 'styles' );
+				expect( data.extraContent ).to.have.property( 'stylesString' );
+				expect( data.content ).to.be.instanceOf( ViewDocumentFragment );
 
 				expect( data._isTransformedWithPasteFromOffice ).to.be.true;
 				expect( data._parsedData ).to.have.property( 'body' );
@@ -170,10 +141,9 @@ describe( 'PasteFromOffice', () => {
 				const data = setUpData( '<p id="docs-internal-guid-12345678-1234-1234-1234-1234567890ab"></p>' );
 				const getDataSpy = sinon.spy( data.dataTransfer, 'getData' );
 
-				clipboard.fire( 'inputTransformation', data );
+				clipboard.fire( 'clipboardInput', data );
 
-				expect( data._isTransformedWithPasteFromOffice ).to.be.undefined;
-				expect( data._parsedData ).to.be.undefined;
+				expect( data.extraContent ).to.be.undefined;
 
 				sinon.assert.notCalled( getDataSpy );
 			} );
@@ -182,16 +152,16 @@ describe( 'PasteFromOffice', () => {
 				const data = setUpData( inputString );
 				const getDataSpy = sinon.spy( data.dataTransfer, 'getData' );
 
-				clipboard.fire( 'inputTransformation', data );
+				viewDocument.fire( 'clipboardInput', data );
 
-				expect( data._isTransformedWithPasteFromOffice ).to.be.undefined;
-				expect( data._parsedData ).to.be.undefined;
+				expect( data.extraContent ).to.be.undefined;
+				expect( data.content ).to.deep.equal( inputString );
 
 				sinon.assert.called( getDataSpy );
 			}
 		} );
 
-		describe( 'data which already have the flag', () => {
+		describe.skip( 'data which already have the flag', () => {
 			it( 'should not process again ms word data containing a flag', () => {
 				checkAlreadyProcessedData( '<meta name=Generator content="Microsoft Word 15">' +
 					'<p class="MsoNormal">Hello world<o:p></o:p></p>' );
@@ -216,19 +186,80 @@ describe( 'PasteFromOffice', () => {
 		} );
 	} );
 
+	describe( 'code block integration', () => {
+		it( 'should not intercept input when selection anchored outside any code block', () => {
+			_setModelData( editor.model, '<paragraph>f[]oo</paragraph>' );
+
+			const clipboardPlugin = editor.plugins.get( ClipboardPipeline );
+			const contentInsertionSpy = sinon.spy();
+			const getDataStub = sinon.stub();
+
+			clipboardPlugin.on( 'contentInsertion', contentInsertionSpy );
+
+			getDataStub.withArgs( 'text/html' ).returns( 'abc' );
+			getDataStub.withArgs( 'text/plain' ).returns( 'bar\nbaz\n' );
+
+			const dataTransferMock = {
+				getData: getDataStub
+			};
+
+			viewDocument.fire( 'clipboardInput', {
+				content: 'abc',
+				dataTransfer: dataTransferMock,
+				stop: sinon.spy()
+			} );
+
+			expect( _getModelData( editor.model ) ).to.equal( '<paragraph>fabc[]oo</paragraph>' );
+
+			// Make sure that ClipboardPipeline was not interrupted.
+			sinon.assert.calledOnce( contentInsertionSpy );
+		} );
+
+		it( 'should intercept input when selection anchored in the code block', () => {
+			_setModelData( editor.model, '<codeBlock language="css">f[o]o</codeBlock>' );
+
+			const clipboardPlugin = editor.plugins.get( ClipboardPipeline );
+			const contentInsertionSpy = sinon.spy();
+			const getDataStub = sinon.stub();
+
+			clipboardPlugin.on( 'contentInsertion', contentInsertionSpy );
+
+			getDataStub.withArgs( 'text/html' ).returns( 'abc' );
+			getDataStub.withArgs( 'text/plain' ).returns( 'bar\nbaz\n' );
+
+			const dataTransferMock = {
+				getData: getDataStub
+			};
+
+			viewDocument.fire( 'clipboardInput', {
+				content: 'abc',
+				dataTransfer: dataTransferMock,
+				stop: sinon.spy()
+			} );
+
+			expect( _getModelData( editor.model ) ).to.equal(
+				'<codeBlock language="css">' +
+					'fbar' +
+					'<softBreak></softBreak>' +
+					'baz' +
+					'<softBreak></softBreak>' +
+					'[]o' +
+				'</codeBlock>' );
+
+			sinon.assert.calledOnce( dataTransferMock.getData );
+
+			// Make sure that ClipboardPipeline was not interrupted.
+			sinon.assert.calledOnce( contentInsertionSpy );
+		} );
+	} );
+
 	// @param {String} inputString html to be processed by paste from office
 	// @param {Boolean} [isTransformedWithPasteFromOffice=false] if set, marks output data with isTransformedWithPasteFromOffice flag
 	// @returns {Object} data object simulating content obtained from the clipboard
-	function setUpData( inputString, isTransformedWithPasteFromOffice = false ) {
-		const data = {
-			content: htmlDataProcessor.toView( inputString ),
+	function setUpData( inputString ) {
+		return {
+			content: inputString,
 			dataTransfer: createDataTransfer( { 'text/html': inputString } )
 		};
-
-		if ( isTransformedWithPasteFromOffice ) {
-			data._isTransformedWithPasteFromOffice = true;
-		}
-
-		return data;
 	}
 } );

--- a/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
+++ b/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
@@ -141,7 +141,7 @@ describe( 'PasteFromOffice', () => {
 				const data = setUpData( '<p id="docs-internal-guid-12345678-1234-1234-1234-1234567890ab"></p>' );
 				const getDataSpy = sinon.spy( data.dataTransfer, 'getData' );
 
-				clipboard.fire( 'clipboardInput', data );
+				viewDocument.fire( 'clipboardInput', data );
 
 				expect( data.extraContent ).to.be.undefined;
 

--- a/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
+++ b/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
@@ -17,7 +17,7 @@ import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
 import { CodeBlockUI, CodeBlockEditing } from '@ckeditor/ckeditor5-code-block';
 
 describe( 'PasteFromOffice', () => {
-	let editor, pasteFromOffice, clipboard, element, viewDocument;
+	let editor, pasteFromOffice, element, viewDocument;
 
 	testUtils.createSinonSandbox();
 
@@ -29,7 +29,6 @@ describe( 'PasteFromOffice', () => {
 			plugins: [ PasteFromOffice, Paragraph, CodeBlockEditing, CodeBlockUI ]
 		} );
 		pasteFromOffice = editor.plugins.get( 'PasteFromOffice' );
-		clipboard = editor.plugins.get( 'ClipboardPipeline' );
 		viewDocument = editor.editing.view.document;
 	} );
 
@@ -103,13 +102,6 @@ describe( 'PasteFromOffice', () => {
 				expect( data.extraContent ).to.have.property( 'stylesString' );
 				expect( data.content ).to.be.instanceOf( ViewDocumentFragment );
 
-				expect( data._isTransformedWithPasteFromOffice ).to.be.true;
-				expect( data._parsedData ).to.have.property( 'body' );
-				expect( data._parsedData ).to.have.property( 'bodyString' );
-				expect( data._parsedData ).to.have.property( 'styles' );
-				expect( data._parsedData ).to.have.property( 'stylesString' );
-				expect( data._parsedData.body ).to.be.instanceOf( ViewDocumentFragment );
-
 				sinon.assert.called( getDataSpy );
 			}
 		} );
@@ -138,14 +130,14 @@ describe( 'PasteFromOffice', () => {
 			it( 'should process data for codeBlock', () => {
 				_setModelData( editor.model, '<codeBlock language="plaintext">[]</codeBlock>' );
 
-				const data = setUpData( '<p id="docs-internal-guid-12345678-1234-1234-1234-1234567890ab"></p>' );
+				const data = setUpData( '<p id="docs-internal-guid-12345678-1234-1234-1234-1234567890ab"></p>', '' );
 				const getDataSpy = sinon.spy( data.dataTransfer, 'getData' );
 
 				viewDocument.fire( 'clipboardInput', data );
 
 				expect( data.extraContent ).to.be.undefined;
 
-				sinon.assert.notCalled( getDataSpy );
+				sinon.assert.called( getDataSpy );
 			} );
 
 			function checkNotProcessedData( inputString ) {
@@ -158,30 +150,6 @@ describe( 'PasteFromOffice', () => {
 				expect( data.content ).to.deep.equal( inputString );
 
 				sinon.assert.called( getDataSpy );
-			}
-		} );
-
-		describe.skip( 'data which already have the flag', () => {
-			it( 'should not process again ms word data containing a flag', () => {
-				checkAlreadyProcessedData( '<meta name=Generator content="Microsoft Word 15">' +
-					'<p class="MsoNormal">Hello world<o:p></o:p></p>' );
-			} );
-
-			it( 'should not process again google docs data containing a flag', () => {
-				checkAlreadyProcessedData( '<meta charset="utf-8"><b id="docs-internal-guid-30db46f5-7fff-15a1-e17c-1234567890ab"' +
-					'style="font-weight:normal;"><p dir="ltr">Hello world</p></b>' );
-			} );
-
-			function checkAlreadyProcessedData( inputString ) {
-				const data = setUpData( inputString, true );
-				const getDataSpy = sinon.spy( data.dataTransfer, 'getData' );
-
-				clipboard.fire( 'inputTransformation', data );
-
-				expect( data._isTransformedWithPasteFromOffice ).to.be.true;
-				expect( data._parsedData ).to.be.undefined;
-
-				sinon.assert.notCalled( getDataSpy );
 			}
 		} );
 	} );
@@ -246,20 +214,22 @@ describe( 'PasteFromOffice', () => {
 					'[]o' +
 				'</codeBlock>' );
 
-			sinon.assert.calledOnce( dataTransferMock.getData );
+			expect( dataTransferMock.getData ).to.be.called;
 
 			// Make sure that ClipboardPipeline was not interrupted.
 			sinon.assert.calledOnce( contentInsertionSpy );
 		} );
 	} );
 
-	// @param {String} inputString html to be processed by paste from office
-	// @param {Boolean} [isTransformedWithPasteFromOffice=false] if set, marks output data with isTransformedWithPasteFromOffice flag
-	// @returns {Object} data object simulating content obtained from the clipboard
-	function setUpData( inputString ) {
+	function setUpData( htmlString, plainTextString ) {
 		return {
-			content: inputString,
-			dataTransfer: createDataTransfer( { 'text/html': inputString } )
+			content: htmlString,
+			dataTransfer: createDataTransfer( {
+				'text/html': htmlString,
+				...typeof plainTextString === 'string' && {
+					'text/plain': plainTextString
+				}
+			} )
 		};
 	}
 } );

--- a/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeediting-block.js
+++ b/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeediting-block.js
@@ -702,8 +702,11 @@ describe( 'RestrictedEditingModeEditing - block exceptions', () => {
 
 				model.change( writer => writer.setSelection( model.document.getRoot().getChild( 0 ), 3 ) );
 
+				const dataTransfer = createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } );
+
 				viewDoc.fire( 'clipboardInput', {
-					dataTransfer: createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } )
+					dataTransfer,
+					content: dataTransfer.getData( 'text/html' )
 				} );
 
 				sinon.assert.notCalled( spy );
@@ -724,8 +727,11 @@ describe( 'RestrictedEditingModeEditing - block exceptions', () => {
 
 				model.change( writer => writer.setSelection( model.document.getRoot().getChild( 0 ), 'in' ) );
 
+				const dataTransfer = createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } );
+
 				viewDoc.fire( 'clipboardInput', {
-					dataTransfer: createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } )
+					dataTransfer,
+					content: dataTransfer.getData( 'text/html' )
 				} );
 
 				sinon.assert.notCalled( spy );
@@ -751,8 +757,11 @@ describe( 'RestrictedEditingModeEditing - block exceptions', () => {
 					)
 				) );
 
+				const dataTransfer = createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } );
+
 				viewDoc.fire( 'clipboardInput', {
-					dataTransfer: createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } )
+					dataTransfer,
+					content: dataTransfer.getData( 'text/html' )
 				} );
 
 				sinon.assert.notCalled( spy );
@@ -778,8 +787,11 @@ describe( 'RestrictedEditingModeEditing - block exceptions', () => {
 					)
 				) );
 
+				const dataTransfer = createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } );
+
 				viewDoc.fire( 'clipboardInput', {
-					dataTransfer: createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } )
+					dataTransfer,
+					content: dataTransfer.getData( 'text/html' )
 				} );
 
 				sinon.assert.notCalled( spy );
@@ -802,8 +814,11 @@ describe( 'RestrictedEditingModeEditing - block exceptions', () => {
 				} );
 
 				it( 'should paste text inside exception marker', () => {
+					const dataTransfer = createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } );
+
 					viewDoc.fire( 'clipboardInput', {
-						dataTransfer: createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } )
+						dataTransfer,
+						content: dataTransfer.getData( 'text/html' )
 					} );
 
 					expect( _getModelData( model ) ).to.equal(
@@ -818,11 +833,14 @@ describe( 'RestrictedEditingModeEditing - block exceptions', () => {
 				} );
 
 				it( 'should paste allowed text attributes inside exception marker', () => {
+					const dataTransfer = createDataTransfer( {
+						'text/html': '<p><a href="foo"><b><i>XXX</i></b></a></p>',
+						'text/plain': 'XXX'
+					} );
+
 					viewDoc.fire( 'clipboardInput', {
-						dataTransfer: createDataTransfer( {
-							'text/html': '<p><a href="foo"><b><i>XXX</i></b></a></p>',
-							'text/plain': 'XXX'
-						} )
+						dataTransfer,
+						content: dataTransfer.getData( 'text/html' )
 					} );
 
 					expect( _getModelData( model ) ).to.equal(
@@ -841,8 +859,11 @@ describe( 'RestrictedEditingModeEditing - block exceptions', () => {
 				} );
 
 				it( 'should paste disallowed (for inline exceptions) text attributes inside exception marker', () => {
+					const dataTransfer = createDataTransfer( { 'text/html': '<p><s>XXX</s></p>', 'text/plain': 'XXX' } );
+
 					viewDoc.fire( 'clipboardInput', {
-						dataTransfer: createDataTransfer( { 'text/html': '<p><s>XXX</s></p>', 'text/plain': 'XXX' } )
+						dataTransfer,
+						content: dataTransfer.getData( 'text/html' )
 					} );
 
 					expect( _getModelData( model ) ).to.equal(
@@ -856,8 +877,11 @@ describe( 'RestrictedEditingModeEditing - block exceptions', () => {
 				} );
 
 				it( 'should allow pasting block elements', () => {
+					const dataTransfer = createDataTransfer( { 'text/html': '<blockquote><p>XXX</p></blockquote>', 'text/plain': 'XXX' } );
+
 					viewDoc.fire( 'clipboardInput', {
-						dataTransfer: createDataTransfer( { 'text/html': '<blockquote><p>XXX</p></blockquote>', 'text/plain': 'XXX' } )
+						dataTransfer,
+						content: dataTransfer.getData( 'text/html' )
 					} );
 
 					expect( _getModelData( model ) ).to.equal(
@@ -873,8 +897,11 @@ describe( 'RestrictedEditingModeEditing - block exceptions', () => {
 				} );
 
 				it( 'should allow pasting multiple block elements', () => {
+					const dataTransfer = createDataTransfer( { 'text/html': '<p>XXX</p><p>YYY</p><p>ZZZ</p>', 'text/plain': 'XXX' } );
+
 					viewDoc.fire( 'clipboardInput', {
-						dataTransfer: createDataTransfer( { 'text/html': '<p>XXX</p><p>YYY</p><p>ZZZ</p>', 'text/plain': 'XXX' } )
+						dataTransfer,
+						content: dataTransfer.getData( 'text/html' )
 					} );
 
 					expect( _getModelData( model ) ).to.equal(
@@ -890,18 +917,21 @@ describe( 'RestrictedEditingModeEditing - block exceptions', () => {
 				} );
 
 				it( 'should strip block exception while pasting', () => {
+					const dataTransfer = createDataTransfer( {
+						'text/html':
+							'<p>AAA</p>' +
+							'<div class="restricted-editing-exception">XXX</div>' +
+							'<blockquote>' +
+								'<p>BBB</p>' +
+								'<div class="restricted-editing-exception">YYY</div>' +
+							'</blockquote>' +
+							'<p>CCC</p>',
+						'text/plain': 'XXX'
+					} );
+
 					viewDoc.fire( 'clipboardInput', {
-						dataTransfer: createDataTransfer( {
-							'text/html':
-								'<p>AAA</p>' +
-								'<div class="restricted-editing-exception">XXX</div>' +
-								'<blockquote>' +
-									'<p>BBB</p>' +
-									'<div class="restricted-editing-exception">YYY</div>' +
-								'</blockquote>' +
-								'<p>CCC</p>',
-							'text/plain': 'XXX'
-						} )
+						dataTransfer,
+						content: dataTransfer.getData( 'text/html' )
 					} );
 
 					expect( _getModelData( model ) ).to.equal(

--- a/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeediting.js
+++ b/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeediting.js
@@ -1325,8 +1325,11 @@ describe( 'RestrictedEditingModeEditing', () => {
 
 				editor.plugins.get( 'ClipboardPipeline' ).on( 'contentInsertion', spy );
 
+				const dataTransfer = createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } );
+
 				viewDoc.fire( 'clipboardInput', {
-					dataTransfer: createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } )
+					dataTransfer,
+					content: dataTransfer.getData( 'text/html' )
 				} );
 
 				sinon.assert.notCalled( spy );
@@ -1339,8 +1342,11 @@ describe( 'RestrictedEditingModeEditing', () => {
 
 				editor.plugins.get( 'ClipboardPipeline' ).on( 'contentInsertion', spy );
 
+				const dataTransfer = createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } );
+
 				viewDoc.fire( 'clipboardInput', {
-					dataTransfer: createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } )
+					content: dataTransfer.getData( 'text/html' ),
+					dataTransfer
 				} );
 
 				sinon.assert.notCalled( spy );
@@ -1355,8 +1361,11 @@ describe( 'RestrictedEditingModeEditing', () => {
 
 				editor.plugins.get( 'ClipboardPipeline' ).on( 'contentInsertion', spy );
 
+				const dataTransfer = createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } );
+
 				viewDoc.fire( 'clipboardInput', {
-					dataTransfer: createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } )
+					content: dataTransfer.getData( 'text/html' ),
+					dataTransfer
 				} );
 
 				sinon.assert.notCalled( spy );
@@ -1371,8 +1380,11 @@ describe( 'RestrictedEditingModeEditing', () => {
 
 				editor.plugins.get( 'ClipboardPipeline' ).on( 'contentInsertion', spy );
 
+				const dataTransfer = createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } );
+
 				viewDoc.fire( 'clipboardInput', {
-					dataTransfer: createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } )
+					content: dataTransfer.getData( 'text/html' ),
+					dataTransfer
 				} );
 
 				sinon.assert.notCalled( spy );
@@ -1385,8 +1397,11 @@ describe( 'RestrictedEditingModeEditing', () => {
 					const firstParagraph = model.document.getRoot().getChild( 0 );
 					addExceptionMarker( 4, 7, firstParagraph, 'inline:1' );
 
+					const dataTransfer = createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } );
+
 					viewDoc.fire( 'clipboardInput', {
-						dataTransfer: createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } )
+						content: dataTransfer.getData( 'text/html' ),
+						dataTransfer
 					} );
 
 					expect( _getModelData( model ) ).to.equalMarkup( '<paragraph>foo bXXX[]ar baz</paragraph>' );
@@ -1398,11 +1413,14 @@ describe( 'RestrictedEditingModeEditing', () => {
 					const firstParagraph = model.document.getRoot().getChild( 0 );
 					addExceptionMarker( 4, 7, firstParagraph, 'inline:1' );
 
+					const dataTransfer = createDataTransfer( {
+						'text/html': '<p><a href="foo"><b><i>XXX</i></b></a></p>',
+						'text/plain': 'XXX'
+					} );
+
 					viewDoc.fire( 'clipboardInput', {
-						dataTransfer: createDataTransfer( {
-							'text/html': '<p><a href="foo"><b><i>XXX</i></b></a></p>',
-							'text/plain': 'XXX'
-						} )
+						dataTransfer,
+						content: dataTransfer.getData( 'text/html' )
 					} );
 
 					expect( _getModelData( model ) ).to.equalMarkup(
@@ -1419,8 +1437,11 @@ describe( 'RestrictedEditingModeEditing', () => {
 					const firstParagraph = model.document.getRoot().getChild( 0 );
 					addExceptionMarker( 4, 7, firstParagraph, 'inline:1' );
 
+					const dataTransfer = createDataTransfer( { 'text/html': '<p><s>XXX</s></p>', 'text/plain': 'XXX' } );
+
 					viewDoc.fire( 'clipboardInput', {
-						dataTransfer: createDataTransfer( { 'text/html': '<p><s>XXX</s></p>', 'text/plain': 'XXX' } )
+						content: dataTransfer.getData( 'text/html' ),
+						dataTransfer
 					} );
 
 					expect( _getModelData( model ) ).to.equalMarkup( '<paragraph>foo bXXX[]ar baz</paragraph>' );
@@ -1432,8 +1453,11 @@ describe( 'RestrictedEditingModeEditing', () => {
 					const firstParagraph = model.document.getRoot().getChild( 0 );
 					addExceptionMarker( 4, 7, firstParagraph, 'inline:1' );
 
+					const dataTransfer = createDataTransfer( { 'text/html': '<p><b><s><i>XXX</i></s></b></p>', 'text/plain': 'XXX' } );
+
 					viewDoc.fire( 'clipboardInput', {
-						dataTransfer: createDataTransfer( { 'text/html': '<p><b><s><i>XXX</i></s></b></p>', 'text/plain': 'XXX' } )
+						dataTransfer,
+						content: dataTransfer.getData( 'text/html' )
 					} );
 
 					expect(
@@ -1448,8 +1472,11 @@ describe( 'RestrictedEditingModeEditing', () => {
 					const firstParagraph = model.document.getRoot().getChild( 0 );
 					addExceptionMarker( 4, 7, firstParagraph, 'inline:1' );
 
+					const dataTransfer = createDataTransfer( { 'text/html': '<blockquote><p>XXX</p></blockquote>', 'text/plain': 'XXX' } );
+
 					viewDoc.fire( 'clipboardInput', {
-						dataTransfer: createDataTransfer( { 'text/html': '<blockquote><p>XXX</p></blockquote>', 'text/plain': 'XXX' } )
+						dataTransfer,
+						content: dataTransfer.getData( 'text/html' )
 					} );
 
 					expect( _getModelData( model ) ).to.equalMarkup( '<paragraph>foo bXXX[]ar baz</paragraph>' );
@@ -1463,8 +1490,11 @@ describe( 'RestrictedEditingModeEditing', () => {
 					const firstParagraph = model.document.getRoot().getChild( 0 );
 					addExceptionMarker( 4, 7, firstParagraph, 'inline:1' );
 
+					const dataTransfer = createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } );
+
 					viewDoc.fire( 'clipboardInput', {
-						dataTransfer: createDataTransfer( { 'text/html': '<p>XXX</p>', 'text/plain': 'XXX' } )
+						dataTransfer,
+						content: dataTransfer.getData( 'text/html' )
 					} );
 
 					expect( _getModelData( model ) ).to.equalMarkup( '<paragraph>foo bXXX[]r baz</paragraph>' );
@@ -1476,8 +1506,11 @@ describe( 'RestrictedEditingModeEditing', () => {
 					const firstParagraph = model.document.getRoot().getChild( 0 );
 					addExceptionMarker( 4, 7, firstParagraph, 'inline:1' );
 
+					const dataTransfer = createDataTransfer( { 'text/html': '<p><b>XXX</b></p>', 'text/plain': 'XXX' } );
+
 					viewDoc.fire( 'clipboardInput', {
-						dataTransfer: createDataTransfer( { 'text/html': '<p><b>XXX</b></p>', 'text/plain': 'XXX' } )
+						dataTransfer,
+						content: dataTransfer.getData( 'text/html' )
 					} );
 
 					expect( _getModelData( model ) ).to.equalMarkup( '<paragraph>foo b<$text bold="true">XXX[]</$text>r baz</paragraph>' );
@@ -1489,8 +1522,11 @@ describe( 'RestrictedEditingModeEditing', () => {
 					const firstParagraph = model.document.getRoot().getChild( 0 );
 					addExceptionMarker( 4, 7, firstParagraph, 'inline:1' );
 
+					const dataTransfer = createDataTransfer( { 'text/html': '<p><s>XXX</s></p>', 'text/plain': 'XXX' } );
+
 					viewDoc.fire( 'clipboardInput', {
-						dataTransfer: createDataTransfer( { 'text/html': '<p><s>XXX</s></p>', 'text/plain': 'XXX' } )
+						dataTransfer,
+						content: dataTransfer.getData( 'text/html' )
 					} );
 
 					expect( _getModelData( model ) ).to.equalMarkup( '<paragraph>foo bXXX[]r baz</paragraph>' );
@@ -1502,8 +1538,11 @@ describe( 'RestrictedEditingModeEditing', () => {
 					const firstParagraph = model.document.getRoot().getChild( 0 );
 					addExceptionMarker( 4, 7, firstParagraph, 'inline:1' );
 
+					const dataTransfer = createDataTransfer( { 'text/html': '<p><b><s><i>XXX</i></s></b></p>', 'text/plain': 'XXX' } );
+
 					viewDoc.fire( 'clipboardInput', {
-						dataTransfer: createDataTransfer( { 'text/html': '<p><b><s><i>XXX</i></s></b></p>', 'text/plain': 'XXX' } )
+						dataTransfer,
+						content: dataTransfer.getData( 'text/html' )
 					} );
 
 					expect(

--- a/packages/ckeditor5-table/tests/tableselection-integration.js
+++ b/packages/ckeditor5-table/tests/tableselection-integration.js
@@ -176,7 +176,9 @@ describe( 'TableSelection - integration', () => {
 			);
 
 			const dataTransferMock = {
-				getData: sinon.stub().withArgs( 'text/plain' ).returns( 'foo' )
+				getData: sinon.stub()
+					.withArgs( 'text/plain' ).returns( 'foo' )
+					.withArgs( 'text/html' ).returns( '<p>foo</p>' )
 			};
 
 			editor.editing.view.document.fire( 'clipboardInput', {

--- a/packages/ckeditor5-table/tests/tableselection-integration.js
+++ b/packages/ckeditor5-table/tests/tableselection-integration.js
@@ -181,7 +181,8 @@ describe( 'TableSelection - integration', () => {
 
 			editor.editing.view.document.fire( 'clipboardInput', {
 				dataTransfer: dataTransferMock,
-				stop: sinon.spy()
+				stop: sinon.spy(),
+				content: dataTransferMock.getData( 'text/html' )
 			} );
 
 			expect( _getModelData( model ) ).to.equalMarkup( modelTable( [

--- a/packages/ckeditor5-widget/tests/widgettypearound/widgettypearound.js
+++ b/packages/ckeditor5-widget/tests/widgettypearound/widgettypearound.js
@@ -1985,12 +1985,15 @@ describe( 'WidgetTypeAround', () => {
 				writer.setSelectionAttribute( TYPE_AROUND_SELECTION_ATTRIBUTE, 'before' );
 			} );
 
-			viewDocument.fire( 'clipboardInput', {
-				dataTransfer: {
-					getData() {
-						return 'foo<b>bar</b>';
-					}
+			const dataTransfer = {
+				getData() {
+					return 'foo<b>bar</b>';
 				}
+			};
+
+			viewDocument.fire( 'clipboardInput', {
+				dataTransfer,
+				content: dataTransfer.getData()
 			} );
 
 			expect( _getModelData( model ) ).to.equal(
@@ -2224,6 +2227,7 @@ describe( 'WidgetTypeAround', () => {
 			} );
 
 			viewDocument.fire( 'clipboardInput', {
+				content: 'bar',
 				dataTransfer: {
 					getData() {
 						return 'bar';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2764,6 +2764,9 @@ importers:
       '@ckeditor/ckeditor5-engine':
         specifier: workspace:*
         version: link:../ckeditor5-engine
+      '@ckeditor/ckeditor5-utils':
+        specifier: workspace:*
+        version: link:../ckeditor5-utils
     devDependencies:
       '@ckeditor/ckeditor5-basic-styles':
         specifier: workspace:*
@@ -2816,9 +2819,6 @@ importers:
       '@ckeditor/ckeditor5-table':
         specifier: workspace:*
         version: link:../ckeditor5-table
-      '@ckeditor/ckeditor5-utils':
-        specifier: workspace:*
-        version: link:../ckeditor5-utils
 
   packages/ckeditor5-remove-format:
     dependencies:


### PR DESCRIPTION
### 🚀 Summary

The ClipboardPipeline and PasteFromOffice should allow for common HTML string normalization before conversion to view. 

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5/issues/17309.
* Based on https://github.com/ckeditor/ckeditor5/pull/17733

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [x] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
