### PR TITLE
Upgrade Chrome version to `148.0.7778.96`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ parameters:
     default: false
   chromeVersion:
     type: string
-    default: "147.0.7727.55"
+    default: "148.0.7778.96"
   isLtsPipeline:
     type: boolean
     default: false


### PR DESCRIPTION
### 🚀 Summary

This PR bumps the Chrome used in CI to **148.0.7778.96**.

---

### 📃 Additional information

- Generated automatically by the Chrome bump workflow.
- Triggered because a new Chrome stable version was detected.
