### PR TITLE
Tab before list item at indent 0 after a skip-level should indent list item

### DIFF
--- a/packages/ckeditor5-indent/tests/integrations/indentblocklistcommand.js
+++ b/packages/ckeditor5-indent/tests/integrations/indentblocklistcommand.js
@@ -253,6 +253,16 @@ describe( 'IndentBlockListCommand', () => {
 
 						expect( command.isEnabled ).to.be.false;
 					} );
+
+					it( 'should be false for a top-level item placed after a skip-level nested list', () => {
+						// `bbb` is the second visible item in the outer list, so block indent must not kick in.
+						_setModelData( model, modelList( [
+							'  # aaa',
+							'# []bbb'
+						] ) );
+
+						expect( command.isEnabled ).to.be.false;
+					} );
 				} );
 			} );
 
@@ -762,6 +772,24 @@ describe( 'IndentBlockListCommand', () => {
 						_setModelData( model, modelList( [
 							'# foo',
 							'    * []bar'
+						] ) );
+
+						expect( command.isEnabled ).to.be.false;
+					} );
+
+					// See ckeditor/ckeditor5-commercial#9763.
+					it( 'should be false for a top-level item placed after a same-type skip-level nested list', () => {
+						// In the view this model is rendered as:
+						//   <ol>
+						//     <li style="list-style-type:none">
+						//       <ol><li>aaa</li></ol>
+						//     </li>
+						//     <li>bbb</li>
+						//   </ol>
+						// `bbb` is the second visible item in the outer list, so block indent must not kick in.
+						_setModelData( model, modelList( [
+							'  # aaa',
+							'# []bbb'
 						] ) );
 
 						expect( command.isEnabled ).to.be.false;

--- a/packages/ckeditor5-indent/tests/integrations/indentblocklistcommand.js
+++ b/packages/ckeditor5-indent/tests/integrations/indentblocklistcommand.js
@@ -777,16 +777,7 @@ describe( 'IndentBlockListCommand', () => {
 						expect( command.isEnabled ).to.be.false;
 					} );
 
-					// See ckeditor/ckeditor5-commercial#9763.
 					it( 'should be false for a top-level item placed after a same-type skip-level nested list', () => {
-						// In the view this model is rendered as:
-						//   <ol>
-						//     <li style="list-style-type:none">
-						//       <ol><li>aaa</li></ol>
-						//     </li>
-						//     <li>bbb</li>
-						//   </ol>
-						// `bbb` is the second visible item in the outer list, so block indent must not kick in.
 						_setModelData( model, modelList( [
 							'  # aaa',
 							'# []bbb'

--- a/packages/ckeditor5-list/src/list/utils/model.ts
+++ b/packages/ckeditor5-list/src/list/utils/model.ts
@@ -602,11 +602,18 @@ export function isNumberedListType( listType: ListType ): boolean {
 }
 
 /**
- * Checks if the given list item is the first item in its list at the given indent.
+ * Checks if the given list item block is the first block of the first item in its list at the given indent.
  *
- * Returns `false` when any preceding list block belongs to the same list — either as a same-indent
- * sibling of the same `listType`, or as a higher-indent block (a regular nested child, or an
- * intermediate skip-level `<li style="list-style-type:none">` wrapper). For example, in the model:
+ * Walks back over previous siblings and returns:
+ * - `true` if it reaches a non-list block or a list block at a lower indent (a new list begins here),
+ * - `false` if it finds a same-indent block of the same `listItemId` (a continuation of the current item) or of the same
+ *   `listType` (the visible list already has earlier items),
+ * - `true` if it finds a same-indent block of a different `listType` and a different `listItemId` (a different list ends; ours
+ *   starts here),
+ * - `false` if it walks off the start of the document while passing only higher-indent blocks (those blocks
+ *   live inside an intermediate skip-level `<li style="list-style-type:none">` wrapper at our indent).
+ *
+ * For example, in the model:
  *
  * ```
  * '  # aaa'
@@ -630,28 +637,37 @@ export function isNumberedListType( listType: ListType ): boolean {
  * So `bbb` is the second visible item in the outer list and the function returns `false`.
  */
 export function isFirstListItemInList( listItem: ModelElement ): boolean {
-	// Same-indent, same-type predecessor. If it exists, we are not the first item in the list.
-	const sameIndentMatch = ListWalker.first( listItem, {
-		sameIndent: true,
-		sameAttributes: 'listType'
-	} );
+	const itemIndent = listItem.getAttribute( 'listIndent' ) as number;
+	const itemListType = listItem.getAttribute( 'listType' );
+	const itemListItemId = listItem.getAttribute( 'listItemId' );
 
-	if ( sameIndentMatch ) {
-		return false;
+	let previous = listItem.previousSibling;
+	let sawHigherIndent = false;
+
+	while ( isListItemBlock( previous ) ) {
+		const previousIndent = previous.getAttribute( 'listIndent' ) as number;
+
+		if ( previousIndent < itemIndent ) {
+			return true;
+		}
+
+		if ( previousIndent === itemIndent ) {
+			// The previous block belongs to the current item — we are a continuation block, not the first block of
+			// the list item, so item-block indent should not apply (a normal list indent should fall through instead).
+			if ( previous.getAttribute( 'listItemId' ) === itemListItemId ) {
+				return false;
+			}
+
+			return previous.getAttribute( 'listType' ) !== itemListType;
+		}
+
+		sawHigherIndent = true;
+		previous = previous.previousSibling;
 	}
 
-	// A higher-indent immediate predecessor means we are nested below something at our indent
-	// (a real parent or an intermediate skip-level wrapper), so we are not first either.
-	const previousItem = listItem.previousSibling;
-
-	if (
-		isListItemBlock( previousItem ) &&
-		( previousItem.getAttribute( 'listIndent' ) as number ) > ( listItem.getAttribute( 'listIndent' ) as number )
-	) {
-		return false;
-	}
-
-	return true;
+	// Walked off the start of the document. If only higher-indent blocks were on the way, they
+	// live inside an intermediate skip-level wrapper at our indent — we are not first.
+	return !sawHigherIndent;
 }
 
 /**

--- a/packages/ckeditor5-list/src/list/utils/model.ts
+++ b/packages/ckeditor5-list/src/list/utils/model.ts
@@ -610,8 +610,9 @@ export function isNumberedListType( listType: ListType ): boolean {
  *   `listType` (the visible list already has earlier items),
  * - `true` if it finds a same-indent block of a different `listType` and a different `listItemId` (a different list ends; ours
  *   starts here),
- * - `false` if it walks off the start of the document while passing only higher-indent blocks (those blocks
- *   live inside an intermediate skip-level `<li style="list-style-type:none">` wrapper at our indent).
+ * - `false` if the loop ends (it reaches the first non-list-item block, or no more previous siblings) while passing only
+ *   higher-indent blocks (those blocks live inside an intermediate skip-level `<li style="list-style-type:none">` wrapper
+ *   at our indent).
  *
  * For example, in the model:
  *
@@ -665,8 +666,8 @@ export function isFirstListItemInList( listItem: ModelElement ): boolean {
 		previous = previous.previousSibling;
 	}
 
-	// Walked off the start of the document. If only higher-indent blocks were on the way, they
-	// live inside an intermediate skip-level wrapper at our indent — we are not first.
+	// Reached the first non-list-item block (or no more previous siblings). If only higher-indent blocks were on
+	// the way, they live inside an intermediate skip-level wrapper at our indent — we are not first.
 	return !sawHigherIndent;
 }
 

--- a/packages/ckeditor5-list/src/list/utils/model.ts
+++ b/packages/ckeditor5-list/src/list/utils/model.ts
@@ -602,18 +602,56 @@ export function isNumberedListType( listType: ListType ): boolean {
 }
 
 /**
- * Checks if the given list item is the first item in the list.
+ * Checks if the given list item is the first item in its list at the given indent.
  *
- * This function checks if there's any other list item before the given list item
- * at the same indent level with the same list type.
+ * Returns `false` when any preceding list block belongs to the same list — either as a same-indent
+ * sibling of the same `listType`, or as a higher-indent block (a regular nested child, or an
+ * intermediate skip-level `<li style="list-style-type:none">` wrapper). For example, in the model:
+ *
+ * ```
+ * '  # aaa'
+ * '# bbb'
+ * ```
+ *
+ * `bbb` is preceded by a higher-indent block `aaa`, which in the view is rendered inside an intermediate
+ * skip-level wrapper at indent 0:
+ *
+ * ```html
+ * <ol>
+ *   <li style="list-style-type:none">
+ *     <ol>
+ *       <li>aaa</li>
+ *     </ol>
+ *   </li>
+ *   <li>bbb</li>
+ * </ol>
+ * ```
+ *
+ * So `bbb` is the second visible item in the outer list and the function returns `false`.
  */
 export function isFirstListItemInList( listItem: ModelElement ): boolean {
-	const previousItem = ListWalker.first( listItem, {
+	// Same-indent, same-type predecessor. If it exists, we are not the first item in the list.
+	const sameIndentMatch = ListWalker.first( listItem, {
 		sameIndent: true,
 		sameAttributes: 'listType'
 	} );
 
-	return !previousItem;
+	if ( sameIndentMatch ) {
+		return false;
+	}
+
+	// A higher-indent immediate predecessor means we are nested below something at our indent
+	// (a real parent or an intermediate skip-level wrapper), so we are not first either.
+	const previousItem = listItem.previousSibling;
+
+	if (
+		isListItemBlock( previousItem ) &&
+		( previousItem.getAttribute( 'listIndent' ) as number ) > ( listItem.getAttribute( 'listIndent' ) as number )
+	) {
+		return false;
+	}
+
+	return true;
 }
 
 /**

--- a/packages/ckeditor5-list/tests/list/integrations/indentmulticommand.js
+++ b/packages/ckeditor5-list/tests/list/integrations/indentmulticommand.js
@@ -1586,16 +1586,8 @@ describe( 'Indent MultiCommand integrations', () => {
 				expect( indentListSpy.callCount ).to.equal( 1, 'indentList command call count' );
 			} );
 
-			// See ckeditor/ckeditor5-commercial#9763.
 			it( 'should execute indentList (not indentBlockList) when at start of a top-level item ' +
 				'placed after a skip-level nested list', () => {
-				// In the view this model is rendered as:
-				//   <ol>
-				//     <li style="list-style-type:none">
-				//       <ol><li>A</li></ol>
-				//     </li>
-				//     <li>B</li>
-				//   </ol>
 				// `B` is the second visible item in the outer list, so Tab should indent it as a list item
 				// (joining the nested list under the intermediate wrapper), not apply block indent.
 				_setModelData( model, modelList( [

--- a/packages/ckeditor5-list/tests/list/integrations/indentmulticommand.js
+++ b/packages/ckeditor5-list/tests/list/integrations/indentmulticommand.js
@@ -1585,6 +1585,34 @@ describe( 'Indent MultiCommand integrations', () => {
 				expect( indentBlockListSpy.callCount ).to.equal( 0, 'indentBlockList command call count' );
 				expect( indentListSpy.callCount ).to.equal( 1, 'indentList command call count' );
 			} );
+
+			// See ckeditor/ckeditor5-commercial#9763.
+			it( 'should execute indentList (not indentBlockList) when at start of a top-level item ' +
+				'placed after a skip-level nested list', () => {
+				// In the view this model is rendered as:
+				//   <ol>
+				//     <li style="list-style-type:none">
+				//       <ol><li>A</li></ol>
+				//     </li>
+				//     <li>B</li>
+				//   </ol>
+				// `B` is the second visible item in the outer list, so Tab should indent it as a list item
+				// (joining the nested list under the intermediate wrapper), not apply block indent.
+				_setModelData( model, modelList( [
+					'  # A',
+					'# []B'
+				] ) );
+
+				editor.commands.get( 'indent' ).execute();
+
+				expect( indentBlockListSpy.callCount ).to.equal( 0, 'indentBlockList command call count' );
+				expect( indentListSpy.callCount ).to.equal( 1, 'indentList command call count' );
+
+				expect( _getModelData( model ) ).to.equalMarkup( modelList( [
+					'  # A',
+					'  # []B'
+				] ) );
+			} );
 		} );
 
 		describe( 'outdent command', () => {

--- a/packages/ckeditor5-list/tests/list/utils/model.js
+++ b/packages/ckeditor5-list/tests/list/utils/model.js
@@ -1980,5 +1980,42 @@ describe( 'List - utils - model', () => {
 			expect( isFirstListItemInList( fragment.getChild( 1 ) ) ).to.be.true;
 			expect( isFirstListItemInList( fragment.getChild( 2 ) ) ).to.be.false;
 		} );
+
+		it( 'should return true for an item starting a new list after a different-type list with a nested list', () => {
+			const input = modelList( [
+				'# a',
+				'  * b',
+				'* c'
+			] );
+
+			const fragment = _parseModel( input, schema );
+
+			expect( isFirstListItemInList( fragment.getChild( 2 ) ) ).to.be.true;
+		} );
+
+		it( 'should return false for a continuation block of a multi-block list item', () => {
+			const input = modelList( [
+				'* a',
+				'  text'
+			] );
+
+			const fragment = _parseModel( input, schema );
+
+			expect( isFirstListItemInList( fragment.getChild( 0 ) ) ).to.be.true;
+			expect( isFirstListItemInList( fragment.getChild( 1 ) ) ).to.be.false;
+		} );
+
+		it( 'should return false for an item placed after a multi-block continuation of a preceding item', () => {
+			const input = modelList( [
+				'* a',
+				'* b',
+				'  text',
+				'* c'
+			] );
+
+			const fragment = _parseModel( input, schema );
+
+			expect( isFirstListItemInList( fragment.getChild( 3 ) ) ).to.be.false;
+		} );
 	} );
 } );

--- a/packages/ckeditor5-list/tests/list/utils/model.js
+++ b/packages/ckeditor5-list/tests/list/utils/model.js
@@ -1993,6 +1993,18 @@ describe( 'List - utils - model', () => {
 			expect( isFirstListItemInList( fragment.getChild( 2 ) ) ).to.be.true;
 		} );
 
+		it( 'should return true for an item starting a new list after a different-type list with a skip-level nested list', () => {
+			const input = modelList( [
+				'# a',
+				'    * b',
+				'* c'
+			] );
+
+			const fragment = _parseModel( input, schema );
+
+			expect( isFirstListItemInList( fragment.getChild( 2 ) ) ).to.be.true;
+		} );
+
 		it( 'should return false for a continuation block of a multi-block list item', () => {
 			const input = modelList( [
 				'* a',

--- a/packages/ckeditor5-list/tests/list/utils/model.js
+++ b/packages/ckeditor5-list/tests/list/utils/model.js
@@ -1824,7 +1824,7 @@ describe( 'List - utils - model', () => {
 	} );
 
 	describe( 'isFirstListItemInList()', () => {
-		it( 'should return true for the first list item in the document', () => {
+		it( 'should return true for the first item in a list and false for the next same-type sibling', () => {
 			const input = modelList( [
 				'* a',
 				'* b'
@@ -1833,16 +1833,6 @@ describe( 'List - utils - model', () => {
 			const fragment = _parseModel( input, schema );
 
 			expect( isFirstListItemInList( fragment.getChild( 0 ) ) ).to.be.true;
-		} );
-
-		it( 'should return false for a list item preceded by another list item of the same type', () => {
-			const input = modelList( [
-				'* a',
-				'* b'
-			] );
-
-			const fragment = _parseModel( input, schema );
-
 			expect( isFirstListItemInList( fragment.getChild( 1 ) ) ).to.be.false;
 		} );
 
@@ -1857,7 +1847,7 @@ describe( 'List - utils - model', () => {
 			expect( isFirstListItemInList( fragment.getChild( 1 ) ) ).to.be.true;
 		} );
 
-		it( 'should return true for a list item preceded by a list item of a different type', () => {
+		it( 'should return true for a list item preceded by a list item of a different type at the same indent', () => {
 			const input = modelList( [
 				'* a',
 				'# b'
@@ -1868,7 +1858,7 @@ describe( 'List - utils - model', () => {
 			expect( isFirstListItemInList( fragment.getChild( 1 ) ) ).to.be.true;
 		} );
 
-		it( 'should return false for a nested list item preceded by a list item of the same type', () => {
+		it( 'should return false for a nested list item preceded by a same-indent same-type sibling', () => {
 			const input = modelList( [
 				'* a',
 				'  * b',
@@ -1912,7 +1902,7 @@ describe( 'List - utils - model', () => {
 			expect( isFirstListItemInList( fragment.getChild( 2 ) ) ).to.be.false;
 		} );
 
-		it( 'should return true for a skip-level list item (indent > 0, first in document)', () => {
+		it( 'should return true for a skip-level list item that is first in the document', () => {
 			const input = modelList( [
 				'  * a',
 				'    * b'
@@ -1923,19 +1913,47 @@ describe( 'List - utils - model', () => {
 			expect( isFirstListItemInList( fragment.getChild( 0 ) ) ).to.be.true;
 		} );
 
-		it( 'should return true for a higher-indent item when the preceding item has a lower indent', () => {
+		it( 'should return false for a top-level item placed after a same-type skip-level nested list', () => {
+			// `bbb` is the second visible item in the outer numbered list, so it is not first.
 			const input = modelList( [
-				'      * a',
-				'    * b'
+				'  # aaa',
+				'# bbb'
 			] );
 
 			const fragment = _parseModel( input, schema );
 
 			expect( isFirstListItemInList( fragment.getChild( 0 ) ) ).to.be.true;
-			expect( isFirstListItemInList( fragment.getChild( 1 ) ) ).to.be.true;
+			expect( isFirstListItemInList( fragment.getChild( 1 ) ) ).to.be.false;
 		} );
 
-		it( 'should return true for same-type items at different indent levels (two separate lists)', () => {
+		it( 'should return false for an item placed after a higher-indent block of a different type', () => {
+			// The higher-indent block is rendered inside a phantom skip-level wrapper at our indent,
+			// so the visible list already has earlier items regardless of the wrapper's type.
+			const input = modelList( [
+				'  * a',
+				'# b'
+			] );
+
+			const fragment = _parseModel( input, schema );
+
+			expect( isFirstListItemInList( fragment.getChild( 1 ) ) ).to.be.false;
+		} );
+
+		it( 'should return false along a chain of higher-indent skip-level items', () => {
+			const input = modelList( [
+				'    * a',
+				'  * b',
+				'* c'
+			] );
+
+			const fragment = _parseModel( input, schema );
+
+			expect( isFirstListItemInList( fragment.getChild( 0 ) ) ).to.be.true;
+			expect( isFirstListItemInList( fragment.getChild( 1 ) ) ).to.be.false;
+			expect( isFirstListItemInList( fragment.getChild( 2 ) ) ).to.be.false;
+		} );
+
+		it( 'should return false for a top-level item placed after a different-type skip-level nested list and before list item', () => {
 			const input = modelList( [
 				'  * a',
 				'# b',
@@ -1945,11 +1963,11 @@ describe( 'List - utils - model', () => {
 			const fragment = _parseModel( input, schema );
 
 			expect( isFirstListItemInList( fragment.getChild( 0 ) ) ).to.be.true;
-			expect( isFirstListItemInList( fragment.getChild( 1 ) ) ).to.be.true;
+			expect( isFirstListItemInList( fragment.getChild( 1 ) ) ).to.be.false;
 			expect( isFirstListItemInList( fragment.getChild( 2 ) ) ).to.be.true;
 		} );
 
-		it( 'should return false for same-type item after nested different-type item at higher indent', () => {
+		it( 'should return true for a top-level item placed after a different-type skip-level nested list and before list item', () => {
 			const input = modelList( [
 				'  * a',
 				'    # b',


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

*A brief summary of what this PR changes.*

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes https://github.com/ckeditor/ckeditor5-commercial/issues/9763.

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [ ] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
