### PR TITLE
Added docs for no-literal-dollar-root and require-explicit-data-context linter rules.

### DIFF
--- a/docs/framework/contributing/code-style.md
+++ b/docs/framework/contributing/code-style.md
@@ -1177,6 +1177,101 @@ This rule ensures that SVG files are imported and exported only in the `@ckedito
 
 This rule ensures that changelog entry files are populated with proper data and a clear description of the change. For a full guide on how to populate changelog entries, see the {@link framework/contributing/changelog-entries Changelog entries} guide.
 
+### Disallow hardcoded `$root` literals: `ckeditor5-rules/no-literal-dollar-root`
+
+This rule disallows the literal `'$root'` string anywhere it could be used as a schema context. Hardcoding `'$root'` is silently wrong when {@link module:core/editor/editorconfig~RootConfig#modelElement `config.root.modelElement`} is customized: the runtime root no longer matches the literal, and any schema check or upcast against it operates against the wrong element name.
+
+The rule also reports two specific patterns that have a name-agnostic replacement and provides an auto-fix for them:
+
+* `node.is( 'element', '$root' )` → `node.is( 'rootElement' )`
+* `node.name === '$root'` / `node.name !== '$root'` → `node.is( 'rootElement' )` / `!node.is( 'rootElement' )`
+
+Options:
+
+* `allowedPackages` &ndash; (optional) A list of package name fragments whose source files are exempt from the rule. Used for `ckeditor5-engine` and `ckeditor5-core` where `'$root'` is the canonical schema element name being defined.
+* `allowedCalls` &ndash; (optional) A list of method names where a `'$root'` literal argument is permitted (e.g. `is` so that `node.is( '$root' )` is allowed alongside the canonical `node.is( 'rootElement' )` form).
+
+The rule also has a narrow built-in exception: a `'$root'` literal under a `context` property of an options object passed to a view-event listener method (`listenTo()`, `on()`, `once()`, `off()`) is not flagged, because in that position `'$root'` is a view-tree bubbling target — not the schema element name.
+
+👎&nbsp; Examples of incorrect code for this rule:
+
+```ts
+const ROOT_NAME = '$root';
+
+if ( node.is( 'element', '$root' ) ) { /* ... */ }
+
+if ( modelElement.name === '$root' ) { /* ... */ }
+
+writer.addRoot( newRoot, '$root' );
+```
+
+👍&nbsp; Examples of correct code for this rule:
+
+```ts
+if ( node.is( 'rootElement' ) ) { /* ... */ }
+
+if ( modelElement.is( 'rootElement' ) ) { /* ... */ }
+
+// View-event listener `context` option — `'$root'` here is a view-tree bubbling target.
+this.listenTo( viewDocument, 'arrowKey', handler, { context: '$root' } );
+
+// Adding attributes to the default root element is the documented escape hatch.
+schema.extend( '$root', { allowAttributes: [ 'foo' ] } );
+```
+
+If the literal `'$root'` is the right value at a call site, opt out with an `// eslint-disable-next-line` comment that explains why. A common case is a feature that is intentionally scoped to roots whose `modelElement` is the default `$root` and is not meant to operate on roots configured with a custom `modelElement`. Such a feature may register its schema only against `$root` on purpose:
+
+```ts
+// eslint-disable-next-line ckeditor5-rules/no-literal-dollar-root -- feature is registered only on the default `$root` by design
+model.schema.register( 'myFeatureElement', { isBlock: true, allowIn: '$root' } );
+```
+
+### Require explicit schema context: `ckeditor5-rules/require-explicit-data-context`
+
+This rule flags calls to engine APIs whose schema-context argument silently defaults to `'$root'` when omitted. Like the rule above, the silent default is wrong as soon as a root is configured with a custom {@link module:core/editor/editorconfig~RootConfig#modelElement `modelElement`}, and the failure is hard to diagnose because no error is raised.
+
+The rule reports calls to these APIs when their context argument is missing:
+
+* {@link module:engine/controller/datacontroller~DataController#parse `data.parse( data, context )`}
+* {@link module:engine/controller/datacontroller~DataController#toModel `data.toModel( view, context )`}
+* {@link module:engine/model/document~ModelDocument#createRoot `document.createRoot( elementName, rootName )`}
+* {@link module:engine/model/writer~ModelWriter#addRoot `writer.addRoot( rootName, elementName )`}
+* {@link module:engine/conversion/upcastdispatcher~UpcastDispatcher#convert `upcastDispatcher.convert( viewElementOrFragment, writer, context )`}
+
+The receiver patterns are matched syntactically (the receiver's final accessed property must be `data` / `document` / `upcastDispatcher`, or a bare identifier `writer` for `addRoot`). This intentionally excludes `MultiRootEditor#addRoot( rootName, options? )`, which has a different signature and resolves the model element name from its options object.
+
+👎&nbsp; Examples of incorrect code for this rule:
+
+```ts
+const fragment = editor.data.parse( html );
+const fragment = editor.data.toModel( view );
+
+editor.model.document.createRoot();
+
+editor.model.change( writer => {
+	writer.addRoot( 'main' );
+} );
+
+editor.data.upcastDispatcher.convert( viewFragment, writer );
+```
+
+👍&nbsp; Examples of correct code for this rule:
+
+```ts
+const fragment = editor.data.parse( html, '$documentFragment' );
+const fragment = editor.data.toModel( view, editor.model.document.getRoot()! );
+
+editor.model.document.createRoot( '$inlineRoot' );
+
+editor.model.change( writer => {
+	writer.addRoot( 'main', '$inlineRoot' );
+} );
+
+editor.data.upcastDispatcher.convert( viewFragment, writer, [ '$root' ] );
+```
+
+If the default `'$root'` context is intentional (for example, an internal editor whose only root always uses the default model element), opt out with an `// eslint-disable-next-line` comment that explains why.
+
 ## CKEditor&nbsp;5 custom Stylelint rules
 
 In addition to the rules provided by Stylelint, CKEditor&nbsp;5 uses a few custom rules described below.


### PR DESCRIPTION
### 🚀 Summary

Added docs for `no-literal-dollar-root` and `require-explicit-data-context` linter rules.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5/issues/20096
* See https://github.com/ckeditor/ckeditor5-linters-config/pull/112

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [ ] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
