### PR TITLE
Add multi-root AI card to the feature digest / Update guide

### DIFF
--- a/docs/features/feature-digest.md
+++ b/docs/features/feature-digest.md
@@ -1244,6 +1244,20 @@ By integrating AI writing assistance directly into the editing experience, CKEdi
 			</ck:button-link>
 		</ck:card-footer>
 	</ck:card>
+
+	<ck:card>
+		<ck:card-title level='4' heading-id='ai-multi-root'>
+			AI in multi-root and multi-editor setups <ck:badge variant='premium' /> <ck:badge variant='experiment' />
+		</ck:card-title>
+		<ck:card-description>
+			Experimental support for AI Chat, Review, and Translate across multi-root editors and across multiple editors sharing a Context. Suggestions, translations, and chat history stay scoped to the right surface.
+		</ck:card-description>
+		<ck:card-footer>
+			<ck:button-link size='sm' variant='secondary' href='{@link features/ckeditor-ai-multi}'>
+				Feature page
+			</ck:button-link>
+		</ck:card-footer>
+	</ck:card>
 </ck:columns>
 
 <ck:heading-badge heading-id='ai-assistant' badge='premium'>AI Assistant (legacy)</ck:heading-badge>

--- a/docs/features/feature-digest.md
+++ b/docs/features/feature-digest.md
@@ -1253,7 +1253,7 @@ By integrating AI writing assistance directly into the editing experience, CKEdi
 			Experimental support for AI Chat, Review, and Translate across multi-root editors and across multiple editors sharing a Context. Suggestions, translations, and chat history stay scoped to the right surface.
 		</ck:card-description>
 		<ck:card-footer>
-			<ck:button-link size='sm' variant='secondary' href='{@link features/ckeditor-ai-multi}'>
+			<ck:button-link size='sm' variant='secondary' href='{@link features/ckeditor-ai-multi-root-multi-editor-support}'>
 				Feature page
 			</ck:button-link>
 		</ck:card-footer>

--- a/docs/updating/update-to-48.md
+++ b/docs/updating/update-to-48.md
@@ -18,6 +18,25 @@ modified_at: 2026-05-13
 
 Released on 13 May, 2026. ([See full release notes](https://github.com/ckeditor/ckeditor5/releases/tag/v48.1.0))
 
+This release improves AI Chat formatting and rendering, introduces experimental AI support for multi-root and multiple editor setups, and strengthens compatibility with structured content pasted from Office and exported for email.
+
+### AI Chat: better formatting and rendering (⭐)
+
+{@link features/ckeditor-ai-chat AI Chat} now handles raw, unformatted content more reliably. Asking AI Chat to format a pasted transcript, add headings, or convert content into a list produces cleaner and more predictable results.
+
+The AI Chat feed also renders generated content differently. Proposed changes now appear in full when they are ready, while plain assistant text continues to stream at a faster pace.
+
+### Experimental: AI in multi-root and multiple editor setups (⭐)
+
+AI features now {@link features/ckeditor-ai-multi-root-multi-editor-support support multi-root editors and multiple editor instances} that share a {@link module:core/context~Context `Context`}. This helps integrations that use several editor areas on one page, such as a title, body, sidebar, or document sections split into independent roots.
+
+With this release:
+
+* AI Review and AI Translate run across all roots in a multi-root editor and across all editors that share a `Context`. Changes are applied to the related root or editor.
+* AI Chat uses content from the focused root or editor, applies suggestions to the related destination, and keeps separate conversation history for each editor in a `Context`.
+
+This feature is experimental and ready for testing in multi-root and multiple editor integrations.
+
 ### AI Chat feed items align to the bottom by default
 
 The AI Chat feed items are now aligned to the bottom of the feed by default. This keeps the most recent messages in view as the conversation grows, in line with common chat interface conventions.
@@ -29,6 +48,16 @@ If you want to revert to the previous top-aligned behavior, add the following CS
 	margin-top: 0;
 }
 ```
+
+### Other improvements and fixes
+
+This release also includes several improvements for content editing, Office content compatibility, and email output:
+
+* Marker boundary elements registered with `markerToElement()` now render in the same order as in the model when two markers meet at the same position. This affects features that rely on markers, including comments, suggestions, mentions, find and replace, and restricted editing.
+* Inline formatting such as bold, italic, font size, font family, font color, and background color is now retained after pressing <kbd>Shift</kbd>+<kbd>Enter</kbd> twice or after deleting all text inside a block and continuing to type.
+* {@link features/source-editing Source editing} now supports native undo and redo keystrokes in the source editing textarea.
+* The editor now handles {@link features/tables#table-alignment alignment attributes} on `<td>` elements that wrap nested tables or images. This improves compatibility with content from Outlook and other sources that use `td[align]` for block layout.
+* Tables now preserve their alignment and inline styles after the {@link features/email#email-specific-style-transformations email export transformation}, improving rendering in Outlook, Gmail, and other major email clients.
 
 ### Minor breaking changes in this release
 

--- a/docs/updating/update-to-48.md
+++ b/docs/updating/update-to-48.md
@@ -3,7 +3,7 @@ category: update-guides
 meta-title: Update to version 48.x | CKEditor 5 Documentation
 menu-title: Update to v48.x
 order: 76
-modified_at: 2026-03-30
+modified_at: 2026-05-13
 ---
 
 # Update to CKEditor&nbsp;5 v48.x
@@ -13,6 +13,27 @@ modified_at: 2026-03-30
 
 	You may try removing the `package-lock.json` or `yarn.lock` files (if applicable) and reinstalling all packages before rebuilding the editor. For optimal results, ensure you use the most recent package versions.
 </info-box>
+
+## Update to CKEditor&nbsp;5 v48.1.0
+
+Released on 13 May, 2026. ([See full release notes](https://github.com/ckeditor/ckeditor5/releases/tag/v48.1.0))
+
+### AI Chat feed items align to the bottom by default
+
+The AI Chat feed items are now aligned to the bottom of the feed by default. This keeps the most recent messages in view as the conversation grows, in line with common chat interface conventions.
+
+If you want to revert to the previous top-aligned behavior, add the following CSS to your integration:
+
+```css
+.ck.ck-ai-chat__feed__items {
+	margin-top: 0;
+}
+```
+
+### Minor breaking changes in this release
+
+* **[ai](https://www.npmjs.com/package/@ckeditor/ckeditor5-ai)**: The AI Chat feed items are now aligned to the bottom of the feed by default. To revert to the previous top-aligned behavior, override the relevant CSS in your integration.
+* **[ai](https://www.npmjs.com/package/@ckeditor/ckeditor5-ai)**: To reduce visual strain on the user, suggestions proposed by the agent in the AI Chat feed are now always displayed in full when ready (previously streamed word-by-word).
 
 ## Update to CKEditor&nbsp;5 v48.0.0
 


### PR DESCRIPTION
### 🚀 Summary

* Adds an `AI in multi-root and multi-editor setups` card to the AI section of `docs/features/feature-digest.md`.
* Add update to v48.1