### PR TITLE
Fix duplicated wrap text and break text translation contexts

### DIFF
--- a/packages/ckeditor5-core/lang/contexts.json
+++ b/packages/ckeditor5-core/lang/contexts.json
@@ -1,6 +1,8 @@
 {
 	"Cancel": "Label for the Cancel button.",
 	"Clear": "Label for the Clear button.",
+	"Wrap text": "The label for the object (e.g. image, media) style button that wraps text around the object.",
+	"Break text": "The label for the object (e.g. image, media) style button that breaks the text around the object.",
 	"Remove color": "The label used by a button next to the color palette in the color picker that removes the color (resets it to an empty value, example usages in font color or table properties).",
 	"Restore default": "The label used by a button next to the color palette in the color picker that restores the default value if the default table properties are specified.",
 	"Save": "Label for the Save button.",

--- a/packages/ckeditor5-image/lang/contexts.json
+++ b/packages/ckeditor5-image/lang/contexts.json
@@ -1,7 +1,5 @@
 {
 	"image widget": "The label for the image widget.",
-	"Wrap text": "The label for the image style button that wraps text around the image.",
-	"Break text": "The label for the image style button that breaks the text around the image.",
 	"In line": "The label for the image style button that places the image inside the line of text.",
 	"Side image": "The label for the Side image option.",
 	"Full size image": "The label for the Full size image option.",

--- a/packages/ckeditor5-media-embed/lang/contexts.json
+++ b/packages/ckeditor5-media-embed/lang/contexts.json
@@ -12,7 +12,5 @@
 	"Open media in new tab": "A tooltip displayed when the user hovers a non-previewable media URL in the editor content.",
 	"Left aligned media": "The label for the left aligned media option.",
 	"Centered media": "The label for the centered media option.",
-	"Right aligned media": "The label for the right aligned media option.",
-	"Wrap text": "The label for the media embed style button that wraps text around the media.",
-	"Break text": "The label for the media embed style button that breaks the text around the media."
+	"Right aligned media": "The label for the right aligned media option."
 }


### PR DESCRIPTION
### 🚀 Summary

Move shared "Wrap text" and "Break text" translation contexts to core.

The new media embed alignment feature reuses the "Wrap text" and "Break text" source strings already declared by ckeditor5-image, which made `translations:validate` fail with a "Duplicated context" error. Since the validator only accepts a context from the message's own package or from ckeditor5-core, the keys are moved to the core package. 

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [ ] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
