### PR TITLE
Add media embed alignment feature

### DIFF
--- a/.changelog/20260504122217_ck_2781_add_media_embed_alignment.md
+++ b/.changelog/20260504122217_ck_2781_add_media_embed_alignment.md
@@ -1,0 +1,9 @@
+---
+type: Feature
+scope:
+  - ckeditor5-media-embed
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/2781
+---
+
+Introduced the media embed alignment feature, with optional text wrapping.

--- a/docs/features/feature-digest.md
+++ b/docs/features/feature-digest.md
@@ -1068,19 +1068,51 @@ Enable Markdown as the default output format instead of HTML with the Markdown p
 
 ### Media embed
 
-Use the insert media button in the toolbar to embed media. Pasting a media URL directly into the editor content automatically embeds the media.
+Embed media such as YouTube or Vimeo videos and other rich content directly in your editor &ndash; either via the insert media button in the toolbar or by pasting a URL straight into the editor.
 
-<ck:button-link size='sm' variant='secondary' href='{@link features/media-embed}'>
-	Feature page
-</ck:button-link>
+<ck:columns>
+	<ck:card>
+		<ck:card-title level='4' heading-id='media-embed'>
+			Media embed
+		</ck:card-title>
+		<ck:card-description>
+			Use the insert media button in the toolbar to embed media. Pasting a media URL directly into the editor content automatically embeds the media.
+		</ck:card-description>
+		<ck:card-footer>
+			<ck:button-link size='sm' variant='secondary' href='{@link features/media-embed}'>
+				Feature page
+			</ck:button-link>
+		</ck:card-footer>
+	</ck:card>
 
-<ck:heading-badge heading-id='media-embed-resize' badge='premium'>Media embed resize</ck:heading-badge>
+	<ck:card>
+		<ck:card-title level='4' heading-id='media-embed-resize'>
+			Media embed resize <ck:badge variant='premium' />
+		</ck:card-title>
+		<ck:card-description>
+			The media embed resize feature lets you change the width of media embeds in your content.
+		</ck:card-description>
+		<ck:card-footer>
+			<ck:button-link size='sm' variant='secondary' href='{@link features/media-embed-resize}'>
+				Feature page
+			</ck:button-link>
+		</ck:card-footer>
+	</ck:card>
 
-The media embed resize feature lets you change the width of media embeds in your content. It is implemented by the MediaEmbedResize plugin.
-
-<ck:button-link size='sm' variant='secondary' href='{@link features/media-embed-resize}'>
-	Feature page
-</ck:button-link>
+	<ck:card>
+		<ck:card-title level='4' heading-id='media-embed-alignment'>
+			Media embed alignment
+		</ck:card-title>
+		<ck:card-description>
+			The media embed alignment feature lets you align media embeds within the surrounding content, with optional text wrapping.
+		</ck:card-description>
+		<ck:card-footer>
+			<ck:button-link size='sm' variant='secondary' href='{@link features/media-embed-alignment}'>
+				Feature page
+			</ck:button-link>
+		</ck:card-footer>
+	</ck:card>
+</ck:columns>
 
 <ck:heading-badge heading-id='paste-markdown' badge='experiment'>Paste Markdown</ck:heading-badge>
 

--- a/packages/ckeditor5-image/theme/imagestyle.css
+++ b/packages/ckeditor5-image/theme/imagestyle.css
@@ -92,29 +92,3 @@
 	}
 }
 
-.ck.ck-splitbutton {
-	/* The button should display as a regular drop-down if the action button
-	is forced to fire the same action as the arrow button. */
-	&.ck-splitbutton_flatten {
-		&:hover,
-		&.ck-splitbutton_open {
-			& > .ck-splitbutton__action:not(.ck-disabled),
-			& > .ck-splitbutton__arrow:not(.ck-disabled),
-			& > .ck-splitbutton__arrow:not(.ck-disabled):not(:hover) {
-				background-color: var(--ck-color-button-on-background);
-
-				&::after {
-					display: none;
-				}
-			}
-		}
-
-		&.ck-splitbutton_open:hover {
-			& > .ck-splitbutton__action:not(.ck-disabled),
-			& > .ck-splitbutton__arrow:not(.ck-disabled),
-			& > .ck-splitbutton__arrow:not(.ck-disabled):not(:hover) {
-				background-color: var(--ck-color-button-on-hover-background);
-			}
-		}
-	}
-}

--- a/packages/ckeditor5-media-embed/ckeditor5-metadata.json
+++ b/packages/ckeditor5-media-embed/ckeditor5-metadata.json
@@ -90,6 +90,85 @@
 			]
 		},
 		{
+			"name": "Media embed style",
+			"className": "MediaEmbedStyle",
+			"description": "Adds alignment to media embeds, with optional text wrapping.",
+			"docs": "features/media-embed/media-embed-alignment.html",
+			"path": "src/mediaembedstyle.ts",
+			"requires": [
+				"MediaEmbed"
+			],
+			"uiComponents": [
+				{
+					"type": "Button",
+					"name": "mediaEmbed:alignLeft",
+					"toolbars": [
+						"mediaEmbed.toolbar"
+					],
+					"iconName": "IconObjectInlineLeft"
+				},
+				{
+					"type": "Button",
+					"name": "mediaEmbed:alignBlockLeft",
+					"toolbars": [
+						"mediaEmbed.toolbar"
+					],
+					"iconName": "IconObjectLeft"
+				},
+				{
+					"type": "Button",
+					"name": "mediaEmbed:alignCenter",
+					"toolbars": [
+						"mediaEmbed.toolbar"
+					],
+					"iconName": "IconObjectCenter"
+				},
+				{
+					"type": "Button",
+					"name": "mediaEmbed:alignBlockRight",
+					"toolbars": [
+						"mediaEmbed.toolbar"
+					],
+					"iconName": "IconObjectRight"
+				},
+				{
+					"type": "Button",
+					"name": "mediaEmbed:alignRight",
+					"toolbars": [
+						"mediaEmbed.toolbar"
+					],
+					"iconName": "IconObjectInlineRight"
+				},
+				{
+					"type": "SplitButton",
+					"name": "mediaEmbed:wrapText",
+					"toolbars": [
+						"mediaEmbed.toolbar"
+					],
+					"iconName": "IconObjectInlineLeft"
+				},
+				{
+					"type": "SplitButton",
+					"name": "mediaEmbed:breakText",
+					"toolbars": [
+						"mediaEmbed.toolbar"
+					],
+					"iconName": "IconObjectCenter"
+				}
+			],
+			"htmlOutput": [
+				{
+					"elements": "figure",
+					"classes": [
+						"media-style-align-left",
+						"media-style-block-align-left",
+						"media-style-block-align-right",
+						"media-style-align-right"
+					]
+				}
+			]
+		},
+		{
 			"name": "Media embed toolbar",
 			"className": "MediaEmbedToolbar",
 			"description": "Implements an optional toolbar for media embed that shows when the media element is selected.",

--- a/packages/ckeditor5-media-embed/docs/features/media-embed-alignment.md
+++ b/packages/ckeditor5-media-embed/docs/features/media-embed-alignment.md
@@ -1,0 +1,119 @@
+---
+category: features-media-embed
+menu-title: Aligning media embeds
+meta-title: Aligning media embeds | CKEditor 5 Documentation
+meta-description: Align embedded videos and other media content within the surrounding content, with optional text wrapping.
+order: 55
+---
+
+# Aligning media embeds
+
+The media embed alignment feature lets you align media embeds (such as YouTube or Vimeo videos) in your content, with optional text wrapping. It is implemented by the {@link module:media-embed/mediaembedstyle~MediaEmbedStyle} plugin.
+
+## Installation
+
+The {@link module:media-embed/mediaembedstyle~MediaEmbedStyle} plugin is not loaded by default. Add it explicitly alongside {@link module:media-embed/mediaembed~MediaEmbed} to enable the feature:
+
+<code-switcher>
+```js
+import { ClassicEditor, MediaEmbed, MediaEmbedStyle } from 'ckeditor5';
+
+ClassicEditor
+	.create( {
+		attachTo: document.querySelector( '#editor' ),
+		licenseKey: '<YOUR_LICENSE_KEY>', // Or 'GPL'.
+		plugins: [ MediaEmbed, MediaEmbedStyle, /* ... */ ],
+		toolbar: [ 'mediaEmbed', /* ... */ ]
+	} )
+	.then( /* ... */ )
+	.catch( /* ... */ );
+```
+</code-switcher>
+
+## Alignment options
+
+The plugin provides the following five alignment options. They can be exposed in the toolbar as individual buttons or grouped into two split-button dropdowns &ndash; see [Toolbar configuration](#toolbar-configuration) for the wiring.
+
+Each non-default option is encoded as a CSS class on the media `<figure>` element (for example, `<figure class="media media-style-block-align-left">`). The default `alignCenter` option emits no class.
+
+**Block alignments** &ndash; the media takes a full line, with surrounding text appearing above and below.
+
+* {@icon @ckeditor/ckeditor5-icons/theme/icons/object-left.svg Left aligned media} **Left aligned** &ndash; button `mediaEmbed:alignBlockLeft`, class `media-style-block-align-left`.
+* {@icon @ckeditor/ckeditor5-icons/theme/icons/object-center.svg Centered media} **Centered** &ndash; button `mediaEmbed:alignCenter`; default, no class.
+* {@icon @ckeditor/ckeditor5-icons/theme/icons/object-right.svg Right aligned media} **Right aligned** &ndash; button `mediaEmbed:alignBlockRight`, class `media-style-block-align-right`.
+
+**Wrap-text alignments** &ndash; the media floats to one side and surrounding text wraps around it.
+
+* {@icon @ckeditor/ckeditor5-icons/theme/icons/object-inline-left.svg Left aligned media} **Left aligned** &ndash; button `mediaEmbed:alignLeft`, class `media-style-align-left`.
+* {@icon @ckeditor/ckeditor5-icons/theme/icons/object-inline-right.svg Right aligned media} **Right aligned** &ndash; button `mediaEmbed:alignRight`, class `media-style-align-right`.
+
+<info-box>
+	The actual styling of the media embeds is the job of the integrator. CKEditor&nbsp;5 comes with some default styles, but they will only be applied to the media inside the editor. The integrator needs to style them appropriately on the target pages.
+
+	You can find the source of the default styles applied by the editor here: [`ckeditor5-media-embed/theme/mediaembedstyle.css`](https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-media-embed/theme/mediaembedstyle.css).
+
+	Read more about {@link getting-started/setup/css styling the content of the editor}.
+</info-box>
+
+## Toolbar configuration
+
+You can wire the buttons into the {@link module:media-embed/mediaembedconfig~MediaEmbedConfig#toolbar media embed contextual toolbar} in two ways.
+
+**Compact (split-button dropdowns)**: exposes the two layout modes as separate dropdowns. The `mediaEmbed:wrapText` dropdown groups the wrap-text alignments; `mediaEmbed:breakText` groups the block alignments. Each dropdown's action button reflects whichever option from its group is currently applied to the selected media, falling back to the dropdown's default (`alignLeft` for wrap, `alignCenter` for break) when none is.
+
+```js
+mediaEmbed: {
+	toolbar: [ 'mediaEmbed:wrapText', 'mediaEmbed:breakText' ]
+}
+```
+
+**Flat (individual buttons)**: exposes all five options as separate buttons.
+
+```js
+mediaEmbed: {
+	toolbar: [
+		'mediaEmbed:alignLeft', 'mediaEmbed:alignBlockLeft',
+		'mediaEmbed:alignCenter',
+		'mediaEmbed:alignBlockRight', 'mediaEmbed:alignRight'
+	]
+}
+```
+
+## Interaction with resizing
+
+<info-box hint>
+	You should combine media embed alignment with the optional {@link features/media-embed-resize media embed resize feature} as these features were designed to be used together &ndash; resizing controls the width, alignment controls the position.
+
+	If you do not enable the media embed resize feature, embeds span the full width of the editor by default and the alignment classes have no visible effect &ndash; the figure already occupies the full row. Alignment starts producing a visible effect once the figure is narrower than its container (via the resize feature, integrator-side CSS, or `style` preserved by other means).
+</info-box>
+
+The HTML representation of an aligned and {@link features/media-embed-resize resized} media embed looks like this:
+
+```html
+<figure class="media media_resized media-style-align-left" style="width:50%;">...</figure>
+```
+
+## Common API
+
+The {@link module:media-embed/mediaembedstyle~MediaEmbedStyle} plugin registers:
+
+* a button for each alignment option (`'mediaEmbed:alignLeft'`, `'mediaEmbed:alignBlockLeft'`, etc.) and two split-button dropdowns (`'mediaEmbed:wrapText'` and `'mediaEmbed:breakText'`), to use in the {@link module:media-embed/mediaembedconfig~MediaEmbedConfig#toolbar media embed contextual toolbar}.
+* the `'mediaStyle'` command implemented by {@link module:media-embed/mediaembedstyle/mediaembedstylecommand~MediaEmbedStyleCommand}.
+
+	You can apply or clear the alignment on the selected media embed by executing the following code:
+
+	```js
+	// Float the selected media to the left so text wraps around it.
+	editor.execute( 'mediaStyle', { value: 'alignLeft' } );
+
+	// Clear the alignment to return to the default (centered) state.
+	editor.execute( 'mediaStyle', { value: null } );
+	```
+
+<info-box>
+	We recommend using the official {@link framework/development-tools/inspector CKEditor&nbsp;5 inspector} for development and debugging. It will give you tons of useful information about the state of the editor such as internal data structures, selection, commands, and many more.
+</info-box>
+
+## Contribute
+
+The source code of the feature is available on GitHub at [https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-media-embed](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-media-embed).

--- a/packages/ckeditor5-media-embed/lang/contexts.json
+++ b/packages/ckeditor5-media-embed/lang/contexts.json
@@ -9,5 +9,10 @@
 	"Media embed": "The label for the Media Embed balloon.",
 	"Media": "Label describing type of the inserted content (e.g. 'insert media').",
 	"Media toolbar": "The label used by assistive technologies describing an image toolbar attached to an image widget.",
-	"Open media in new tab": "A tooltip displayed when the user hovers a non-previewable media URL in the editor content."
+	"Open media in new tab": "A tooltip displayed when the user hovers a non-previewable media URL in the editor content.",
+	"Left aligned media": "The label for the left aligned media option.",
+	"Centered media": "The label for the centered media option.",
+	"Right aligned media": "The label for the right aligned media option.",
+	"Wrap text": "The label for the media embed style button that wraps text around the media.",
+	"Break text": "The label for the media embed style button that breaks the text around the media."
 }

--- a/packages/ckeditor5-media-embed/src/augmentation.ts
+++ b/packages/ckeditor5-media-embed/src/augmentation.ts
@@ -14,7 +14,11 @@ import type {
 	MediaEmbedResize,
 	MediaEmbedResizeEditing,
 	MediaEmbedResizeHandles,
-	ResizeMediaEmbedCommand
+	ResizeMediaEmbedCommand,
+	MediaEmbedStyle,
+	MediaEmbedStyleEditing,
+	MediaEmbedStyleUI,
+	MediaEmbedStyleCommand
 } from './index.js';
 
 declare module '@ckeditor/ckeditor5-core' {
@@ -37,10 +41,14 @@ declare module '@ckeditor/ckeditor5-core' {
 		[ MediaEmbedResize.pluginName ]: MediaEmbedResize;
 		[ MediaEmbedResizeEditing.pluginName ]: MediaEmbedResizeEditing;
 		[ MediaEmbedResizeHandles.pluginName ]: MediaEmbedResizeHandles;
+		[ MediaEmbedStyle.pluginName ]: MediaEmbedStyle;
+		[ MediaEmbedStyleEditing.pluginName ]: MediaEmbedStyleEditing;
+		[ MediaEmbedStyleUI.pluginName ]: MediaEmbedStyleUI;
 	}
 
 	interface CommandsMap {
 		mediaEmbed: MediaEmbedCommand;
 		resizeMediaEmbed: ResizeMediaEmbedCommand;
+		mediaStyle: MediaEmbedStyleCommand;
 	}
 }

--- a/packages/ckeditor5-media-embed/src/index.ts
+++ b/packages/ckeditor5-media-embed/src/index.ts
@@ -17,6 +17,10 @@ export { MediaEmbedResize } from './mediaembedresize.js';
 export { MediaEmbedResizeEditing } from './mediaembedresize/mediaembedresizeediting.js';
 export { MediaEmbedResizeHandles } from './mediaembedresize/mediaembedresizehandles.js';
 export { ResizeMediaEmbedCommand } from './mediaembedresize/resizemediaembedcommand.js';
+export { MediaEmbedStyle } from './mediaembedstyle.js';
+export { MediaEmbedStyleEditing } from './mediaembedstyle/mediaembedstyleediting.js';
+export { MediaEmbedStyleUI } from './mediaembedstyle/mediaembedstyleui.js';
+export { MediaEmbedStyleCommand } from './mediaembedstyle/mediaembedstylecommand.js';
 
 export type { MediaEmbedConfig } from './mediaembedconfig.js';
 

--- a/packages/ckeditor5-media-embed/src/mediaembedstyle.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedstyle.ts
@@ -1,0 +1,46 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+/**
+ * @module media-embed/mediaembedstyle
+ */
+
+import { Plugin } from '@ckeditor/ckeditor5-core';
+import { MediaEmbedStyleEditing } from './mediaembedstyle/mediaembedstyleediting.js';
+import { MediaEmbedStyleUI } from './mediaembedstyle/mediaembedstyleui.js';
+
+import '../theme/mediaembedstyle.css';
+
+/**
+ * The media embed style plugin.
+ *
+ * This is a "glue" plugin which loads the following plugins:
+ * * {@link module:media-embed/mediaembedstyle/mediaembedstyleediting~MediaEmbedStyleEditing},
+ * * {@link module:media-embed/mediaembedstyle/mediaembedstyleui~MediaEmbedStyleUI}
+ *
+ * For a detailed overview, check the {@glink features/media-embed/media-embed-alignment Aligning media embeds feature documentation}.
+ */
+export class MediaEmbedStyle extends Plugin {
+	/**
+	 * @inheritDoc
+	 */
+	public static get requires() {
+		return [ MediaEmbedStyleEditing, MediaEmbedStyleUI ] as const;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static get pluginName() {
+		return 'MediaEmbedStyle' as const;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static override get isOfficialPlugin(): true {
+		return true;
+	}
+}

--- a/packages/ckeditor5-media-embed/src/mediaembedstyle/constants.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedstyle/constants.ts
@@ -1,0 +1,27 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+/**
+ * @module media-embed/mediaembedstyle/constants
+ */
+
+/**
+ * The valid names for media embed alignment styles.
+ *
+ * @internal
+ */
+export type MediaStyleName =
+	| 'alignLeft'
+	| 'alignBlockLeft'
+	| 'alignCenter'
+	| 'alignBlockRight'
+	| 'alignRight';
+
+/**
+ * The name of the default media style.
+ *
+ * @internal
+ */
+export const DEFAULT_STYLE_NAME: MediaStyleName = 'alignCenter';

--- a/packages/ckeditor5-media-embed/src/mediaembedstyle/mediaembedstylecommand.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedstyle/mediaembedstylecommand.ts
@@ -1,0 +1,78 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+/**
+ * @module media-embed/mediaembedstyle/mediaembedstylecommand
+ */
+
+import { Command } from '@ckeditor/ckeditor5-core';
+import { getSelectedMediaModelWidget } from '../utils.js';
+import { DEFAULT_STYLE_NAME, type MediaStyleName } from './constants.js';
+
+/**
+ * The media embed style command. It is used to apply an alignment style to a selected media embed.
+ */
+export class MediaEmbedStyleCommand extends Command {
+	/**
+	 * The current media style name, or `false` when the command is disabled (no media selected).
+	 * Falls back to the default style name when the selected media has no `mediaStyle` attribute,
+	 * so the default-state UI button can light up on insert.
+	 */
+	declare public value: string | false;
+
+	/**
+	 * @inheritDoc
+	 */
+	public override refresh(): void {
+		const element = getSelectedMediaModelWidget( this.editor.model.document.selection );
+
+		this.isEnabled = !!element;
+
+		if ( !element ) {
+			this.value = false;
+		} else if ( element.hasAttribute( 'mediaStyle' ) ) {
+			this.value = element.getAttribute( 'mediaStyle' ) as MediaStyleName;
+		} else {
+			this.value = DEFAULT_STYLE_NAME;
+		}
+	}
+
+	/**
+	 * Executes the command and applies the alignment style to the currently selected media embed.
+	 *
+	 * ```ts
+	 * editor.execute( 'mediaStyle', { value: 'alignLeft' } );
+	 * editor.execute( 'mediaStyle', { value: 'alignCenter' } ); // removes the attribute
+	 * editor.execute( 'mediaStyle', { value: null } );          // removes the attribute
+	 * ```
+	 *
+	 * Only {@link module:media-embed/mediaembedstyle/constants~MediaStyleName} values are honored.
+	 * The schema does not constrain the `mediaStyle` attribute, so passing an unknown string will
+	 * still set the model attribute, but the downcast will silently drop it (no class is emitted).
+	 *
+	 * @param options
+	 * @param options.value The name of the style to apply, or `null` to clear the alignment.
+	 * Passing the default style name (`'alignCenter'`) also clears the attribute.
+	 * @fires execute
+	 */
+	public override execute( options: { value: MediaStyleName | null } ): void {
+		const model = this.editor.model;
+		const element = getSelectedMediaModelWidget( model.document.selection );
+
+		if ( element ) {
+			const requestedStyle = options.value;
+
+			model.change( writer => {
+				// The default style is encoded as attribute-absence on the model.
+				if ( !requestedStyle || requestedStyle === DEFAULT_STYLE_NAME ) {
+					writer.removeAttribute( 'mediaStyle', element );
+					return;
+				}
+
+				writer.setAttribute( 'mediaStyle', requestedStyle, element );
+			} );
+		}
+	}
+}

--- a/packages/ckeditor5-media-embed/src/mediaembedstyle/mediaembedstyleediting.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedstyle/mediaembedstyleediting.ts
@@ -82,13 +82,7 @@ export class MediaEmbedStyleEditing extends Plugin {
 					return;
 				}
 
-				const figure = conversionApi.mapper.toViewElement( data.item );
-
-				/* istanbul ignore if: paranoid check — the figure is always mapped here -- @preserve */
-				if ( !figure ) {
-					return;
-				}
-
+				const figure = conversionApi.mapper.toViewElement( data.item )!;
 				const viewWriter = conversionApi.writer;
 				const oldClass = MEDIA_STYLE_CLASSES.get( data.attributeOldValue as MediaStyleName );
 				const newClass = MEDIA_STYLE_CLASSES.get( data.attributeNewValue as MediaStyleName );
@@ -107,7 +101,6 @@ export class MediaEmbedStyleEditing extends Plugin {
 		// priority so the main media upcast creates the `media` model element first.
 		editor.conversion.for( 'upcast' ).add( dispatcher => {
 			dispatcher.on<UpcastElementEvent>( 'element:figure', ( _evt, data, conversionApi ) => {
-				/* istanbul ignore if: paranoid check — modelRange is set when conversion produces a model -- @preserve */
 				if ( !data.modelRange ) {
 					return;
 				}

--- a/packages/ckeditor5-media-embed/src/mediaembedstyle/mediaembedstyleediting.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedstyle/mediaembedstyleediting.ts
@@ -1,0 +1,131 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+/**
+ * @module media-embed/mediaembedstyle/mediaembedstyleediting
+ */
+
+import { first } from '@ckeditor/ckeditor5-utils';
+import type { UpcastElementEvent } from '@ckeditor/ckeditor5-engine';
+import { Plugin } from '@ckeditor/ckeditor5-core';
+import { MediaEmbedEditing } from '../mediaembedediting.js';
+import { MediaEmbedStyleCommand } from './mediaembedstylecommand.js';
+import type { MediaStyleName } from './constants.js';
+
+/**
+ * Style name → view class for the four class-bearing alignment options. `alignCenter` is
+ * absent because the default style encodes as attribute-absence (no class). Iteration
+ * order is load-bearing for the upcast — when multiple alignment classes are present on
+ * a single figure, the last consumed wins.
+ */
+const MEDIA_STYLE_CLASSES = new Map<MediaStyleName, string>( [
+	[ 'alignLeft', 'media-style-align-left' ],
+	[ 'alignBlockLeft', 'media-style-block-align-left' ],
+	[ 'alignBlockRight', 'media-style-block-align-right' ],
+	[ 'alignRight', 'media-style-align-right' ]
+] );
+
+/**
+ * The media embed style engine plugin. It extends the schema with the `mediaStyle` attribute,
+ * registers the {@link module:media-embed/mediaembedstyle/mediaembedstylecommand~MediaEmbedStyleCommand} command,
+ * and adds the converters that apply alignment CSS classes to the figure.
+ */
+export class MediaEmbedStyleEditing extends Plugin {
+	/**
+	 * @inheritDoc
+	 */
+	public static get requires() {
+		return [ MediaEmbedEditing ] as const;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static get pluginName() {
+		return 'MediaEmbedStyleEditing' as const;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static override get isOfficialPlugin(): true {
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public init(): void {
+		const editor = this.editor;
+		const schema = editor.model.schema;
+
+		schema.extend( 'media', { allowAttributes: [ 'mediaStyle' ] } );
+		schema.setAttributeProperties( 'mediaStyle', { isFormatting: true } );
+
+		editor.commands.add( 'mediaStyle', new MediaEmbedStyleCommand( editor ) );
+
+		this._registerConverters();
+	}
+
+	/**
+	 * Registers the downcast and upcast converters for the `mediaStyle` attribute.
+	 */
+	private _registerConverters(): void {
+		const editor = this.editor;
+
+		// Downcast: `mediaStyle` → CSS class on the <figure>. Covers both editing and data pipelines.
+		editor.conversion.for( 'downcast' ).add( dispatcher =>
+			dispatcher.on( 'attribute:mediaStyle:media', ( evt, data, conversionApi ) => {
+				if ( !conversionApi.consumable.consume( data.item, evt.name ) ) {
+					return;
+				}
+
+				const figure = conversionApi.mapper.toViewElement( data.item );
+
+				/* istanbul ignore if: paranoid check — the figure is always mapped here -- @preserve */
+				if ( !figure ) {
+					return;
+				}
+
+				const viewWriter = conversionApi.writer;
+				const oldClass = MEDIA_STYLE_CLASSES.get( data.attributeOldValue as MediaStyleName );
+				const newClass = MEDIA_STYLE_CLASSES.get( data.attributeNewValue as MediaStyleName );
+
+				if ( oldClass ) {
+					viewWriter.removeClass( oldClass, figure );
+				}
+
+				if ( newClass ) {
+					viewWriter.addClass( newClass, figure );
+				}
+			} )
+		);
+
+		// Upcast: alignment class on a media <figure> → `mediaStyle` attribute. Runs at `low`
+		// priority so the main media upcast creates the `media` model element first.
+		editor.conversion.for( 'upcast' ).add( dispatcher => {
+			dispatcher.on<UpcastElementEvent>( 'element:figure', ( _evt, data, conversionApi ) => {
+				/* istanbul ignore if: paranoid check — modelRange is set when conversion produces a model -- @preserve */
+				if ( !data.modelRange ) {
+					return;
+				}
+
+				const modelElement = first( data.modelRange.getItems() );
+
+				if ( !modelElement || !modelElement.is( 'element', 'media' ) ) {
+					return;
+				}
+
+				// Iterate in insertion order — last consumed class wins when multiple
+				// alignment classes are present on the same figure.
+				for ( const [ styleName, className ] of MEDIA_STYLE_CLASSES ) {
+					if ( conversionApi.consumable.consume( data.viewItem, { classes: className } ) ) {
+						conversionApi.writer.setAttribute( 'mediaStyle', styleName, modelElement );
+					}
+				}
+			}, { priority: 'low' } );
+		} );
+	}
+}

--- a/packages/ckeditor5-media-embed/src/mediaembedstyle/mediaembedstyleui.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedstyle/mediaembedstyleui.ts
@@ -1,0 +1,235 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+/**
+ * @module media-embed/mediaembedstyle/mediaembedstyleui
+ */
+
+import { Plugin } from '@ckeditor/ckeditor5-core';
+import { ButtonView, createDropdown, addToolbarToDropdown, SplitButtonView } from '@ckeditor/ckeditor5-ui';
+import {
+	IconObjectCenter,
+	IconObjectInlineLeft,
+	IconObjectInlineRight,
+	IconObjectLeft,
+	IconObjectRight
+} from '@ckeditor/ckeditor5-icons';
+import { MediaEmbedStyleEditing } from './mediaembedstyleediting.js';
+import { type MediaEmbedStyleCommand } from './mediaembedstylecommand.js';
+import { DEFAULT_STYLE_NAME, type MediaStyleName } from './constants.js';
+
+/**
+ * Definition of a single alignment button registered by `MediaEmbedStyleUI`.
+ */
+type ButtonDefinition = {
+	name: MediaStyleName;
+	label: string;
+	icon: string;
+};
+
+/**
+ * Definition of a default split-button dropdown.
+ */
+type DropdownDefinition = {
+	name: string;
+	title: string;
+	items: Array<MediaStyleName>;
+	defaultItem: MediaStyleName;
+};
+
+/**
+ * The media embed style UI plugin.
+ *
+ * It registers buttons for each alignment style and the default split-button dropdowns
+ * (`mediaEmbed:wrapText` and `mediaEmbed:breakText`) that can be used in the
+ * {@link module:media-embed/mediaembedconfig~MediaEmbedConfig#toolbar media embed toolbar}.
+ */
+export class MediaEmbedStyleUI extends Plugin {
+	/**
+	 * @inheritDoc
+	 */
+	public static get requires() {
+		return [ MediaEmbedStyleEditing ] as const;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static get pluginName() {
+		return 'MediaEmbedStyleUI' as const;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static override get isOfficialPlugin(): true {
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public init(): void {
+		for ( const button of this._getButtonDefinitions() ) {
+			this._createButton( button );
+		}
+
+		for ( const dropdown of this._getDropdownDefinitions() ) {
+			this._createDropdown( dropdown );
+		}
+	}
+
+	/**
+	 * Returns the alignment button definitions, with localized labels.
+	 */
+	private _getButtonDefinitions(): Array<ButtonDefinition> {
+		const t = this.editor.t;
+
+		return [
+			{ name: 'alignLeft', label: t( 'Left aligned media' ), icon: IconObjectInlineLeft },
+			{ name: 'alignBlockLeft', label: t( 'Left aligned media' ), icon: IconObjectLeft },
+			{ name: 'alignCenter', label: t( 'Centered media' ), icon: IconObjectCenter },
+			{ name: 'alignBlockRight', label: t( 'Right aligned media' ), icon: IconObjectRight },
+			{ name: 'alignRight', label: t( 'Right aligned media' ), icon: IconObjectInlineRight }
+		];
+	}
+
+	/**
+	 * Returns the default split-button dropdown definitions, with localized titles.
+	 */
+	private _getDropdownDefinitions(): Array<DropdownDefinition> {
+		const t = this.editor.t;
+
+		return [
+			{
+				name: 'wrapText',
+				title: t( 'Wrap text' ),
+				items: [ 'alignLeft', 'alignRight' ],
+				defaultItem: 'alignLeft'
+			},
+			{
+				name: 'breakText',
+				title: t( 'Break text' ),
+				items: [ 'alignBlockLeft', 'alignCenter', 'alignBlockRight' ],
+				defaultItem: DEFAULT_STYLE_NAME
+			}
+		];
+	}
+
+	/**
+	 * Registers a single alignment toggle button in the component factory.
+	 */
+	private _createButton( definition: ButtonDefinition ): void {
+		const editor = this.editor;
+		const componentName = `mediaEmbed:${ definition.name }`;
+
+		editor.ui.componentFactory.add( componentName, locale => {
+			const command: MediaEmbedStyleCommand = editor.commands.get( 'mediaStyle' )!;
+			const view = new ButtonView( locale );
+
+			view.set( {
+				label: definition.label,
+				icon: definition.icon,
+				tooltip: true,
+				isToggleable: true
+			} );
+
+			view.bind( 'isEnabled' ).to( command, 'isEnabled' );
+			view.bind( 'isOn' ).to( command, 'value', value => value === definition.name );
+
+			view.on( 'execute', () => {
+				editor.execute( 'mediaStyle', { value: definition.name } );
+				editor.editing.view.focus();
+			} );
+
+			return view;
+		} );
+	}
+
+	/**
+	 * Registers a split-button dropdown grouping a set of alignment buttons. The action button
+	 * reflects whichever child option is currently `isOn`, falling back to the dropdown's
+	 * `defaultItem` when nothing is active.
+	 */
+	private _createDropdown( definition: DropdownDefinition ): void {
+		const editor = this.editor;
+		const factory = editor.ui.componentFactory;
+
+		factory.add( `mediaEmbed:${ definition.name }`, locale => {
+			// Build child buttons via the factory; pick the default by name.
+			const buttonViews = definition.items.map(
+				itemName => factory.create( `mediaEmbed:${ itemName }` ) as ButtonView
+			);
+			const defaultButton = buttonViews[ definition.items.indexOf( definition.defaultItem ) ] as ButtonView;
+
+			// Resolve the currently-active child or fall back to the default. Used by the
+			// reactive `icon` and `label` bindings on the split button.
+			const activeOrDefault = ( ...areOn: Array<boolean> ): ButtonView => {
+				const index = areOn.findIndex( Boolean );
+
+				return index < 0 ? defaultButton : buttonViews[ index ];
+			};
+
+			// Build the dropdown shell.
+			const dropdownView = createDropdown( locale, SplitButtonView );
+			const splitButtonView = dropdownView.buttonView as SplitButtonView;
+
+			addToolbarToDropdown( dropdownView, buttonViews, { enableActiveItemFocusOnDropdownOpen: true } );
+
+			splitButtonView.set( {
+				label: getDropdownButtonTitle( definition.title, defaultButton.label! ),
+				class: null,
+				tooltip: true
+			} );
+
+			splitButtonView.arrowView.unbind( 'label' );
+			splitButtonView.arrowView.set( { label: definition.title } );
+
+			// Reactive: action button mirrors the active child's icon and label.
+			splitButtonView.bind( 'icon' ).toMany( buttonViews, 'isOn',
+				( ...areOn ) => activeOrDefault( ...areOn ).icon
+			);
+
+			splitButtonView.bind( 'label' ).toMany( buttonViews, 'isOn',
+				( ...areOn ) => getDropdownButtonTitle( definition.title, activeOrDefault( ...areOn ).label! )
+			);
+
+			// Reactive: split button shows the "active" state when any child is on.
+			splitButtonView.bind( 'isOn' ).toMany( buttonViews, 'isOn', ( ...areOn ) => areOn.some( Boolean ) );
+
+			splitButtonView.bind( 'class' ).toMany( buttonViews, 'isOn',
+				( ...areOn ) => areOn.some( Boolean ) ? 'ck-splitbutton_flatten' : undefined
+			);
+
+			// Action click: re-fire the default child when nothing is active; otherwise toggle the dropdown.
+			this.listenTo( splitButtonView, 'execute', () => {
+				if ( buttonViews.some( ( { isOn } ) => isOn ) ) {
+					dropdownView.isOpen = !dropdownView.isOpen;
+				} else {
+					defaultButton.fire( 'execute' );
+				}
+			} );
+
+			// Reactive: dropdown is enabled when any child is enabled.
+			dropdownView.bind( 'isEnabled' ).toMany( buttonViews, 'isEnabled',
+				( ...areEnabled ) => areEnabled.some( Boolean )
+			);
+
+			// Refocus the editing view so the dropdown action doesn't steal caret position.
+			this.listenTo( dropdownView, 'execute', () => {
+				editor.editing.view.focus();
+			} );
+
+			return dropdownView;
+		} );
+	}
+}
+
+/**
+ * Combines the dropdown title and the default action item label for the split-button label.
+ */
+function getDropdownButtonTitle( dropdownTitle: string, buttonTitle: string ): string {
+	return `${ dropdownTitle }: ${ buttonTitle }`;
+}

--- a/packages/ckeditor5-media-embed/tests/manual/mediaembed.md
+++ b/packages/ckeditor5-media-embed/tests/manual/mediaembed.md
@@ -106,3 +106,47 @@
 1. Load the existing document (the "Media with previews" section uses the old `padding-bottom` wrapper format),
 1. The editor should render them correctly — upcast reads only the URL and regenerates the preview using the current provider HTML,
 1. Call `editor.getData()` — the iframe should carry inline `aspect-ratio` CSS directly, wrapped only in a plain `<div>` (no `padding-bottom` or `position` styles on the wrapper).
+
+### Default centering
+
+1. Insert a new media embed,
+1. An unresized YouTube/Vimeo figure spans the full editor width; an unresized Spotify figure stays at 300px and is centered horizontally,
+1. The data output `<figure>` should be `class="media"` only — no alignment class.
+
+### Alignment toolbar — buttons active on insert
+
+1. Insert a media embed and select it,
+1. The "Centered media" entry inside the **Break text** dropdown should be active by default,
+1. The data `<figure>` has no `media-style-*` class while the center button is on (default style is encoded as attribute-absence).
+
+### Block alignment
+
+1. Resize a media embed to ~50% (a full-width figure has no spare space to shift into),
+1. From the **Break text** dropdown, click "Left aligned media" — the figure should pin to the left edge of the content area,
+1. The data `<figure>` should include `media-style-block-align-left`,
+1. Repeat for "Right aligned media" — the figure should pin to the right edge, class becomes `media-style-block-align-right`,
+1. Click "Centered media" — both classes should be removed and the figure should re-center.
+
+### Text-wrap (float) alignment
+
+1. Below a paragraph of text, select a resized media (~50% width),
+1. From the **Wrap text** dropdown, click "Left aligned media" — the figure should float left and the surrounding paragraph text should wrap around it,
+1. The data `<figure>` should include `media-style-align-left` (no "block-"),
+1. Repeat with "Right aligned media" — the figure should float right with text wrapping on the left.
+
+### Side-by-side floats
+
+1. Insert two media embeds in a row,
+1. Float-align the first one left and the second one right,
+1. Both should sit on the same line (the `clear: none` override allows this) with text wrapping between or below.
+
+### Alignment + resize coexist
+
+1. Resize a media to ~50%,
+1. Apply each alignment in turn — the figure should keep its 50% width and reposition correctly,
+1. The data `<figure>` should include both `media_resized` (with `style="width: …"`) and the corresponding alignment class.
+
+### Alignment URL change
+
+1. Apply alignment to a media (e.g. `alignBlockLeft`),
+1. Change the URL to any other provider — alignment should be preserved across providers.

--- a/packages/ckeditor5-media-embed/tests/manual/mediaembedstyle-no-resize.html
+++ b/packages/ckeditor5-media-embed/tests/manual/mediaembedstyle-no-resize.html
@@ -1,0 +1,74 @@
+<head>
+	<meta name="x-cke-crawler-ignore-patterns" content='{
+		"console-error": [ "<svg> attribute preserveAspectRatio", "transparent NaN" ]
+	}'>
+
+	<style>
+		input {
+			width: 500px;
+		}
+
+		body {
+			width: 700px;
+		}
+
+		/*
+			Integrator-side override that narrows the YouTube figure. Stands in for the
+			real-world scenarios where the figure's width comes from somewhere other than
+			the resize feature (custom stylesheet, GeneralHtmlSupport preserving inline
+			styles, custom upcast, etc.). Scoped to YouTube so the Spotify embed below
+			demos a different width source (its built-in 300px default).
+		*/
+		.ck-content .media:has(> div[data-oembed-url*="youtube"]) {
+			max-width: 50%;
+		}
+	</style>
+</head>
+
+<h2>Example URLs</h2>
+<ul>
+	<li><input type="text" value="https://www.youtube.com/watch?v=H08tGjXNHO4"></li>
+	<li><input type="text" value="https://open.spotify.com/album/2IXlgvecaDqOeF3viUZnPI?si=ogVw7KlcQAGZKK4Jz9QzvA"></li>
+</ul>
+
+<h2>Test editor</h2>
+<div id="editor">
+	<h2>Provider with integrator-side width (YouTube)</h2>
+	<p>Default centering — no alignment class on the figure below.</p>
+
+	<figure class="media">
+		<div data-oembed-url="https://www.youtube.com/watch?v=ZVv7UMQPEWk">
+			<div>
+				<iframe src="https://www.youtube.com/embed/ZVv7UMQPEWk"
+					width="1280" height="720"
+					style="width: 100%; height: auto; aspect-ratio: 16 / 9; border: 0; display: block;"
+					frameborder="0" allow="autoplay; encrypted-media"
+					referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe>
+			</div>
+		</div>
+	</figure>
+
+	<p>
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore
+		magna aliqua. 
+	</p>
+
+	<h2>Provider with a built-in default width (Spotify)</h2>
+	<p>Spotify embeds default to a 300px wide figure.</p>
+
+	<figure class="media">
+		<div data-oembed-url="https://open.spotify.com/artist/7GaxyUddsPok8BuhxN6OUW?si=LM7Q50vqQ4-NYnAIcMTNuQ">
+			<div>
+				<iframe src="https://open.spotify.com/embed/artist/7GaxyUddsPok8BuhxN6OUW"
+					width="300" height="378"
+					style="width: 100%; height: auto; aspect-ratio: 100 / 126; border: 0; display: block;"
+					frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+			</div>
+		</div>
+	</figure>
+
+	<p>
+		Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+		consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+	</p>
+</div>

--- a/packages/ckeditor5-media-embed/tests/manual/mediaembedstyle-no-resize.js
+++ b/packages/ckeditor5-media-embed/tests/manual/mediaembedstyle-no-resize.js
@@ -7,25 +7,21 @@ import { ClassicEditor } from '@ckeditor/ckeditor5-editor-classic';
 import { ArticlePluginSet } from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset.js';
 import { MediaEmbed } from '../../src/mediaembed.js';
 import { MediaEmbedToolbar } from '../../src/mediaembedtoolbar.js';
-import { MediaEmbedResize } from '../../src/mediaembedresize.js';
 import { MediaEmbedStyle } from '../../src/mediaembedstyle.js';
 
 ClassicEditor
 	.create( {
 		attachTo: document.querySelector( '#editor' ),
 		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
-		plugins: [ ArticlePluginSet, MediaEmbed, MediaEmbedToolbar, MediaEmbedResize, MediaEmbedStyle ],
+		plugins: [ ArticlePluginSet, MediaEmbed, MediaEmbedToolbar, MediaEmbedStyle ],
 		toolbar: [
 			'heading', '|', 'mediaEmbed', '|', 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'link', 'undo', 'redo'
 		],
 		menuBar: { isVisible: true },
 		mediaEmbed: {
-			previewsInData: true,
 			toolbar: [
 				'mediaEmbed:breakText',
-				'mediaEmbed:wrapText',
-				'|',
-				'blockQuote'
+				'mediaEmbed:wrapText'
 			]
 		}
 	} )

--- a/packages/ckeditor5-media-embed/tests/manual/mediaembedstyle-no-resize.md
+++ b/packages/ckeditor5-media-embed/tests/manual/mediaembedstyle-no-resize.md
@@ -1,0 +1,40 @@
+# Media embed alignment without the resize feature
+
+Editor configured with `MediaEmbed` + `MediaEmbedStyle` (no `MediaEmbedResize`). The page stylesheet
+caps the YouTube figure at `max-width: 50%`, simulating a scenario where the figure's width comes
+from outside the resize feature (custom integrator CSS, GeneralHtmlSupport preserving inline styles,
+custom upcast, etc.). The Spotify embed is unaffected by that rule and demos a different width
+source — its built-in 300px default.
+
+The selected figure should have a contextual toolbar with **Break text** and **Wrap text** dropdowns.
+
+## Default centering
+
+1. The first figure (no alignment class) should be centered horizontally inside the editor content,
+1. The data `<figure>` should be `class="media"` only — no alignment class.
+
+## Block alignment shifts the figure even without `media_resized`
+
+1. Select the YouTube embed,
+1. From the **Break text** dropdown, click "Left aligned media" — the figure should pin to the left edge of the content area,
+1. The data `<figure>` should include `media-style-block-align-left` (no `media_resized` class — the resize plugin is not loaded),
+1. Repeat for "Right aligned media" — the figure should pin to the right edge,
+1. Click "Centered media" — the figure should re-center.
+
+## Wrap-text alignment with surrounding text
+
+1. Select the YouTube embed,
+1. From the **Wrap text** dropdown, click "Left aligned media" — the figure should float left and the paragraph below should wrap around it,
+1. The data `<figure>` should include `media-style-align-left`,
+1. Repeat with "Right aligned media" — the figure should float right with text wrapping on the left.
+
+## Provider with a built-in default width (Spotify)
+
+1. Select the Spotify embed (300px wide by default),
+1. Apply each block alignment in turn — the figure should shift to the corresponding edge of the content area,
+1. Apply each wrap-text alignment in turn — the figure should float to the corresponding side and surrounding text should wrap around it.
+
+## Round-trip
+
+1. Apply any alignment,
+1. Call `editor.getData()` — the output should contain only `media-style-*` classes; no `media_resized`, no `style="width: …"` (the resize feature is not loaded).

--- a/packages/ckeditor5-media-embed/tests/manual/semanticmediaembed.js
+++ b/packages/ckeditor5-media-embed/tests/manual/semanticmediaembed.js
@@ -6,16 +6,25 @@
 import { ClassicEditor } from '@ckeditor/ckeditor5-editor-classic';
 import { ArticlePluginSet } from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset.js';
 import { MediaEmbed } from '../../src/mediaembed.js';
+import { MediaEmbedToolbar } from '../../src/mediaembedtoolbar.js';
 import { MediaEmbedResize } from '../../src/mediaembedresize.js';
+import { MediaEmbedStyle } from '../../src/mediaembedstyle.js';
 
 ClassicEditor
 	.create( {
 		attachTo: document.querySelector( '#editor' ),
 		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
-		plugins: [ ArticlePluginSet, MediaEmbed, MediaEmbedResize ],
+		plugins: [ ArticlePluginSet, MediaEmbed, MediaEmbedToolbar, MediaEmbedResize, MediaEmbedStyle ],
 		toolbar: [
 			'heading', '|', 'mediaEmbed', '|', 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'link', 'undo', 'redo'
-		]
+		],
+		mediaEmbed: {
+			previewsInData: false,
+			toolbar: [
+				'mediaEmbed:breakText',
+				'mediaEmbed:wrapText'
+			]
+		}
 	} )
 	.then( editor => {
 		window.editor = editor;

--- a/packages/ckeditor5-media-embed/tests/manual/semanticmediaembed.md
+++ b/packages/ckeditor5-media-embed/tests/manual/semanticmediaembed.md
@@ -92,3 +92,21 @@
 1. The iframe should be wrapped in a plain `<div>` (no `padding-bottom` or `position` styles on the wrapper),
 1. The iframe's inline CSS should include `aspect-ratio: 16 / 9` and `height: auto`,
 1. Resizing the embed should preserve the 16:9 proportion.
+
+### Alignment classes survive in semantic data output
+
+1. Insert a media embed and apply each alignment in turn (use the **Wrap text** and **Break text** dropdowns),
+1. Call `editor.getData()` after each application,
+1. Output `<figure>` should include the matching class for `alignLeft`/`alignBlockLeft`/`alignBlockRight`/`alignRight`:
+   - `media-style-align-left` (float)
+   - `media-style-block-align-left` (block)
+   - `media-style-block-align-right` (block)
+   - `media-style-align-right` (float)
+1. For `alignCenter` (default), the output `<figure>` should be `class="media"` only — no alignment class.
+1. The inner element should remain `<oembed url="…">` — alignment changes the figure class, not the inner element.
+
+### Resize + alignment in semantic mode
+
+1. Resize a media to ~50% then apply `alignLeft` from the **Wrap text** dropdown,
+1. Output `<figure>` should include both `media_resized` (with `style="width: 50%"`) and `media-style-align-left`,
+1. The inner `<oembed>` is unchanged.

--- a/packages/ckeditor5-media-embed/tests/mediaembedstyle.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedstyle.js
@@ -1,0 +1,59 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+import { ClassicTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
+import { global } from '@ckeditor/ckeditor5-utils';
+
+import { MediaEmbedStyle } from '../src/mediaembedstyle.js';
+import { MediaEmbedStyleEditing } from '../src/mediaembedstyle/mediaembedstyleediting.js';
+import { MediaEmbedStyleUI } from '../src/mediaembedstyle/mediaembedstyleui.js';
+
+describe( 'MediaEmbedStyle', () => {
+	let editorElement, editor;
+
+	beforeEach( () => {
+		editorElement = global.document.createElement( 'div' );
+		global.document.body.appendChild( editorElement );
+
+		return ClassicTestEditor
+			.create( {
+				attachTo: editorElement,
+				plugins: [ MediaEmbedStyle ]
+			} )
+			.then( newEditor => {
+				editor = newEditor;
+			} );
+	} );
+
+	afterEach( () => {
+		editorElement.remove();
+
+		return editor.destroy();
+	} );
+
+	it( 'should be loaded', () => {
+		expect( editor.plugins.get( MediaEmbedStyle ) ).to.instanceOf( MediaEmbedStyle );
+	} );
+
+	it( 'should load MediaEmbedStyleEditing plugin', () => {
+		expect( editor.plugins.get( MediaEmbedStyleEditing ) ).to.instanceOf( MediaEmbedStyleEditing );
+	} );
+
+	it( 'should load MediaEmbedStyleUI plugin', () => {
+		expect( editor.plugins.get( MediaEmbedStyleUI ) ).to.instanceOf( MediaEmbedStyleUI );
+	} );
+
+	it( 'has proper name', () => {
+		expect( MediaEmbedStyle.pluginName ).to.equal( 'MediaEmbedStyle' );
+	} );
+
+	it( 'should have `isOfficialPlugin` static flag set to `true`', () => {
+		expect( MediaEmbedStyle.isOfficialPlugin ).to.be.true;
+	} );
+
+	it( 'should have `isPremiumPlugin` static flag set to `false`', () => {
+		expect( MediaEmbedStyle.isPremiumPlugin ).to.be.false;
+	} );
+} );

--- a/packages/ckeditor5-media-embed/tests/mediaembedstyle/mediaembedstyle-integration.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedstyle/mediaembedstyle-integration.js
@@ -1,0 +1,178 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+import { VirtualTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor.js';
+import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
+import { _setModelData, _getModelData } from '@ckeditor/ckeditor5-engine';
+
+import { MediaEmbedEditing } from '../../src/mediaembedediting.js';
+import { MediaEmbedResizeEditing } from '../../src/mediaembedresize/mediaembedresizeediting.js';
+import { MediaEmbedStyleEditing } from '../../src/mediaembedstyle/mediaembedstyleediting.js';
+
+const YOUTUBE_URL = 'https://youtu.be/foo';
+const VIMEO_URL = 'https://vimeo.com/1234';
+
+describe( 'MediaEmbedStyle integration', () => {
+	describe( 'with MediaEmbedResize', () => {
+		let editor, model;
+
+		beforeEach( async () => {
+			editor = await VirtualTestEditor.create( {
+				plugins: [ Paragraph, MediaEmbedEditing, MediaEmbedResizeEditing, MediaEmbedStyleEditing ]
+			} );
+
+			model = editor.model;
+		} );
+
+		afterEach( async () => {
+			await editor.destroy();
+		} );
+
+		it( 'preserves both alignment and resize on the same figure', () => {
+			_setModelData( model,
+				`<media mediaStyle="alignBlockLeft" resizedWidth="50%" url="${ YOUTUBE_URL }"></media>`
+			);
+
+			const data = editor.getData();
+
+			expect( data ).to.match( /media_resized/ );
+			expect( data ).to.match( /media-style-block-align-left/ );
+			expect( data ).to.match( /style="width:50%;"/ );
+		} );
+
+		it( 'preserves a wrap alignment alongside resize', () => {
+			_setModelData( model,
+				`<media mediaStyle="alignLeft" resizedWidth="40%" url="${ YOUTUBE_URL }"></media>`
+			);
+
+			const data = editor.getData();
+
+			expect( data ).to.match( /media-style-align-left/ );
+			expect( data ).to.match( /media_resized/ );
+			expect( data ).to.match( /style="width:40%;"/ );
+		} );
+
+		it( 'emits no alignment class for the default style (alignCenter), even when resized', () => {
+			_setModelData( model, `<media resizedWidth="50%" url="${ YOUTUBE_URL }"></media>` );
+
+			const data = editor.getData();
+
+			expect( data ).to.match( /media_resized/ );
+			expect( data ).to.match( /style="width:50%;"/ );
+			expect( data ).not.to.match( /media-style-/ );
+		} );
+
+		it( 'preserves alignment when URL changes between resizable providers', () => {
+			_setModelData( model,
+				`<media mediaStyle="alignBlockLeft" url="${ YOUTUBE_URL }"></media>`
+			);
+
+			const mediaModel = model.document.getRoot().getChild( 0 );
+
+			model.change( writer => writer.setAttribute( 'url', VIMEO_URL, mediaModel ) );
+
+			expect( mediaModel.getAttribute( 'mediaStyle' ) ).to.equal( 'alignBlockLeft' );
+			expect( editor.getData() ).to.match( /media-style-block-align-left/ );
+		} );
+	} );
+
+	describe( 'standalone (without MediaEmbedResize)', () => {
+		let editor, model;
+
+		beforeEach( async () => {
+			editor = await VirtualTestEditor.create( {
+				plugins: [ Paragraph, MediaEmbedEditing, MediaEmbedStyleEditing ]
+			} );
+
+			model = editor.model;
+		} );
+
+		afterEach( async () => {
+			await editor.destroy();
+		} );
+
+		for ( const [ value, className ] of [
+			[ 'alignLeft', 'media-style-align-left' ],
+			[ 'alignBlockLeft', 'media-style-block-align-left' ],
+			[ 'alignBlockRight', 'media-style-block-align-right' ],
+			[ 'alignRight', 'media-style-align-right' ]
+		] ) {
+			it( `applies ${ value } correctly without MediaEmbedResize loaded`, () => {
+				_setModelData( model, `<media mediaStyle="${ value }" url="${ YOUTUBE_URL }"></media>` );
+
+				expect( editor.getData() ).to.match( new RegExp( className ) );
+			} );
+		}
+
+		it( 'emits no media_resized class (resize plugin absent)', () => {
+			_setModelData( model, `<media mediaStyle="alignBlockLeft" url="${ YOUTUBE_URL }"></media>` );
+
+			const data = editor.getData();
+
+			expect( data ).to.match( /media-style-block-align-left/ );
+			expect( data ).not.to.match( /media_resized/ );
+		} );
+	} );
+
+	describe( 'semantic data output (previewsInData: false)', () => {
+		let editor, model;
+
+		beforeEach( async () => {
+			editor = await VirtualTestEditor.create( {
+				plugins: [ Paragraph, MediaEmbedEditing, MediaEmbedResizeEditing, MediaEmbedStyleEditing ],
+				mediaEmbed: {
+					previewsInData: false
+				}
+			} );
+
+			model = editor.model;
+		} );
+
+		afterEach( async () => {
+			await editor.destroy();
+		} );
+
+		it( 'emits the alignment class on the <figure> with <oembed> inner element', () => {
+			_setModelData( model, `<media mediaStyle="alignBlockLeft" url="${ YOUTUBE_URL }"></media>` );
+
+			const data = editor.getData();
+
+			expect( data ).to.match( /^<figure class="media media-style-block-align-left">/ );
+			expect( data ).to.match( /<oembed url="https:\/\/youtu\.be\/foo">/ );
+		} );
+
+		it( 'emits both alignment class and resize style on the <figure>', () => {
+			_setModelData( model,
+				`<media mediaStyle="alignLeft" resizedWidth="50%" url="${ YOUTUBE_URL }"></media>`
+			);
+
+			const data = editor.getData();
+
+			expect( data ).to.match( /media_resized/ );
+			expect( data ).to.match( /media-style-align-left/ );
+			expect( data ).to.match( /style="width:50%;"/ );
+			expect( data ).to.match( /<oembed url=/ );
+		} );
+
+		it( 'preserves a resized + aligned figure through semantic round-trip', () => {
+			const input =
+				'<figure class="media media_resized media-style-align-left" style="width:50%;">' +
+					`<oembed url="${ YOUTUBE_URL }"></oembed>` +
+				'</figure>';
+
+			editor.setData( input );
+
+			expect( _getModelData( model, { withoutSelection: true } ) ).to.equal(
+				`<media mediaStyle="alignLeft" resizedWidth="50%" url="${ YOUTUBE_URL }"></media>`
+			);
+
+			const output = editor.getData();
+			expect( output ).to.match( /media_resized/ );
+			expect( output ).to.match( /media-style-align-left/ );
+			expect( output ).to.match( /style="width:50%;"/ );
+			expect( output ).to.match( /<oembed url="https:\/\/youtu\.be\/foo">/ );
+		} );
+	} );
+} );

--- a/packages/ckeditor5-media-embed/tests/mediaembedstyle/mediaembedstylecommand.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedstyle/mediaembedstylecommand.js
@@ -1,0 +1,165 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+import { VirtualTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor.js';
+import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
+import { UndoEditing } from '@ckeditor/ckeditor5-undo';
+import { _setModelData, _getModelData } from '@ckeditor/ckeditor5-engine';
+
+import { MediaEmbedEditing } from '../../src/mediaembedediting.js';
+import { MediaEmbedStyleEditing } from '../../src/mediaembedstyle/mediaembedstyleediting.js';
+import { MediaEmbedStyleCommand } from '../../src/mediaembedstyle/mediaembedstylecommand.js';
+
+const URL = 'https://youtu.be/foo';
+
+describe( 'MediaEmbedStyleCommand', () => {
+	let editor, model, command;
+
+	beforeEach( async () => {
+		editor = await VirtualTestEditor.create( {
+			plugins: [ Paragraph, MediaEmbedEditing, MediaEmbedStyleEditing, UndoEditing ]
+		} );
+
+		model = editor.model;
+		command = editor.commands.get( 'mediaStyle' );
+	} );
+
+	afterEach( async () => {
+		await editor.destroy();
+	} );
+
+	it( 'is an instance of MediaEmbedStyleCommand', () => {
+		expect( command ).to.be.instanceOf( MediaEmbedStyleCommand );
+	} );
+
+	describe( '#isEnabled', () => {
+		it( 'is true when a media element is selected', () => {
+			_setModelData( model, `<paragraph>x</paragraph>[<media url="${ URL }"></media>]` );
+
+			expect( command.isEnabled ).to.be.true;
+		} );
+
+		it( 'is false when no media is selected', () => {
+			_setModelData( model, `<paragraph>x[]</paragraph><media url="${ URL }"></media>` );
+
+			expect( command.isEnabled ).to.be.false;
+		} );
+
+		it( 'is false when selection is inside a paragraph', () => {
+			_setModelData( model, '<paragraph>x[]y</paragraph>' );
+
+			expect( command.isEnabled ).to.be.false;
+		} );
+	} );
+
+	describe( '#value', () => {
+		it( 'is false when no media is selected', () => {
+			_setModelData( model, `<paragraph>x[]</paragraph><media url="${ URL }"></media>` );
+
+			expect( command.value ).to.be.false;
+		} );
+
+		it( 'falls back to "alignCenter" when the selected media has no mediaStyle attribute', () => {
+			_setModelData( model, `[<media url="${ URL }"></media>]` );
+
+			expect( command.value ).to.equal( 'alignCenter' );
+		} );
+
+		for ( const value of [ 'alignLeft', 'alignBlockLeft', 'alignCenter', 'alignBlockRight', 'alignRight' ] ) {
+			it( `reflects mediaStyle="${ value }" when set on the selected media`, () => {
+				_setModelData( model, `[<media mediaStyle="${ value }" url="${ URL }"></media>]` );
+
+				expect( command.value ).to.equal( value );
+			} );
+		}
+	} );
+
+	describe( 'execute()', () => {
+		for ( const value of [ 'alignLeft', 'alignBlockLeft', 'alignBlockRight', 'alignRight' ] ) {
+			it( `sets mediaStyle="${ value }" on the selected media`, () => {
+				_setModelData( model, `[<media url="${ URL }"></media>]` );
+
+				command.execute( { value } );
+
+				expect( _getModelData( model ) ).to.equal(
+					`[<media mediaStyle="${ value }" url="${ URL }"></media>]`
+				);
+			} );
+		}
+
+		it( 'removes the attribute when value is the default style ("alignCenter")', () => {
+			_setModelData( model, `[<media mediaStyle="alignBlockLeft" url="${ URL }"></media>]` );
+
+			command.execute( { value: 'alignCenter' } );
+
+			expect( _getModelData( model ) ).to.equal(
+				`[<media url="${ URL }"></media>]`
+			);
+		} );
+
+		it( 'removes the attribute when value is null', () => {
+			_setModelData( model, `[<media mediaStyle="alignBlockLeft" url="${ URL }"></media>]` );
+
+			command.execute( { value: null } );
+
+			expect( _getModelData( model ) ).to.equal(
+				`[<media url="${ URL }"></media>]`
+			);
+		} );
+
+		it( 'replaces an existing mediaStyle attribute', () => {
+			_setModelData( model, `[<media mediaStyle="alignBlockLeft" url="${ URL }"></media>]` );
+
+			command.execute( { value: 'alignBlockRight' } );
+
+			expect( _getModelData( model ) ).to.equal(
+				`[<media mediaStyle="alignBlockRight" url="${ URL }"></media>]`
+			);
+		} );
+
+		it( 'is a no-op when called twice with the same non-default value', () => {
+			_setModelData( model, `[<media url="${ URL }"></media>]` );
+
+			command.execute( { value: 'alignBlockLeft' } );
+			command.execute( { value: 'alignBlockLeft' } );
+
+			expect( _getModelData( model ) ).to.equal(
+				`[<media mediaStyle="alignBlockLeft" url="${ URL }"></media>]`
+			);
+		} );
+
+		it( 'does nothing when no media is selected', () => {
+			_setModelData( model, `<paragraph>x[]</paragraph><media url="${ URL }"></media>` );
+
+			command.execute( { value: 'alignBlockLeft' } );
+
+			expect( _getModelData( model ) ).to.equal(
+				`<paragraph>x[]</paragraph><media url="${ URL }"></media>`
+			);
+		} );
+
+		it( 'is undoable in a single step', () => {
+			_setModelData( model, `[<media url="${ URL }"></media>]` );
+
+			command.execute( { value: 'alignBlockLeft' } );
+			editor.execute( 'undo' );
+
+			expect( _getModelData( model ) ).to.equal(
+				`[<media url="${ URL }"></media>]`
+			);
+		} );
+
+		it( 'is undoable when clearing the attribute', () => {
+			_setModelData( model, `[<media mediaStyle="alignBlockLeft" url="${ URL }"></media>]` );
+
+			command.execute( { value: null } );
+			editor.execute( 'undo' );
+
+			expect( _getModelData( model ) ).to.equal(
+				`[<media mediaStyle="alignBlockLeft" url="${ URL }"></media>]`
+			);
+		} );
+	} );
+} );

--- a/packages/ckeditor5-media-embed/tests/mediaembedstyle/mediaembedstyleediting.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedstyle/mediaembedstyleediting.js
@@ -1,0 +1,260 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+import { VirtualTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor.js';
+import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
+import { _setModelData, _getModelData } from '@ckeditor/ckeditor5-engine';
+
+import { MediaEmbedEditing } from '../../src/mediaembedediting.js';
+import { MediaEmbedStyleEditing } from '../../src/mediaembedstyle/mediaembedstyleediting.js';
+import { MediaEmbedStyleCommand } from '../../src/mediaembedstyle/mediaembedstylecommand.js';
+
+const YOUTUBE_URL = 'https://youtu.be/foo';
+
+describe( 'MediaEmbedStyleEditing', () => {
+	let editor, model;
+
+	beforeEach( async () => {
+		editor = await VirtualTestEditor.create( {
+			plugins: [ Paragraph, MediaEmbedEditing, MediaEmbedStyleEditing ]
+		} );
+
+		model = editor.model;
+	} );
+
+	afterEach( async () => {
+		await editor.destroy();
+	} );
+
+	it( 'should be named', () => {
+		expect( MediaEmbedStyleEditing.pluginName ).to.equal( 'MediaEmbedStyleEditing' );
+	} );
+
+	it( 'should have `isOfficialPlugin` static flag set to `true`', () => {
+		expect( MediaEmbedStyleEditing.isOfficialPlugin ).to.be.true;
+	} );
+
+	it( 'should have `isPremiumPlugin` static flag set to `false`', () => {
+		expect( MediaEmbedStyleEditing.isPremiumPlugin ).to.be.false;
+	} );
+
+	it( 'should require MediaEmbedEditing', () => {
+		expect( MediaEmbedStyleEditing.requires ).to.include( MediaEmbedEditing );
+	} );
+
+	describe( 'schema', () => {
+		it( 'allows mediaStyle attribute on media', () => {
+			expect( model.schema.checkAttribute( [ '$root', 'media' ], 'mediaStyle' ) ).to.be.true;
+		} );
+
+		it( 'marks mediaStyle as a formatting attribute', () => {
+			expect( model.schema.getAttributeProperties( 'mediaStyle' ) ).to.deep.include( {
+				isFormatting: true
+			} );
+		} );
+	} );
+
+	describe( 'command', () => {
+		it( 'registers the mediaStyle command', () => {
+			expect( editor.commands.get( 'mediaStyle' ) ).to.be.instanceOf( MediaEmbedStyleCommand );
+		} );
+	} );
+
+	describe( 'conversion (data pipeline)', () => {
+		describe( 'downcast — mediaStyle attribute', () => {
+			for ( const [ value, className ] of [
+				[ 'alignLeft', 'media-style-align-left' ],
+				[ 'alignBlockLeft', 'media-style-block-align-left' ],
+				[ 'alignBlockRight', 'media-style-block-align-right' ],
+				[ 'alignRight', 'media-style-align-right' ]
+			] ) {
+				it( `produces "${ className }" on the figure for mediaStyle="${ value }"`, () => {
+					_setModelData( model, `<media mediaStyle="${ value }" url="${ YOUTUBE_URL }"></media>` );
+
+					expect( editor.getData() ).to.match(
+						new RegExp( `^<figure class="media ${ className }">` )
+					);
+				} );
+			}
+
+			it( 'does not produce a class for mediaStyle="alignCenter" (default)', () => {
+				// alignCenter is the default style — encoded by attribute-absence in normal use.
+				// If something sets it explicitly, the downcast still emits no class.
+				_setModelData( model, `<media mediaStyle="alignCenter" url="${ YOUTUBE_URL }"></media>` );
+
+				expect( editor.getData() ).to.match( /^<figure class="media">/ );
+			} );
+
+			it( 'removes the old class and adds the new class when mediaStyle changes', () => {
+				_setModelData( model, `<media mediaStyle="alignBlockLeft" url="${ YOUTUBE_URL }"></media>` );
+
+				const mediaModel = model.document.getRoot().getChild( 0 );
+
+				model.change( writer => {
+					writer.setAttribute( 'mediaStyle', 'alignBlockRight', mediaModel );
+				} );
+
+				const data = editor.getData();
+				expect( data ).to.match( /^<figure class="media media-style-block-align-right">/ );
+				expect( data ).not.to.match( /media-style-block-align-left/ );
+			} );
+
+			it( 'removes the class when mediaStyle is cleared', () => {
+				_setModelData( model, `<media mediaStyle="alignBlockLeft" url="${ YOUTUBE_URL }"></media>` );
+
+				const mediaModel = model.document.getRoot().getChild( 0 );
+
+				model.change( writer => {
+					writer.removeAttribute( 'mediaStyle', mediaModel );
+				} );
+
+				expect( editor.getData() ).to.match( /^<figure class="media">/ );
+			} );
+
+			it( 'does not write a class for an unknown mediaStyle value', () => {
+				// Unknown values are silently ignored — schema doesn't constrain values, but
+				// the downcast looks the value up in MEDIA_STYLE_CLASSES.
+				_setModelData( model, `<media mediaStyle="bogus" url="${ YOUTUBE_URL }"></media>` );
+
+				expect( editor.getData() ).to.match( /^<figure class="media">/ );
+			} );
+
+			it( 'does not downcast if the event was already consumed', () => {
+				editor.conversion.for( 'downcast' ).add( dispatcher =>
+					dispatcher.on( 'attribute:mediaStyle:media', ( evt, data, conversionApi ) => {
+						conversionApi.consumable.consume( data.item, 'attribute:mediaStyle:media' );
+					}, { priority: 'high' } )
+				);
+
+				_setModelData( model, `<media mediaStyle="alignBlockLeft" url="${ YOUTUBE_URL }"></media>` );
+
+				expect( editor.getData() ).not.to.match( /media-style-block-align-left/ );
+			} );
+		} );
+
+		describe( 'upcast — alignment class → mediaStyle attribute', () => {
+			for ( const [ className, value ] of [
+				[ 'media-style-align-left', 'alignLeft' ],
+				[ 'media-style-block-align-left', 'alignBlockLeft' ],
+				[ 'media-style-block-align-right', 'alignBlockRight' ],
+				[ 'media-style-align-right', 'alignRight' ]
+			] ) {
+				it( `converts ${ className } to mediaStyle="${ value }"`, () => {
+					editor.setData(
+						`<figure class="media ${ className }"><oembed url="${ YOUTUBE_URL }"></oembed></figure>`
+					);
+
+					const mediaModel = model.document.getRoot().getChild( 0 );
+
+					expect( mediaModel.getAttribute( 'mediaStyle' ) ).to.equal( value );
+				} );
+			}
+
+			it( 'does not set mediaStyle when no alignment class is present', () => {
+				editor.setData( `<figure class="media"><oembed url="${ YOUTUBE_URL }"></oembed></figure>` );
+
+				const mediaModel = model.document.getRoot().getChild( 0 );
+
+				expect( mediaModel.hasAttribute( 'mediaStyle' ) ).to.be.false;
+			} );
+
+			it( 'when multiple alignment classes are present, the last one (in iteration order) wins', () => {
+				// Iteration order from MEDIA_STYLE_CLASSES:
+				// alignLeft, alignBlockLeft, alignBlockRight, alignRight.
+				// So if both align-left and align-right are present, align-right wins.
+				editor.setData(
+					'<figure class="media media-style-align-left media-style-align-right">' +
+						`<oembed url="${ YOUTUBE_URL }"></oembed>` +
+					'</figure>'
+				);
+
+				const mediaModel = model.document.getRoot().getChild( 0 );
+
+				expect( mediaModel.getAttribute( 'mediaStyle' ) ).to.equal( 'alignRight' );
+			} );
+
+			it( 'does not set mediaStyle on a non-media figure', () => {
+				editor.model.schema.register( 'customWidget', {
+					inheritAllFrom: '$blockObject',
+					allowAttributes: [ 'mediaStyle' ]
+				} );
+				editor.conversion.elementToElement( {
+					view: { name: 'figure', classes: [ 'widget' ] },
+					model: 'customWidget'
+				} );
+
+				editor.setData( '<figure class="widget media-style-align-left"></figure>' );
+
+				const widget = model.document.getRoot().getChild( 0 );
+
+				expect( widget.name ).to.equal( 'customWidget' );
+				expect( widget.hasAttribute( 'mediaStyle' ) ).to.be.false;
+			} );
+		} );
+
+		describe( 'round-trip', () => {
+			for ( const [ value, className ] of [
+				[ 'alignLeft', 'media-style-align-left' ],
+				[ 'alignBlockLeft', 'media-style-block-align-left' ],
+				[ 'alignBlockRight', 'media-style-block-align-right' ],
+				[ 'alignRight', 'media-style-align-right' ]
+			] ) {
+				it( `preserves an "${ value }" alignment through load-and-save`, () => {
+					const input = `<figure class="media ${ className }"><oembed url="${ YOUTUBE_URL }"></oembed></figure>`;
+
+					editor.setData( input );
+
+					expect( _getModelData( model, { withoutSelection: true } ) ).to.equal(
+						`<media mediaStyle="${ value }" url="${ YOUTUBE_URL }"></media>`
+					);
+
+					expect( editor.getData() ).to.equal( input );
+				} );
+			}
+		} );
+	} );
+
+	describe( 'conversion with previewsInData: true', () => {
+		let previewEditor, previewModel;
+
+		beforeEach( async () => {
+			previewEditor = await VirtualTestEditor.create( {
+				plugins: [ Paragraph, MediaEmbedEditing, MediaEmbedStyleEditing ],
+				mediaEmbed: {
+					previewsInData: true
+				}
+			} );
+
+			previewModel = previewEditor.model;
+		} );
+
+		afterEach( async () => {
+			await previewEditor.destroy();
+		} );
+
+		it( 'emits the alignment class alongside the preview HTML', () => {
+			_setModelData( previewModel, `<media mediaStyle="alignBlockLeft" url="${ YOUTUBE_URL }"></media>` );
+
+			const data = previewEditor.getData();
+
+			expect( data ).to.match( /^<figure class="media media-style-block-align-left">/ );
+			expect( data ).to.match( /data-oembed-url="https:\/\/youtu\.be\/foo"/ );
+		} );
+
+		it( 'upcasts an alignment class even when preview HTML is present', () => {
+			previewEditor.setData(
+				'<figure class="media media-style-align-right">' +
+					`<div data-oembed-url="${ YOUTUBE_URL }">` +
+						'<iframe src="https://www.youtube.com/embed/foo" width="1280" height="720"></iframe>' +
+					'</div>' +
+				'</figure>'
+			);
+
+			const mediaModel = previewModel.document.getRoot().getChild( 0 );
+
+			expect( mediaModel.getAttribute( 'mediaStyle' ) ).to.equal( 'alignRight' );
+		} );
+	} );
+} );

--- a/packages/ckeditor5-media-embed/tests/mediaembedstyle/mediaembedstyleediting.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedstyle/mediaembedstyleediting.js
@@ -192,6 +192,14 @@ describe( 'MediaEmbedStyleEditing', () => {
 				expect( widget.name ).to.equal( 'customWidget' );
 				expect( widget.hasAttribute( 'mediaStyle' ) ).to.be.false;
 			} );
+
+			it( 'returns early when no upcast produces a model range for the figure', () => {
+				// A <figure> without `class="media"` - the main media upcast doesn't claim it,
+				// so `data.modelRange` is never set when our low-priority listener fires.
+				editor.setData( '<figure></figure>' );
+
+				expect( _getModelData( model, { withoutSelection: true } ) ).not.to.contain( '<media' );
+			} );
 		} );
 
 		describe( 'round-trip', () => {

--- a/packages/ckeditor5-media-embed/tests/mediaembedstyle/mediaembedstyleui.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedstyle/mediaembedstyleui.js
@@ -1,0 +1,263 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+import { ClassicTestEditor } from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
+import { global } from '@ckeditor/ckeditor5-utils';
+import { ButtonView, DropdownView, SplitButtonView } from '@ckeditor/ckeditor5-ui';
+import { _setModelData } from '@ckeditor/ckeditor5-engine';
+import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
+
+import { MediaEmbedEditing } from '../../src/mediaembedediting.js';
+import { MediaEmbedStyleEditing } from '../../src/mediaembedstyle/mediaembedstyleediting.js';
+import { MediaEmbedStyleUI } from '../../src/mediaembedstyle/mediaembedstyleui.js';
+
+const URL = 'https://youtu.be/foo';
+
+const BUTTON_NAMES = [
+	'mediaEmbed:alignLeft',
+	'mediaEmbed:alignBlockLeft',
+	'mediaEmbed:alignCenter',
+	'mediaEmbed:alignBlockRight',
+	'mediaEmbed:alignRight'
+];
+
+const DROPDOWN_NAMES = [
+	'mediaEmbed:wrapText',
+	'mediaEmbed:breakText'
+];
+
+describe( 'MediaEmbedStyleUI', () => {
+	let editor, editorElement, factory, command;
+
+	beforeEach( async () => {
+		editorElement = global.document.createElement( 'div' );
+		global.document.body.appendChild( editorElement );
+
+		editor = await ClassicTestEditor.create( editorElement, {
+			plugins: [ Paragraph, MediaEmbedEditing, MediaEmbedStyleEditing, MediaEmbedStyleUI ]
+		} );
+
+		factory = editor.ui.componentFactory;
+		command = editor.commands.get( 'mediaStyle' );
+	} );
+
+	afterEach( async () => {
+		editorElement.remove();
+		await editor.destroy();
+	} );
+
+	it( 'should be named', () => {
+		expect( MediaEmbedStyleUI.pluginName ).to.equal( 'MediaEmbedStyleUI' );
+	} );
+
+	it( 'should have `isOfficialPlugin` static flag set to `true`', () => {
+		expect( MediaEmbedStyleUI.isOfficialPlugin ).to.be.true;
+	} );
+
+	it( 'should have `isPremiumPlugin` static flag set to `false`', () => {
+		expect( MediaEmbedStyleUI.isPremiumPlugin ).to.be.false;
+	} );
+
+	it( 'should require MediaEmbedStyleEditing', () => {
+		expect( MediaEmbedStyleUI.requires ).to.include( MediaEmbedStyleEditing );
+	} );
+
+	describe( 'init()', () => {
+		it( 'should register all five alignment buttons', () => {
+			for ( const name of BUTTON_NAMES ) {
+				expect( factory.has( name ), name ).to.be.true;
+			}
+		} );
+
+		it( 'should register the wrapText and breakText dropdowns', () => {
+			for ( const name of DROPDOWN_NAMES ) {
+				expect( factory.has( name ), name ).to.be.true;
+			}
+		} );
+	} );
+
+	describe( 'buttons', () => {
+		it( 'is a ButtonView instance', () => {
+			for ( const name of BUTTON_NAMES ) {
+				const button = factory.create( name );
+				expect( button, name ).to.be.instanceOf( ButtonView );
+				button.destroy();
+			}
+		} );
+
+		it( 'has tooltip, isToggleable, label and icon', () => {
+			for ( const name of BUTTON_NAMES ) {
+				const button = factory.create( name );
+				expect( button.tooltip, `${ name } tooltip` ).to.be.true;
+				expect( button.isToggleable, `${ name } isToggleable` ).to.be.true;
+				expect( button.label, `${ name } label` ).to.be.a( 'string' ).and.not.empty;
+				expect( button.icon, `${ name } icon` ).to.be.a( 'string' ).and.not.empty;
+				button.destroy();
+			}
+		} );
+
+		it( 'binds isEnabled to the command', () => {
+			for ( const name of BUTTON_NAMES ) {
+				const button = factory.create( name );
+
+				_setModelData( editor.model, `[<media url="${ URL }"></media>]` );
+				expect( button.isEnabled, `${ name } enabled on media selection` ).to.be.true;
+
+				_setModelData( editor.model, '<paragraph>x[]</paragraph>' );
+				expect( button.isEnabled, `${ name } disabled outside media` ).to.be.false;
+
+				button.destroy();
+			}
+		} );
+
+		it( 'mediaEmbed:alignLeft is on when the command value is "alignLeft"', () => {
+			const button = factory.create( 'mediaEmbed:alignLeft' );
+
+			_setModelData( editor.model, `[<media mediaStyle="alignLeft" url="${ URL }"></media>]` );
+			expect( button.isOn ).to.be.true;
+
+			_setModelData( editor.model, `[<media mediaStyle="alignBlockLeft" url="${ URL }"></media>]` );
+			expect( button.isOn ).to.be.false;
+
+			button.destroy();
+		} );
+
+		it( 'mediaEmbed:alignCenter is on by default for an unaligned media (default-state lighting)', () => {
+			const button = factory.create( 'mediaEmbed:alignCenter' );
+
+			_setModelData( editor.model, `[<media url="${ URL }"></media>]` );
+
+			expect( button.isOn ).to.be.true;
+
+			button.destroy();
+		} );
+
+		it( 'fires the command with the right value when executed', () => {
+			const button = factory.create( 'mediaEmbed:alignBlockLeft' );
+			const executeSpy = sinon.spy( command, 'execute' );
+
+			_setModelData( editor.model, `[<media url="${ URL }"></media>]` );
+
+			button.fire( 'execute' );
+
+			expect( executeSpy.calledOnce ).to.be.true;
+			expect( executeSpy.firstCall.args[ 0 ] ).to.deep.equal( { value: 'alignBlockLeft' } );
+
+			button.destroy();
+		} );
+
+		it( 'refocuses the editing view after click', () => {
+			const button = factory.create( 'mediaEmbed:alignBlockLeft' );
+			const focusSpy = sinon.spy( editor.editing.view, 'focus' );
+
+			_setModelData( editor.model, `[<media url="${ URL }"></media>]` );
+
+			button.fire( 'execute' );
+
+			expect( focusSpy.calledOnce ).to.be.true;
+
+			button.destroy();
+		} );
+	} );
+
+	describe( 'dropdowns', () => {
+		it( 'is a DropdownView instance with a SplitButtonView and an enabled tooltip', () => {
+			for ( const name of DROPDOWN_NAMES ) {
+				const dropdown = factory.create( name );
+				expect( dropdown, name ).to.be.instanceOf( DropdownView );
+				expect( dropdown.buttonView, `${ name } buttonView` ).to.be.instanceOf( SplitButtonView );
+				expect( dropdown.buttonView.tooltip, `${ name } tooltip` ).to.be.true;
+				dropdown.destroy();
+			}
+		} );
+
+		it( 'is enabled when a media is selected and disabled otherwise', () => {
+			for ( const name of DROPDOWN_NAMES ) {
+				const dropdown = factory.create( name );
+
+				_setModelData( editor.model, `[<media url="${ URL }"></media>]` );
+				expect( dropdown.isEnabled, `${ name } enabled on media selection` ).to.be.true;
+
+				_setModelData( editor.model, '<paragraph>x[]</paragraph>' );
+				expect( dropdown.isEnabled, `${ name } disabled outside media` ).to.be.false;
+
+				dropdown.destroy();
+			}
+		} );
+
+		it( 'breakText action button reflects the active alignment (alignBlockLeft)', () => {
+			const dropdown = factory.create( 'mediaEmbed:breakText' );
+			// Force lazy initialization of bindings.
+			dropdown.render();
+
+			_setModelData( editor.model, `[<media mediaStyle="alignBlockLeft" url="${ URL }"></media>]` );
+
+			expect( dropdown.buttonView.isOn ).to.be.true;
+
+			dropdown.destroy();
+		} );
+
+		it( 'wrapText action button reflects no active state when no wrap alignment is set', () => {
+			const dropdown = factory.create( 'mediaEmbed:wrapText' );
+			dropdown.render();
+
+			_setModelData( editor.model, `[<media mediaStyle="alignBlockLeft" url="${ URL }"></media>]` );
+
+			expect( dropdown.buttonView.isOn ).to.be.false;
+
+			dropdown.destroy();
+		} );
+
+		it( 'breakText action button click executes the default item (alignCenter) when no child is active', () => {
+			// Use a wrap alignment so none of breakText's children
+			// (alignBlockLeft, alignCenter, alignBlockRight) is active.
+			_setModelData( editor.model, `[<media mediaStyle="alignLeft" url="${ URL }"></media>]` );
+
+			const dropdown = factory.create( 'mediaEmbed:breakText' );
+			dropdown.render();
+
+			const executeSpy = sinon.spy( command, 'execute' );
+
+			dropdown.buttonView.fire( 'execute' );
+
+			expect( executeSpy.calledOnce ).to.be.true;
+			expect( executeSpy.firstCall.args[ 0 ] ).to.deep.equal( { value: 'alignCenter' } );
+
+			dropdown.destroy();
+		} );
+
+		it( 'breakText action button click toggles the dropdown when a child is active', () => {
+			const dropdown = factory.create( 'mediaEmbed:breakText' );
+			dropdown.render();
+
+			// alignBlockLeft is one of breakText's children, so the dropdown's "any child on" state is true.
+			_setModelData( editor.model, `[<media mediaStyle="alignBlockLeft" url="${ URL }"></media>]` );
+
+			const executeSpy = sinon.spy( command, 'execute' );
+
+			dropdown.buttonView.fire( 'execute' );
+
+			expect( executeSpy.called, 'command should not be executed' ).to.be.false;
+			expect( dropdown.isOpen, 'dropdown should be open' ).to.be.true;
+
+			dropdown.destroy();
+		} );
+
+		it( 'refocuses the editing view after a dropdown action', () => {
+			const dropdown = factory.create( 'mediaEmbed:breakText' );
+			dropdown.render();
+
+			const focusSpy = sinon.spy( editor.editing.view, 'focus' );
+
+			_setModelData( editor.model, `[<media url="${ URL }"></media>]` );
+
+			dropdown.fire( 'execute' );
+
+			expect( focusSpy.calledOnce ).to.be.true;
+
+			dropdown.destroy();
+		} );
+	} );
+} );

--- a/packages/ckeditor5-media-embed/theme/mediaembedstyle.css
+++ b/packages/ckeditor5-media-embed/theme/mediaembedstyle.css
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+:root {
+	/* Side spacing between a floated media and surrounding text. */
+	--ck-content-media-style-spacing: 1.5em;
+}
+
+.ck-content {
+	/* `clear: none` lets multiple floats stack horizontally. `width: 100%` keeps float
+	   from collapsing the iframe to its 300×150 default; resize's inline `style="width: …"`
+	   and Spotify's `:has()` rule in mediaembedediting.css both win on specificity. */
+	& .media.media-style-align-left,
+	& .media.media-style-align-right {
+		clear: none;
+		width: 100%;
+	}
+
+	& .media.media-style-align-left {
+		float: left;
+		margin-right: var(--ck-content-media-style-spacing);
+	}
+
+	& .media.media-style-align-right {
+		float: right;
+		margin-left: var(--ck-content-media-style-spacing);
+	}
+
+	/* Margin-auto shifts a width-constrained figure within its line — a no-op for full-width
+	   figures, visible once a width constraint applies (resize's inline width, or Spotify's
+	   backward-compat 300px). */
+	& .media.media-style-block-align-left {
+		margin-left: 0;
+		margin-right: auto;
+	}
+
+	& .media.media-style-block-align-right {
+		margin-left: auto;
+		margin-right: 0;
+	}
+}

--- a/packages/ckeditor5-ui/theme/components/dropdown/splitbutton.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/splitbutton.css
@@ -112,6 +112,32 @@
 			}
 		}
 	}
+
+	/* The button should display as a regular drop-down if the action button
+	is forced to fire the same action as the arrow button. */
+	&.ck-splitbutton_flatten {
+		&:hover,
+		&.ck-splitbutton_open {
+			& > .ck-splitbutton__action:not(.ck-disabled),
+			& > .ck-splitbutton__arrow:not(.ck-disabled),
+			& > .ck-splitbutton__arrow:not(.ck-disabled):not(:hover) {
+				background-color: var(--ck-color-button-on-background);
+
+				&::after {
+					display: none;
+				}
+			}
+		}
+
+		&.ck-splitbutton_open:hover {
+			& > .ck-splitbutton__action:not(.ck-disabled),
+			& > .ck-splitbutton__arrow:not(.ck-disabled),
+			& > .ck-splitbutton__arrow:not(.ck-disabled):not(:hover) {
+				background-color: var(--ck-color-button-on-hover-background);
+			}
+		}
+	}
+
 	/* Enable font size inheritance, which allows fluid UI scaling. */
 	font-size: inherit;
 }

--- a/packages/ckeditor5/tests/manual/all-features.js
+++ b/packages/ckeditor5/tests/manual/all-features.js
@@ -19,7 +19,7 @@ import { HtmlEmbed } from '@ckeditor/ckeditor5-html-embed';
 import { HtmlComment, GeneralHtmlSupport } from '@ckeditor/ckeditor5-html-support';
 import { IndentBlock } from '@ckeditor/ckeditor5-indent';
 import { ListProperties, TodoList } from '@ckeditor/ckeditor5-list';
-import { MediaEmbedResize } from '@ckeditor/ckeditor5-media-embed';
+import { MediaEmbedResize, MediaEmbedStyle, MediaEmbedToolbar } from '@ckeditor/ckeditor5-media-embed';
 import { Mention } from '@ckeditor/ckeditor5-mention';
 import { PageBreak } from '@ckeditor/ckeditor5-page-break';
 import { PasteFromOffice } from '@ckeditor/ckeditor5-paste-from-office';
@@ -48,7 +48,9 @@ ClassicEditor
 			ArticlePluginSet, Underline, Strikethrough, Superscript, Subscript, Code, RemoveFormat,
 			FindAndReplace, FontColor, FontBackgroundColor, FontFamily, FontSize, Highlight,
 			CodeBlock, TodoList, ListProperties, TableProperties, TableCellProperties, TableCaption, TableColumnResize,
-			EasyImage, ImageResize, ImageInsert, LinkImage, AutoImage, MediaEmbedResize, HtmlEmbed, HtmlComment,
+			EasyImage, ImageResize, ImageInsert, LinkImage, AutoImage,
+			MediaEmbedResize, MediaEmbedStyle, MediaEmbedToolbar,
+			HtmlEmbed, HtmlComment,
 			AutoLink, Mention, TextTransformation,
 			Alignment, IndentBlock, Bookmark,
 			PasteFromOffice, PageBreak, HorizontalLine, ShowBlocks,
@@ -82,6 +84,12 @@ ClassicEditor
 		table: {
 			contentToolbar: [
 				'tableColumn', 'tableRow', 'mergeTableCells', 'tableProperties', 'tableCellProperties', 'toggleTableCaption'
+			]
+		},
+		mediaEmbed: {
+			toolbar: [
+				'mediaEmbed:breakText',
+				'mediaEmbed:wrapText'
 			]
 		},
 		image: {


### PR DESCRIPTION
### 🚀 Summary

Adds the `MediaEmbedStyle` plugin to align media embeds, with optional text wrapping.

Configuration options similar to those available in the image style plugins will be delivered in a follow-up ticket: https://github.com/ckeditor/ckeditor5/issues/20131

---

### 📌 Related issues

* Closes #2781

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [x] Have tests been added that fail without this change (against regression)?
- [x] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [x] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [x] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [x] I manually verified the change (e.g., in manual tests or documentation).
- [x] The target branch is correct.
