### PR TITLE
Fix AI tabs transitionend listener not being removed after leaving fullscreen.

### DIFF
--- a/.changelog/20260507150602_ck_20129.md
+++ b/.changelog/20260507150602_ck_20129.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-fullscreen
+closes:
+  - 20129
+---
+
+Fixed errors that could appear when maximizing the AI panel after leaving fullscreen mode.

--- a/packages/ckeditor5-fullscreen/src/handlers/abstracteditorhandler.ts
+++ b/packages/ckeditor5-fullscreen/src/handlers/abstracteditorhandler.ts
@@ -936,7 +936,7 @@ export class FullscreenAbstractEditorHandler {
 
 		// Adjust the visible elements when the transition (changing the size of the AI tabs) ends. Earlier we do not have the
 		// correct sizes of elements.
-		aiTabs.view.element.addEventListener( 'transitionend', ( evt: TransitionEvent ) => this._handleAISidebarTransitions( evt ) );
+		aiTabs.view.element.addEventListener( 'transitionend', this._aiTabsTransitionEndCallback );
 	}
 
 	/**
@@ -965,7 +965,7 @@ export class FullscreenAbstractEditorHandler {
 
 		this._aiTabsData = null;
 
-		aiTabs.view.element.removeEventListener( 'transitionend', this._handleAISidebarTransitions );
+		aiTabs.view.element.removeEventListener( 'transitionend', this._aiTabsTransitionEndCallback );
 	}
 
 	/**
@@ -1117,4 +1117,11 @@ export class FullscreenAbstractEditorHandler {
 			this._wrapper!.querySelector( '.ck-fullscreen__right-sidebar' )!.classList.remove( 'ck-fullscreen__right-sidebar--collapsed' );
 		}
 	}
+
+	/**
+	 * Handler for AI tabs `transitionend`; must be the same reference in `addEventListener` / `removeEventListener`.
+	 */
+	private _aiTabsTransitionEndCallback = ( evt: Event ): void => {
+		this._handleAISidebarTransitions( evt as TransitionEvent );
+	};
 }

--- a/packages/ckeditor5-fullscreen/tests/handlers/abstracteditorhandler.js
+++ b/packages/ckeditor5-fullscreen/tests/handlers/abstracteditorhandler.js
@@ -1050,6 +1050,24 @@ describe( 'AbstractHandler', () => {
 			expect( adjustVisibleElementsStub ).to.have.been.called;
 		} );
 	} );
+
+	describe( '_aiTabsTransitionEndCallback', () => {
+		afterEach( () => {
+			sinon.restore();
+		} );
+
+		it( 'should forward the transition event to _handleAISidebarTransitions', () => {
+			const handleAISidebarTransitionsStub = sinon.stub( abstractHandler, '_handleAISidebarTransitions' );
+			const evt = new TransitionEvent( 'transitionend', {
+				propertyName: 'width'
+			} );
+
+			abstractHandler._aiTabsTransitionEndCallback( evt );
+
+			expect( handleAISidebarTransitionsStub ).to.have.been.calledOnce;
+			expect( handleAISidebarTransitionsStub.firstCall.args[ 0 ] ).to.equal( evt );
+		} );
+	} );
 } );
 
 function wait( time ) {


### PR DESCRIPTION
### 🚀 Summary

Adding and removing event listeners used different function references, so the listeners were not removed properly. We need to use a wrapper function or store the `.bind(this) `reference to properly remove the listeners.

The issue can be reproduced by simply opening and closing fullscreen mode, then using maximize in AI Chat.

---

### 📌 Related issues

* Closes #20129

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [x] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
