### PR TITLE
Fix missing `This link has no URL` label on links with an empty href.

### DIFF
--- a/.changelog/20260514133321_ck_20136.md
+++ b/.changelog/20260514133321_ck_20136.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-link
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/20136
+---
+
+The link preview button for links with an empty href now correctly displays a no url label.

--- a/.changelog/20260514134321_ck_20136.md
+++ b/.changelog/20260514134321_ck_20136.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-link
+see:
+  - https://github.com/ckeditor/ckeditor5/issues/20136
+---
+
+The link edit form back button was hidden when editing a link with an empty URL via the balloon toolbar.

--- a/.changelog/20260514140028_ck_20136.md
+++ b/.changelog/20260514140028_ck_20136.md
@@ -6,4 +6,4 @@ see:
   - https://github.com/ckeditor/ckeditor5/issues/20136
 ---
 
-Text centering in the link preview button.
+Fix text centering in the link preview button.

--- a/.changelog/20260514140028_ck_20136.md
+++ b/.changelog/20260514140028_ck_20136.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-link
+see:
+  - https://github.com/ckeditor/ckeditor5/issues/20136
+---
+
+Text centering in the link preview button.

--- a/packages/ckeditor5-link/lang/contexts.json
+++ b/packages/ckeditor5-link/lang/contexts.json
@@ -12,5 +12,6 @@
 	"Create link": "Keystroke description for assistive technologies: keystroke for creating a link.",
 	"Move out of a link": "Keystroke description for assistive technologies: keystroke for moving out of a link.",
 	"Displayed text": "The label of the input field for the displayed text of the link.",
-	"No links available": "Placeholder shown when placeholder items view is empty."
+	"No links available": "Placeholder shown when placeholder items view is empty.",
+	"This link has no URL": "The label of the switch button shown when link has empty href attribute."
 }

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -537,7 +537,7 @@ export class LinkUI extends Plugin {
 
 			const setHref = ( href: string | undefined ) => {
 				if ( !href ) {
-					button.label = undefined;
+					button.label = href === '' ? t( 'This link has no URL' ) : undefined;
 					button.icon = undefined;
 					button.tooltip = t( 'Open link in new tab' );
 					return;
@@ -812,7 +812,7 @@ export class LinkUI extends Plugin {
 
 		this.formView!.disableCssTransitions();
 		this.formView!.resetFormStatus();
-		this.formView!.backButtonView.isVisible = linkCommand.isEnabled && !!linkCommand.value;
+		this.formView!.backButtonView.isVisible = linkCommand.isEnabled && linkCommand.value !== undefined;
 
 		this._balloon.add( {
 			view: this.formView!,

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -536,8 +536,15 @@ export class LinkUI extends Plugin {
 			} );
 
 			const setHref = ( href: string | undefined ) => {
+				if ( href === '' ) {
+					button.label = t( 'This link has no URL' );
+					button.icon = undefined;
+					button.tooltip = false;
+					return;
+				}
+
 				if ( !href ) {
-					button.label = href === '' ? t( 'This link has no URL' ) : undefined;
+					button.label = undefined;
 					button.icon = undefined;
 					button.tooltip = t( 'Open link in new tab' );
 					return;

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -235,15 +235,27 @@ describe( 'LinkUI', () => {
 				expect( button.icon ).to.equal( undefined );
 			} );
 
-			it( 'should reset button labels when command is empty', () => {
+			it( 'should reset button labels when command is blank', () => {
+				const linkCommand = editor.commands.get( 'link' );
+
+				linkCommand.value = 'foo';
+				expect( button.icon ).to.equal( undefined );
+
+				linkCommand.value = undefined;
+				expect( button.icon ).to.equal( undefined );
+				expect( button.label ).to.be.undefined;
+				expect( button.tooltip ).to.equal( 'Open link in new tab' );
+			} );
+
+			it( 'should set no URL label when command returns empty link', () => {
 				const linkCommand = editor.commands.get( 'link' );
 
 				linkCommand.value = 'foo';
 				expect( button.icon ).to.equal( undefined );
 
 				linkCommand.value = '';
-				expect( button.icon ).to.equal( undefined );
-				expect( button.label ).to.be.undefined;
+				expect( button.icon ).to.be.undefined;
+				expect( button.label ).to.equal( 'This link has no URL' );
 				expect( button.tooltip ).to.equal( 'Open link in new tab' );
 			} );
 		} );
@@ -328,6 +340,18 @@ describe( 'LinkUI', () => {
 				// Simulate link selection.
 				linkCommand.isEnabled = true;
 				linkCommand.value = 'http://ckeditor.com';
+
+				button.fire( 'execute' );
+
+				expect( linkUIFeature.formView.backButtonView.isVisible ).to.be.true;
+			} );
+
+			it( 'should open link form view with back button (empty link)', () => {
+				const linkCommand = editor.commands.get( 'link' );
+
+				// Simulate link selection.
+				linkCommand.isEnabled = true;
+				linkCommand.value = '';
 
 				button.fire( 'execute' );
 

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -256,7 +256,7 @@ describe( 'LinkUI', () => {
 				linkCommand.value = '';
 				expect( button.icon ).to.be.undefined;
 				expect( button.label ).to.equal( 'This link has no URL' );
-				expect( button.tooltip ).to.equal( 'Open link in new tab' );
+				expect( button.tooltip ).to.be.false;
 			} );
 		} );
 

--- a/packages/ckeditor5-link/tests/manual/linkdecorator.html
+++ b/packages/ckeditor5-link/tests/manual/linkdecorator.html
@@ -1,5 +1,6 @@
 <h2>Manual decorators</h2>
 <div id="editor">
+	<a href="">Link with empty anchor</a>
 	<p>This is <a href="http://ckeditor.com" target="_blank" rel="noopener noreferrer">CKEditor5</a> from <a href="http://cksource.com" download="download" target="_blank" rel="noopener noreferrer" >CKSource</a>.</p>
 	<p>This is <a href="//ckeditor.com" class="gallery">CKEditor5</a> as schemaless url.</p>
 	<p>This is <a href="#anchor">anchor</a> on this page.</p>

--- a/packages/ckeditor5-link/theme/linktoolbar.css
+++ b/packages/ckeditor5-link/theme/linktoolbar.css
@@ -15,10 +15,13 @@
 }
 
 a.ck.ck-button.ck-link-toolbar__preview {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: center;
 	padding: 0 var(--ck-spacing-medium);
 	color: var(--ck-color-link-default);
 	cursor: pointer;
-	justify-content: center;
 
 	& .ck.ck-button__label {
 		text-overflow: ellipsis;


### PR DESCRIPTION
### 🚀 Summary

Fix missing `This link has no URL` label on links with an empty href.

---

### 📌 Related issues

* Closes #20136 

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [x] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
