### PR TITLE
Update Umberto from 10.5.0 to 10.5.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "svgo": "^3.3.2",
     "table": "^6.8.1",
     "typescript": "5.5.4",
-    "umberto": "^10.5.0",
+    "umberto": "^10.5.1",
     "upath": "^2.0.0",
     "vitest": "^4.0.18",
     "wait-on": "^9.0.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,8 +191,8 @@ importers:
         specifier: 5.5.4
         version: 5.5.4
       umberto:
-        specifier: ^10.5.0
-        version: 10.5.0(@swc/core@1.13.5)(chokidar@3.6.0)(esbuild@0.25.10)
+        specifier: ^10.5.1
+        version: 10.5.1(@swc/core@1.13.5)(chokidar@3.6.0)(esbuild@0.25.10)
       upath:
         specifier: ^2.0.0
         version: 2.0.1
@@ -11392,8 +11392,8 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
-  umberto@10.5.0:
-    resolution: {integrity: sha512-kmsviEc2v6KslrAtlcKuY5jFuZiPUuJ22jLMUi5aX2FGAGH4bRFB9rA4DoqHmYZ8WmDfJxOQ3agdhzVYfuLRig==}
+  umberto@10.5.1:
+    resolution: {integrity: sha512-JdGSnB3a8i3ds0Vm2esahqiyrmgmnDB8HiOv4XcF+TXjY4I4KhikbzGcUzlwCwk6uuQ9j6g+Kh5HUZdj2QbQdw==}
     engines: {node: '>=24.11.0'}
 
   undici-types@7.18.2:
@@ -20652,7 +20652,7 @@ snapshots:
 
   ufo@1.6.1: {}
 
-  umberto@10.5.0(@swc/core@1.13.5)(chokidar@3.6.0)(esbuild@0.25.10):
+  umberto@10.5.1(@swc/core@1.13.5)(chokidar@3.6.0)(esbuild@0.25.10):
     dependencies:
       '@babel/core': 7.28.4
       '@babel/preset-env': 7.28.3(@babel/core@7.28.4)


### PR DESCRIPTION
### 🚀 Summary

Update Umberto from 10.5.0 to 10.5.1 to fix the “Call for Feedback” box appearing in the docs table of contents.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-commercial/issues/9989

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [x] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
