### PR TITLE
No longer use old initialization syntax of the editor in jsdocs.

### DIFF
--- a/packages/ckeditor5-alignment/src/alignmentconfig.ts
+++ b/packages/ckeditor5-alignment/src/alignmentconfig.ts
@@ -12,7 +12,7 @@
  *
  * ```ts
  * ClassicEditor
- *   .create( editorElement, {
+ *   .create( {
  *     alignment: {
  *       options: [ 'left', 'right' ]
  *     }
@@ -38,7 +38,7 @@ export interface AlignmentConfig {
  *
  * ```ts
  * ClassicEditor
- *   .create( editorElement, {
+ *   .create( {
  *     alignment: {
  *       options: [ 'left', 'right' ]
  *     }
@@ -54,7 +54,7 @@ export interface AlignmentConfig {
  *
  * ```ts
  * ClassicEditor
- *   .create( editorElement, {
+ *   .create( {
  *     alignment: {
  *       options: [
  *         { name: 'left', className: 'my-align-left' },

--- a/packages/ckeditor5-bookmark/src/bookmarkconfig.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkconfig.ts
@@ -14,7 +14,7 @@
  *
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		bookmark: {
  * 			// Bookmark configuration.
  * 		}

--- a/packages/ckeditor5-ckbox/src/ckboxconfig.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxconfig.ts
@@ -18,7 +18,7 @@ import type { ArrayOrItem } from '@ckeditor/ckeditor5-utils';
  *
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		ckbox: {
  * 			tokenUrl: 'https://example.com/cs-token-endpoint'
  * 		}
@@ -31,7 +31,7 @@ import type { ArrayOrItem } from '@ckeditor/ckeditor5-utils';
  *
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		ckbox: {
  * 			defaultUploadCategories: {
  * 				Bitmaps: [ 'bmp' ],

--- a/packages/ckeditor5-ckfinder/src/ckfinderconfig.ts
+++ b/packages/ckeditor5-ckfinder/src/ckfinderconfig.ts
@@ -13,7 +13,7 @@
  *
  * ```
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		ckfinder: {
  * 			options: {
  * 				resourceType: 'Images'
@@ -58,7 +58,7 @@ export interface CKFinderConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( editorElement, {
+	 * 	.create( {
 	 * 		ckfinder: {
 	 * 			uploadUrl: '/ckfinder/core/connector/php/connector.php?command=QuickUpload&type=Files&responseType=json'
 	 * 		}

--- a/packages/ckeditor5-core/src/editor/editor.ts
+++ b/packages/ckeditor5-core/src/editor/editor.ts
@@ -221,7 +221,7 @@ export abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 	 *
 	 * // The default options can be overridden by the configuration passed to create().
 	 * ClassicEditor
-	 * 	.create( sourceElement, { bar: 3 } )
+	 * 	.create( { bar: 3 } )
 	 * 	.then( editor => {
 	 * 		editor.config.get( 'foo' ); // -> 1
 	 * 		editor.config.get( 'bar' ); // -> 3
@@ -255,7 +255,7 @@ export abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 	 * 	} );
 	 *
 	 * ClassicEditor
-	 * 	.create( sourceElement, {
+	 * 	.create( {
 	 * 		// Do not initialize these plugins (note: it is defined by a string):
 	 * 		removePlugins: [ 'Foo' ]
 	 * 	} )
@@ -265,7 +265,7 @@ export abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 	 * 	} );
 	 *
 	 * ClassicEditor
-	 * 	.create( sourceElement, {
+	 * 	.create( {
 	 * 		// Load only this plugin. It can also be defined by a string if
 	 * 		// this plugin was built into the editor class.
 	 * 		plugins: [ FooPlugin ]

--- a/packages/ckeditor5-core/src/editor/editorconfig.ts
+++ b/packages/ckeditor5-core/src/editor/editorconfig.ts
@@ -86,8 +86,11 @@ export interface EditorConfig extends EngineConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( document.querySelector( '#editor' ), {
-	 * 		initialData: '<h2>Initial data</h2><p>Foo bar.</p>'
+	 * 	.create( {
+	 * 		attachTo: document.querySelector( '#editor' ),
+	 * 		root: {
+	 * 			initialData: '<h2>Initial data</h2><p>Foo bar.</p>'
+	 * 		}
 	 * 	} )
 	 * 	.then( ... )
 	 * 	.catch( ... );
@@ -101,24 +104,26 @@ export interface EditorConfig extends EngineConfig {
 	 * roots names and values equal to the data that should be set in each root:
 	 *
 	 * ```ts
-	 * MultiRootEditor.create(
-	 * 	// Roots for the editor:
-	 * 	{
-	 * 		header: document.querySelector( '#header' ),
-	 * 		content: document.querySelector( '#content' ),
-	 * 		leftSide: document.querySelector( '#left-side' ),
-	 * 		rightSide: document.querySelector( '#right-side' )
-	 * 	},
-	 * 	// Config:
-	 * 	{
-	 * 		initialData: {
-	 * 			header: '<p>Content for header part.</p>',
-	 * 			content: '<p>Content for main part.</p>',
-	 * 			leftSide: '<p>Content for left-side box.</p>',
-	 * 			rightSide: '<p>Content for right-side box.</p>'
+	 * MultiRootEditor.create( {
+	 * 	roots: {
+	 * 		header: {
+	 * 			element: document.querySelector( '#header' ),
+	 * 			initialData: '<p>Content for header part.</p>'
+	 * 		},
+	 * 		content: {
+	 * 			element: document.querySelector( '#content' ),
+	 * 			initialData: '<p>Content for main part.</p>'
+	 * 		},
+	 * 		leftSide: {
+	 * 			element: document.querySelector( '#left-side' ),
+	 * 			initialData: '<p>Content for left-side box.</p>'
+	 * 		},
+	 * 		rightSide: {
+	 * 			element: document.querySelector( '#right-side' ),
+	 * 			initialData: '<p>Content for right-side box.</p>'
 	 * 		}
 	 * 	}
-	 * )
+	 * } )
 	 * .then( ... )
 	 * .catch( ... );
 	 * ```
@@ -531,8 +536,11 @@ export interface EditorConfig extends EngineConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( document.querySelector( '#editor' ), {
-	 * 		placeholder: 'Type some text...'
+	 * 	.create( {
+	 * 		attachTo: document.querySelector( '#editor' ),
+	 * 		root: {
+	 * 			placeholder: 'Type some text...'
+	 * 		}
 	 * 	} )
 	 * 	.then( ... )
 	 * 	.catch( ... );
@@ -542,24 +550,26 @@ export interface EditorConfig extends EngineConfig {
 	 * roots names and values equal to the placeholder that should be set in each root:
 	 *
 	 * ```ts
-	 * MultiRootEditor.create(
-	 * 	// Roots for the editor:
-	 * 	{
-	 * 		header: document.querySelector( '#header' ),
-	 * 		content: document.querySelector( '#content' ),
-	 * 		leftSide: document.querySelector( '#left-side' ),
-	 * 		rightSide: document.querySelector( '#right-side' )
-	 * 	},
-	 * 	// Config:
-	 * 	{
-	 * 		placeholder: {
-	 * 			header: 'Type header...',
-	 * 			content: 'Type content...',
-	 * 			leftSide: 'Type left-side...',
-	 * 			rightSide: 'Type right-side...'
+	 * MultiRootEditor.create( {
+	 * 	roots: {
+	 * 		header: {
+	 * 			element: document.querySelector( '#header' ),
+	 * 			placeholder: 'Type header...'
+	 * 		},
+	 * 		content: {
+	 * 			element: document.querySelector( '#content' ),
+	 * 			placeholder: 'Type content...'
+	 * 		},
+	 * 		leftSide: {
+	 * 			element: document.querySelector( '#left-side' ),
+	 * 			placeholder: 'Type left-side...'
+	 * 		},
+	 * 		rightSide: {
+	 * 			element: document.querySelector( '#right-side' ),
+	 * 			placeholder: 'Type right-side...'
 	 * 		}
 	 * 	}
-	 * )
+	 * } )
 	 * .then( ... )
 	 * .catch( ... );
 	 * ```
@@ -885,8 +895,11 @@ export interface EditorConfig extends EngineConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( document.querySelector( '#editor' ), {
-	 * 		label: 'Article main content'
+	 * 	.create( {
+	 * 		attachTo: document.querySelector( '#editor' ),
+	 * 		root: {
+	 * 			label: 'Article main content'
+	 * 		}
 	 * 	} )
 	 * 	.then( ... )
 	 * 	.catch( ... );
@@ -896,24 +909,26 @@ export interface EditorConfig extends EngineConfig {
 	 * roots names and values equal to the label that should be used for each root:
 	 *
 	 * ```ts
-	 * MultiRootEditor.create(
-	 * 	// Roots for the editor:
-	 * 	{
-	 * 		header: document.querySelector( '#header' ),
-	 * 		content: document.querySelector( '#content' ),
-	 * 		sideQuote: document.querySelector( '#side-quote' ),
-	 * 		relatedLinks: document.querySelector( '#related-links' )
-	 * 	},
-	 * 	// Config:
-	 * 	{
-	 * 		label: {
-	 * 			header: 'Article header',
-	 * 			content: 'Article main content',
-	 * 			sideQuote: 'Side-quote',
-	 * 			relatedLinks: 'Related links'
+	 * MultiRootEditor.create( {
+	 * 	roots: {
+	 * 		header: {
+	 * 			element: document.querySelector( '#header' ),
+	 * 			label: 'Article header'
+	 * 		},
+	 * 		content: {
+	 * 			element: document.querySelector( '#content' ),
+	 * 			label: 'Article main content'
+	 * 		},
+	 * 		sideQuote: {
+	 * 			element: document.querySelector( '#side-quote' ),
+	 * 			label: 'Side-quote'
+	 * 		},
+	 * 		relatedLinks: {
+	 * 			element: document.querySelector( '#related-links' ),
+	 * 			label: 'Related links'
 	 * 		}
 	 * 	}
-	 * )
+	 * } )
 	 * .then( ... )
 	 * .catch( ... );
 	 * ```

--- a/packages/ckeditor5-emoji/src/emojiconfig.ts
+++ b/packages/ckeditor5-emoji/src/emojiconfig.ts
@@ -14,7 +14,7 @@
  *
  * ```ts
  *	ClassicEditor
- *		.create( editorElement, {
+ *		.create( {
  *			emoji: ... // Emoji feature options.
  *		} )
  *		.then( ... )
@@ -30,7 +30,7 @@ export interface EmojiConfig {
 	 *
 	 * ```ts
 	 *	ClassicEditor
-	 *		.create( editorElement, {
+	 *		.create( {
 	 *			plugins: [ Emoji, ... ],
 	 *			emoji: {
 	 *				dropdownLimit: 4
@@ -49,7 +49,7 @@ export interface EmojiConfig {
 	 *
 	 * ```ts
 	 *	ClassicEditor
-	 *		.create( editorElement, {
+	 *		.create( {
 	 *			plugins: [ Emoji, ... ],
 	 *			emoji: {
 	 *				skinTone: 'medium'
@@ -68,7 +68,7 @@ export interface EmojiConfig {
 	 *
 	 * ```ts
 	 *	ClassicEditor
-	 *		.create( editorElement, {
+	 *		.create( {
 	 *			plugins: [ Emoji, ... ],
 	 *			emoji: {
 	 *				definitionsUrl: ''
@@ -85,7 +85,7 @@ export interface EmojiConfig {
 	 *
 	 * ```ts
 	 *	ClassicEditor
-	 *		.create( editorElement, {
+	 *		.create( {
 	 *			plugins: [ Emoji, ... ],
 	 *			emoji: {
 	 *				version: 15

--- a/packages/ckeditor5-fullscreen/src/fullscreenconfig.ts
+++ b/packages/ckeditor5-fullscreen/src/fullscreenconfig.ts
@@ -14,7 +14,7 @@
  *
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		fullscreen: {
  * 			// Fullscreen mode configuration.
  * 		}

--- a/packages/ckeditor5-highlight/src/highlightconfig.ts
+++ b/packages/ckeditor5-highlight/src/highlightconfig.ts
@@ -57,7 +57,7 @@ export interface HighlightOption {
  * The configuration of the {@link module:highlight/highlight~Highlight highlight feature}.
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		highlight:  ... // Highlight feature configuration.
  * 	} )
  * 	.then( ... )
@@ -152,7 +152,7 @@ export interface HighlightConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( editorElement, {
+	 * 	.create( {
 	 * 		highlight: {
 	 * 			options: [
 	 * 				{

--- a/packages/ckeditor5-html-embed/src/htmlembedconfig.ts
+++ b/packages/ckeditor5-html-embed/src/htmlembedconfig.ts
@@ -12,7 +12,7 @@
  *
  * ```ts
  * ClassicEditor
- *   .create( editorElement, {
+ *   .create( {
  *     htmlEmbed: ... // HTML embed feature options.
  *   } )
  * 	 .then( ... )
@@ -50,7 +50,7 @@ export interface HtmlEmbedConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 *   .create( editorElement, {
+	 *   .create( {
 	 *     htmlEmbed: {
 	 *       showPreviews: true,
 	 *       sanitizeHtml( inputHtml ) {

--- a/packages/ckeditor5-html-support/src/generalhtmlsupportconfig.ts
+++ b/packages/ckeditor5-html-support/src/generalhtmlsupportconfig.ts
@@ -185,7 +185,7 @@ export interface GHSFullPageConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( editorElement, {
+	 * 	.create( {
 	 * 		htmlSupport: {
 	 * 			fullPage: {
 	 * 				allowRenderStylesFromHead: true,

--- a/packages/ckeditor5-indent/src/indentconfig.ts
+++ b/packages/ckeditor5-indent/src/indentconfig.ts
@@ -16,7 +16,7 @@
  *
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		indentBlock: {
  * 			offset: 2,
  * 			unit: 'em'
@@ -31,7 +31,7 @@
  *
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		indentBlock: {
  * 			classes: [
  * 				'indent-a', // The first step - smallest indentation.

--- a/packages/ckeditor5-link/src/linkconfig.ts
+++ b/packages/ckeditor5-link/src/linkconfig.ts
@@ -14,7 +14,7 @@ import type { ArrayOrItem } from '@ckeditor/ckeditor5-utils';
  *
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		link:  ... // Link feature configuration.
  * 	} )
  * 	.then( ... )
@@ -35,7 +35,7 @@ export interface LinkConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( editorElement, {
+	 * 	.create( {
 	 * 		link: {
 	 * 			defaultProtocol: 'http://'
 	 * 		}
@@ -57,7 +57,7 @@ export interface LinkConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( editorElement, {
+	 * 	.create( {
 	 * 		link: {
 	 * 			allowedProtocols: [ 'http', 'https', 'ftp', 'tel', 'mailto', 'ssh' ]
 	 * 		}
@@ -74,7 +74,7 @@ export interface LinkConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( editorElement, {
+	 * 	.create( {
 	 * 		link: {
 	 * 			allowCreatingEmptyLinks: true
 	 * 		}
@@ -95,7 +95,7 @@ export interface LinkConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( editorElement, {
+	 * 	.create( {
 	 * 		link: {
 	 * 			addTargetToExternalLinks: true
 	 * 		}
@@ -143,7 +143,7 @@ export interface LinkConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( editorElement, {
+	 * 	.create( {
 	 * 		link: {
 	 * 			decorators: {
 	 * 				isExternal: {

--- a/packages/ckeditor5-list/src/listconfig.ts
+++ b/packages/ckeditor5-list/src/listconfig.ts
@@ -15,7 +15,7 @@ import { type ArrayOrItem } from '@ckeditor/ckeditor5-utils';
  *
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		list:  ... // The list feature configuration.
  * 	} )
  * 	.then( ... )
@@ -77,7 +77,7 @@ export interface ListConfig {
  *
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		list: {
  * 			properties: {
  * 				styles: true,

--- a/packages/ckeditor5-media-embed/src/mediaembedconfig.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedconfig.ts
@@ -17,7 +17,7 @@ import type { ArrayOrItem } from '@ckeditor/ckeditor5-utils';
  *
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 			mediaEmbed: ... // Media embed feature options.
  * 	} )
  * 	.then( ... )
@@ -65,7 +65,7 @@ export interface MediaEmbedConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( editorElement, {
+	 * 	.create( {
 	 * 		plugins: [ MediaEmbed, ... ],
 	 * 		mediaEmbed: {
 	 * 			providers: [
@@ -99,7 +99,7 @@ export interface MediaEmbedConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( editorElement, {
+	 * 	.create( {
 	 * 		plugins: [ MediaEmbed, ... ],
 	 * 		mediaEmbed: {
 	 * 			extraProviders: [

--- a/packages/ckeditor5-mention/src/mentionconfig.ts
+++ b/packages/ckeditor5-mention/src/mentionconfig.ts
@@ -14,7 +14,7 @@
  *
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		mention: ... // Mention feature options.
  * 	} )
  * 	.then( ... )
@@ -30,7 +30,7 @@ export interface MentionConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( editorElement, {
+	 * 	.create( {
 	 * 		plugins: [ Mention, ... ],
 	 * 		mention: {
 	 * 			feeds: [
@@ -56,7 +56,7 @@ export interface MentionConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( editorElement, {
+	 * 	.create( {
 	 * 		plugins: [ Mention, ... ],
 	 * 		mention: {
 	 * 			// [ Enter, Space ]
@@ -88,7 +88,7 @@ export interface MentionConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( editorElement, {
+	 * 	.create( {
 	 * 		plugins: [ Mention, ... ],
 	 * 		mention: {
 	 * 			dropdownLimit: 20,
@@ -102,7 +102,7 @@ export interface MentionConfig {
 	 * 	.catch( ... );
 	 *
 	 * ClassicEditor
-	 * 	.create( editorElement, {
+	 * 	.create( {
 	 * 		plugins: [ Mention, ... ],
 	 * 		mention: {
 	 * 			dropdownLimit: Infinity,
@@ -222,7 +222,7 @@ export type MentionItemRenderer = ( item: MentionFeedObjectItem ) => HTMLElement
  *
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		plugins: [ Mention, ... ],
  * 		mention: {
  * 			feeds: [

--- a/packages/ckeditor5-minimap/src/minimapconfig.ts
+++ b/packages/ckeditor5-minimap/src/minimapconfig.ts
@@ -78,7 +78,7 @@ export interface MinimapConfig {
 	 * ```ts
 	 * ClassicEditor
 	 * 	.create( {
-	 * 		attachTo: document.getElementById( 'editor' )!,
+	 * 		attachTo: document.getElementById( 'editor' ),
 	 * 		minimap: {
 	 * 			extraClasses: 'website styled-container'
 	 * 		}

--- a/packages/ckeditor5-minimap/src/minimapconfig.ts
+++ b/packages/ckeditor5-minimap/src/minimapconfig.ts
@@ -77,7 +77,8 @@ export interface MinimapConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( document.getElementById( 'editor' ), {
+	 * 	.create( {
+	 * 		attachTo: document.getElementById( 'editor' )!,
 	 * 		minimap: {
 	 * 			extraClasses: 'website styled-container'
 	 * 		}

--- a/packages/ckeditor5-special-characters/src/specialcharactersconfig.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharactersconfig.ts
@@ -14,7 +14,7 @@
  *
  * ```ts
  * ClassicEditor
- *   .create( editorElement, {
+ *   .create( {
  *     specialCharacters: ... // Special characters feature options.
  *   } )
  *   .then( ... )
@@ -34,7 +34,7 @@ export interface SpecialCharactersConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 *   .create( editorElement, {
+	 *   .create( {
 	 *     plugins: [ SpecialCharacters, SpecialCharactersEssentials, ... ],
 	 *     specialCharacters: {
 	 *       order: [

--- a/packages/ckeditor5-table/src/tableconfig.ts
+++ b/packages/ckeditor5-table/src/tableconfig.ts
@@ -15,7 +15,7 @@ import type { ColorOption, ColorPickerConfig } from '@ckeditor/ckeditor5-ui';
  *
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		table: ... // Table feature options.
  * 	} )
  * 	.then( ... )

--- a/packages/ckeditor5-typing/src/typingconfig.ts
+++ b/packages/ckeditor5-typing/src/typingconfig.ts
@@ -12,7 +12,7 @@
  *
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		typing: ... // Typing feature options.
  * 	} )
  * 	.then( ... )
@@ -44,7 +44,7 @@ export interface TypingConfig {
  *
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		typing: {
  * 			transformations: ... // Text transformation feature options.
  * 		}

--- a/packages/ckeditor5-ui/docs/_snippets/examples/bootstrap-ui.js
+++ b/packages/ckeditor5-ui/docs/_snippets/examples/bootstrap-ui.js
@@ -10,6 +10,7 @@ import {
 	ItalicEditing,
 	UnderlineEditing,
 	Clipboard,
+	CKEditorError,
 	Editor,
 	ElementApiMixin,
 	attachToForm,
@@ -28,11 +29,18 @@ import {
 
 // Extending the Editor class, which brings base editor API.
 export default class BootstrapEditor extends ElementApiMixin( Editor ) {
-	constructor( element, config ) {
+	constructor( config ) {
 		super( config );
 
+		const sourceElement = config.root?.element;
+
+		if ( !sourceElement ) {
+			// This example expects the editable host in `config.root.element` (see EditorConfig).
+			throw new CKEditorError( 'bootstrap-editor-missing-root-element', null );
+		}
+
 		// Remember the element the editor is created with.
-		this.sourceElement = element;
+		this.sourceElement = sourceElement;
 
 		// Create the ("main") root element of the model tree.
 		this.model.document.createRoot();
@@ -55,16 +63,18 @@ export default class BootstrapEditor extends ElementApiMixin( Editor ) {
 		return super.destroy();
 	}
 
-	static create( element, config ) {
+	static create( config ) {
 		return new Promise( resolve => {
-			const editor = new this( element, config );
+			const editor = new this( config );
+
+			const replacementElement = editor.sourceElement;
 
 			resolve(
 				editor.initPlugins()
 					// Initialize the UI first. See the BootstrapEditorUI class to learn more.
-					.then( () => editor.ui.init( element ) )
+					.then( () => editor.ui.init( replacementElement ) )
 					// Fill the editable with the initial data.
-					.then( () => editor.data.init( getDataFromElement( element ) ) )
+					.then( () => editor.data.init( getDataFromElement( replacementElement ) ) )
 					// Fire the `editor#ready` event that announce the editor is complete and ready to use.
 					.then( () => editor.fire( 'ready' ) )
 					.then( () => editor )
@@ -274,7 +284,10 @@ class BootstrapEditorUI extends EditorUI {
 
 // Finally, create the BootstrapEditor instance with a selected set of features.
 BootstrapEditor
-	.create( $( '#editor' ).get( 0 ), {
+	.create( {
+		root: {
+			element: $( '#editor' ).get( 0 )
+		},
 		plugins: [
 			Clipboard, Enter, Typing, Paragraph, Image,
 			BoldEditing, ItalicEditing, UnderlineEditing, HeadingEditing, UndoEditing

--- a/packages/ckeditor5-ui/docs/framework/external-ui.md
+++ b/packages/ckeditor5-ui/docs/framework/external-ui.md
@@ -50,7 +50,8 @@ import {
 	BoldEditing,
 	ItalicEditing,
 	UnderlineEditing,
-	HeadingEditing
+	HeadingEditing,
+	CKEditorError
 } from 'ckeditor5';
 ```
 </code-switcher>
@@ -66,11 +67,18 @@ After importing the basic editor components, you can define the custom `Bootstra
 ```js
 // Extending the Editor class, which brings the base editor API.
 export default class BootstrapEditor extends ElementApiMixin( Editor ) {
-	constructor( element, config ) {
+	constructor( config ) {
 		super( config );
 
+		const sourceElement = config.root?.element;
+
+		if ( !sourceElement ) {
+			// This example expects the editable host in `config.root.element` (see EditorConfig).
+			throw new CKEditorError( 'bootstrap-editor-missing-root-element', null );
+		}
+
 		// Remember the element the editor is created with.
-		this.sourceElement = element;
+		this.sourceElement = sourceElement;
 
 		// Create the ("main") root element of the model tree.
 		this.model.document.createRoot();
@@ -93,16 +101,18 @@ export default class BootstrapEditor extends ElementApiMixin( Editor ) {
 		return super.destroy();
 	}
 
-	static create( element, config ) {
+	static create( config ) {
 		return new Promise( resolve => {
-			const editor = new this( element, config );
+			const editor = new this( config );
+
+			const replacementElement = editor.sourceElement;
 
 			resolve(
 				editor.initPlugins()
 					// Initialize the UI first. See the BootstrapEditorUI class to learn more.
-					.then( () => editor.ui.init( element ) )
+					.then( () => editor.ui.init( replacementElement ) )
 					// Fill the editable with the initial data.
-					.then( () => editor.data.init( getDataFromElement( element ) ) )
+					.then( () => editor.data.init( getDataFromElement( replacementElement ) ) )
 					// Fire the `editor#ready` event that announce the editor is complete and ready to use.
 					.then( () => editor.fire( 'ready' ) )
 					.then( () => editor )
@@ -484,10 +494,13 @@ _setupBootstrapHeadingDropdown() {
 
 ## Running the editor
 
-When the editor classes and the user interface are ready, it is time to run the editor. Just make sure all the plugins are loaded and the right DOM element is passed to `BootstrapEditor#create`:
+When the editor classes and the user interface are ready, it is time to run the editor. Just make sure all the plugins are loaded and the source element is set in {@link module:core/editor/editorconfig~EditorConfig#root `config.root.element`}:
 
 ```js
-BootstrapEditor.create( $( '#editor' ).get( 0 ), {
+BootstrapEditor.create( {
+	root: {
+		element: $( '#editor' ).get( 0 )
+	},
 	plugins: [
 		Clipboard, Enter, Typing, Paragraph,
 		BoldEditing, ItalicEditing, UnderlineEditing, HeadingEditing, UndoEditing

--- a/packages/ckeditor5-upload/src/uploadconfig.ts
+++ b/packages/ckeditor5-upload/src/uploadconfig.ts
@@ -12,7 +12,7 @@
  *
  * ```ts
  * ClassicEditor
- * 	.create( editorElement, {
+ * 	.create( {
  * 		simpleUpload: {
  * 			// The URL the images are uploaded to.
  * 			uploadUrl: 'http://example.com',
@@ -52,7 +52,7 @@ export interface SimpleUploadConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( editorElement, {
+	 * 	.create( {
 	 * 		simpleUpload: {
 	 * 			// Set headers statically:
 	 * 			headers: {
@@ -85,7 +85,7 @@ export interface SimpleUploadConfig {
 	 *
 	 * ```ts
 	 * ClassicEditor
-	 * 	.create( editorElement, {
+	 * 	.create( {
 	 * 		simpleUpload: {
 	 * 			withCredentials: true
 	 * 		}

--- a/packages/ckeditor5-watchdog/src/actionsrecorder.ts
+++ b/packages/ckeditor5-watchdog/src/actionsrecorder.ts
@@ -45,7 +45,7 @@ import { isPlainObject } from 'es-toolkit/compat';
  *
  * ```ts
  * 	ClassicEditor
- * 		.create( editorElement, {
+ * 		.create( {
  * 			plugins: [ ActionsRecorder, ... ],
  * 			actionsRecorder: {
  * 				maxEntries: 1000, // This is the default value and could be adjusted.
@@ -68,7 +68,7 @@ import { isPlainObject } from 'es-toolkit/compat';
  *
  * ```ts
  * 	ClassicEditor
- * 		.create( editorElement, {
+ * 		.create( {
  * 			plugins: [ ActionsRecorder, ... ],
  * 			actionsRecorder: {
  * 				maxEntries: 50, // This is the batch size.

--- a/packages/ckeditor5-watchdog/src/actionsrecorderconfig.ts
+++ b/packages/ckeditor5-watchdog/src/actionsrecorderconfig.ts
@@ -14,7 +14,7 @@ import type { ActionsRecorder } from './actionsrecorder.js';
  *
  * ```ts
  *	ClassicEditor
- *		.create( editorElement, {
+ *		.create( {
  *			actionsRecorder: ... // ActionsRecorder feature options.
  *		} )
  *		.then( ... )
@@ -33,7 +33,7 @@ export interface ActionsRecorderConfig {
 	 *
 	 * ```ts
 	 *	ClassicEditor
-	 *		.create( editorElement, {
+	 *		.create( {
 	 *			plugins: [ ActionsRecorder, ... ],
 	 *			actionsRecorder: {
 	 *				maxEntries: 1000
@@ -56,7 +56,7 @@ export interface ActionsRecorderConfig {
 	 *
 	 * ```ts
 	 *	ClassicEditor
-	 *		.create( editorElement, {
+	 *		.create( {
 	 *			plugins: [ ActionsRecorder, ... ],
 	 *			actionsRecorder: {
 	 *				onFilter( entry, prevEntries ) {
@@ -76,7 +76,7 @@ export interface ActionsRecorderConfig {
 	 *
 	 * ```ts
 	 *	ClassicEditor
-	 *		.create( editorElement, {
+	 *		.create( {
 	 *			plugins: [ ActionsRecorder, ... ],
 	 *			actionsRecorder: {
 	 *				onError( error, entries ) {
@@ -98,7 +98,7 @@ export interface ActionsRecorderConfig {
 	 *
 	 * ```ts
 	 * 	ClassicEditor
-	 * 		.create( editorElement, {
+	 * 		.create( {
 	 * 			plugins: [ ActionsRecorder, ... ],
 	 * 			actionsRecorder: {
 	 * 				onMaxEntries() {


### PR DESCRIPTION
### 🚀 Summary

No longer use old initialization syntax of the editor in jsdocs.

---

### 📌 Related issues

* Closes #20125

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [x] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [x] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
