### PR TITLE
Move "Wrap text" and "Break text" translations to core

### DIFF
--- a/packages/ckeditor5-core/lang/contexts.json
+++ b/packages/ckeditor5-core/lang/contexts.json
@@ -1,8 +1,6 @@
 {
 	"Cancel": "Label for the Cancel button.",
 	"Clear": "Label for the Clear button.",
-	"Wrap text": "The label for the object (e.g. image, media) style button that wraps text around the object.",
-	"Break text": "The label for the object (e.g. image, media) style button that breaks the text around the object.",
 	"Remove color": "The label used by a button next to the color palette in the color picker that removes the color (resets it to an empty value, example usages in font color or table properties).",
 	"Restore default": "The label used by a button next to the color palette in the color picker that restores the default value if the default table properties are specified.",
 	"Save": "Label for the Save button.",
@@ -36,5 +34,7 @@
 	"Insert": "Label for the Insert button.",
 	"Update": "Label for the Update button.",
 	"Back": "Label for the Back button.",
-	"Please try a different phrase or check the spelling.": "The secondary text of the message shown to the user when no results are available for the search criteria."
+	"Please try a different phrase or check the spelling.": "The secondary text of the message shown to the user when no results are available for the search criteria.",
+	"Wrap text": "The label for the object (e.g. image, media) style button that wraps text around the object.",
+	"Break text": "The label for the object (e.g. image, media) style button that breaks the text around the object."
 }

--- a/packages/ckeditor5-core/lang/translations/af.po
+++ b/packages/ckeditor5-core/lang/translations/af.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/af.po
+++ b/packages/ckeditor5-core/lang/translations/af.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/ar.po
+++ b/packages/ckeditor5-core/lang/translations/ar.po
@@ -154,3 +154,11 @@ msgstr "تحديث"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "الرجوع"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "التفاف النص"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "اعتراض النص"

--- a/packages/ckeditor5-core/lang/translations/ar.po
+++ b/packages/ckeditor5-core/lang/translations/ar.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "الرجوع"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "التفاف النص"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "اعتراض النص"

--- a/packages/ckeditor5-core/lang/translations/ast.po
+++ b/packages/ckeditor5-core/lang/translations/ast.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/ast.po
+++ b/packages/ckeditor5-core/lang/translations/ast.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/az.po
+++ b/packages/ckeditor5-core/lang/translations/az.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/az.po
+++ b/packages/ckeditor5-core/lang/translations/az.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/be.po
+++ b/packages/ckeditor5-core/lang/translations/be.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Абгарнуць тэкст"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Разрываць тэкст"

--- a/packages/ckeditor5-core/lang/translations/be.po
+++ b/packages/ckeditor5-core/lang/translations/be.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Абгарнуць тэкст"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Разрываць тэкст"

--- a/packages/ckeditor5-core/lang/translations/bg.po
+++ b/packages/ckeditor5-core/lang/translations/bg.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Назад"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Събери текст"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Раздели текст"

--- a/packages/ckeditor5-core/lang/translations/bg.po
+++ b/packages/ckeditor5-core/lang/translations/bg.po
@@ -154,3 +154,11 @@ msgstr "Обнови"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Назад"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Събери текст"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Раздели текст"

--- a/packages/ckeditor5-core/lang/translations/bn.po
+++ b/packages/ckeditor5-core/lang/translations/bn.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "ফিরে যান"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "টেক্সট মোড়ানো"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "টেক্সট ভেঙ্গে ফেলুন"

--- a/packages/ckeditor5-core/lang/translations/bn.po
+++ b/packages/ckeditor5-core/lang/translations/bn.po
@@ -154,3 +154,11 @@ msgstr "আপডেট করুন"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "ফিরে যান"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "টেক্সট মোড়ানো"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "টেক্সট ভেঙ্গে ফেলুন"

--- a/packages/ckeditor5-core/lang/translations/bs.po
+++ b/packages/ckeditor5-core/lang/translations/bs.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Prelomi tekst"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/bs.po
+++ b/packages/ckeditor5-core/lang/translations/bs.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Prelomi tekst"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/ca.po
+++ b/packages/ckeditor5-core/lang/translations/ca.po
@@ -154,3 +154,11 @@ msgstr "Actualitzar"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Enrere"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Embolcallar el text"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Parteix el text"

--- a/packages/ckeditor5-core/lang/translations/ca.po
+++ b/packages/ckeditor5-core/lang/translations/ca.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Enrere"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Embolcallar el text"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Parteix el text"

--- a/packages/ckeditor5-core/lang/translations/cs.po
+++ b/packages/ckeditor5-core/lang/translations/cs.po
@@ -154,3 +154,11 @@ msgstr "Aktualizace"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Zpět"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Text nahoře a dole"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Obtékání textu"

--- a/packages/ckeditor5-core/lang/translations/cs.po
+++ b/packages/ckeditor5-core/lang/translations/cs.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Zpět"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Text nahoře a dole"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Obtékání textu"

--- a/packages/ckeditor5-core/lang/translations/da.po
+++ b/packages/ckeditor5-core/lang/translations/da.po
@@ -154,3 +154,11 @@ msgstr "Opdater"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Tilbage"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Ombryd tekst"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Opdel tekst"

--- a/packages/ckeditor5-core/lang/translations/da.po
+++ b/packages/ckeditor5-core/lang/translations/da.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Tilbage"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Ombryd tekst"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Opdel tekst"

--- a/packages/ckeditor5-core/lang/translations/de-ch.po
+++ b/packages/ckeditor5-core/lang/translations/de-ch.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/de-ch.po
+++ b/packages/ckeditor5-core/lang/translations/de-ch.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/de.po
+++ b/packages/ckeditor5-core/lang/translations/de.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Zurück"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Text umfließt Bild"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Bild teilt Text"

--- a/packages/ckeditor5-core/lang/translations/de.po
+++ b/packages/ckeditor5-core/lang/translations/de.po
@@ -154,3 +154,11 @@ msgstr "Aktualisieren"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Zurück"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Text umfließt Bild"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Bild teilt Text"

--- a/packages/ckeditor5-core/lang/translations/el.po
+++ b/packages/ckeditor5-core/lang/translations/el.po
@@ -154,3 +154,11 @@ msgstr "Ενημέρωση"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Πίσω"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Αναδίπλωση κειμένου"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Κατάτμηση κειμένου"

--- a/packages/ckeditor5-core/lang/translations/el.po
+++ b/packages/ckeditor5-core/lang/translations/el.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Πίσω"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Αναδίπλωση κειμένου"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Κατάτμηση κειμένου"

--- a/packages/ckeditor5-core/lang/translations/en-au.po
+++ b/packages/ckeditor5-core/lang/translations/en-au.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Back"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Wrap text"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Break text"

--- a/packages/ckeditor5-core/lang/translations/en-au.po
+++ b/packages/ckeditor5-core/lang/translations/en-au.po
@@ -154,3 +154,11 @@ msgstr "Update"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Back"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Wrap text"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Break text"

--- a/packages/ckeditor5-core/lang/translations/en-gb.po
+++ b/packages/ckeditor5-core/lang/translations/en-gb.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Back"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/en-gb.po
+++ b/packages/ckeditor5-core/lang/translations/en-gb.po
@@ -154,3 +154,11 @@ msgstr "Update"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Back"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/en.po
+++ b/packages/ckeditor5-core/lang/translations/en.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Back"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Wrap text"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Break text"

--- a/packages/ckeditor5-core/lang/translations/en.po
+++ b/packages/ckeditor5-core/lang/translations/en.po
@@ -154,3 +154,11 @@ msgstr "Update"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Back"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Wrap text"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Break text"

--- a/packages/ckeditor5-core/lang/translations/eo.po
+++ b/packages/ckeditor5-core/lang/translations/eo.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/eo.po
+++ b/packages/ckeditor5-core/lang/translations/eo.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/es-co.po
+++ b/packages/ckeditor5-core/lang/translations/es-co.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/es-co.po
+++ b/packages/ckeditor5-core/lang/translations/es-co.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/es.po
+++ b/packages/ckeditor5-core/lang/translations/es.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Volver"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Mantener texto unido"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Permitir quebrar texto"

--- a/packages/ckeditor5-core/lang/translations/es.po
+++ b/packages/ckeditor5-core/lang/translations/es.po
@@ -154,3 +154,11 @@ msgstr "Actualizar"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Volver"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Mantener texto unido"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Permitir quebrar texto"

--- a/packages/ckeditor5-core/lang/translations/et.po
+++ b/packages/ckeditor5-core/lang/translations/et.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Tagasi"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Murra teksti ridu"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Murra teksti"

--- a/packages/ckeditor5-core/lang/translations/et.po
+++ b/packages/ckeditor5-core/lang/translations/et.po
@@ -154,3 +154,11 @@ msgstr "Uuenda"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Tagasi"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Murra teksti ridu"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Murra teksti"

--- a/packages/ckeditor5-core/lang/translations/eu.po
+++ b/packages/ckeditor5-core/lang/translations/eu.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/eu.po
+++ b/packages/ckeditor5-core/lang/translations/eu.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/fa.po
+++ b/packages/ckeditor5-core/lang/translations/fa.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/fa.po
+++ b/packages/ckeditor5-core/lang/translations/fa.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/fi.po
+++ b/packages/ckeditor5-core/lang/translations/fi.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Takaisin"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Sovita teksti"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Irrota teksti"

--- a/packages/ckeditor5-core/lang/translations/fi.po
+++ b/packages/ckeditor5-core/lang/translations/fi.po
@@ -154,3 +154,11 @@ msgstr "Päivitä"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Takaisin"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Sovita teksti"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Irrota teksti"

--- a/packages/ckeditor5-core/lang/translations/fr.po
+++ b/packages/ckeditor5-core/lang/translations/fr.po
@@ -154,3 +154,11 @@ msgstr "Mettre à jour"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Retour"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Retour à la ligne"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Saut de ligne"

--- a/packages/ckeditor5-core/lang/translations/fr.po
+++ b/packages/ckeditor5-core/lang/translations/fr.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Retour"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Retour à la ligne"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Saut de ligne"

--- a/packages/ckeditor5-core/lang/translations/gl.po
+++ b/packages/ckeditor5-core/lang/translations/gl.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Envolver o texto"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Romper o texto"

--- a/packages/ckeditor5-core/lang/translations/gl.po
+++ b/packages/ckeditor5-core/lang/translations/gl.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Envolver o texto"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Romper o texto"

--- a/packages/ckeditor5-core/lang/translations/gu.po
+++ b/packages/ckeditor5-core/lang/translations/gu.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/gu.po
+++ b/packages/ckeditor5-core/lang/translations/gu.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/he.po
+++ b/packages/ckeditor5-core/lang/translations/he.po
@@ -154,3 +154,11 @@ msgstr "עדכן"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "חזור"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "גלישת טקסט"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "שבירת טקסט"

--- a/packages/ckeditor5-core/lang/translations/he.po
+++ b/packages/ckeditor5-core/lang/translations/he.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "חזור"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "גלישת טקסט"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "שבירת טקסט"

--- a/packages/ckeditor5-core/lang/translations/hi.po
+++ b/packages/ckeditor5-core/lang/translations/hi.po
@@ -154,3 +154,11 @@ msgstr "अपडेट"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "वापस जाएँ"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "टेक्स्ट रैप करें"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "टेक्स्ट तोड़ें"

--- a/packages/ckeditor5-core/lang/translations/hi.po
+++ b/packages/ckeditor5-core/lang/translations/hi.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "वापस जाएँ"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "टेक्स्ट रैप करें"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "टेक्स्ट तोड़ें"

--- a/packages/ckeditor5-core/lang/translations/hr.po
+++ b/packages/ckeditor5-core/lang/translations/hr.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Prelamanje teksta"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Prelomi tekst"

--- a/packages/ckeditor5-core/lang/translations/hr.po
+++ b/packages/ckeditor5-core/lang/translations/hr.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Prelamanje teksta"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Prelomi tekst"

--- a/packages/ckeditor5-core/lang/translations/hu.po
+++ b/packages/ckeditor5-core/lang/translations/hu.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Vissza"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Körbefuttatás"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Sortörés"

--- a/packages/ckeditor5-core/lang/translations/hu.po
+++ b/packages/ckeditor5-core/lang/translations/hu.po
@@ -154,3 +154,11 @@ msgstr "Frissítés"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Vissza"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Körbefuttatás"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Sortörés"

--- a/packages/ckeditor5-core/lang/translations/hy.po
+++ b/packages/ckeditor5-core/lang/translations/hy.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/hy.po
+++ b/packages/ckeditor5-core/lang/translations/hy.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/id.po
+++ b/packages/ckeditor5-core/lang/translations/id.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Kembali"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Bungkus teks"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Pecahkan teks"

--- a/packages/ckeditor5-core/lang/translations/id.po
+++ b/packages/ckeditor5-core/lang/translations/id.po
@@ -154,3 +154,11 @@ msgstr "PErbarui"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Kembali"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Bungkus teks"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Pecahkan teks"

--- a/packages/ckeditor5-core/lang/translations/it.po
+++ b/packages/ckeditor5-core/lang/translations/it.po
@@ -154,3 +154,11 @@ msgstr "Aggiornamento"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Indietro"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Testo a capo"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Interrompi testo"

--- a/packages/ckeditor5-core/lang/translations/it.po
+++ b/packages/ckeditor5-core/lang/translations/it.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Indietro"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Testo a capo"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Interrompi testo"

--- a/packages/ckeditor5-core/lang/translations/ja.po
+++ b/packages/ckeditor5-core/lang/translations/ja.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "戻る"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "テキストを折り返す"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "テキストを分割する"

--- a/packages/ckeditor5-core/lang/translations/ja.po
+++ b/packages/ckeditor5-core/lang/translations/ja.po
@@ -154,3 +154,11 @@ msgstr "アップデート"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "戻る"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "テキストを折り返す"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "テキストを分割する"

--- a/packages/ckeditor5-core/lang/translations/jv.po
+++ b/packages/ckeditor5-core/lang/translations/jv.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/jv.po
+++ b/packages/ckeditor5-core/lang/translations/jv.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/kk.po
+++ b/packages/ckeditor5-core/lang/translations/kk.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/kk.po
+++ b/packages/ckeditor5-core/lang/translations/kk.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/km.po
+++ b/packages/ckeditor5-core/lang/translations/km.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/km.po
+++ b/packages/ckeditor5-core/lang/translations/km.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/kn.po
+++ b/packages/ckeditor5-core/lang/translations/kn.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/kn.po
+++ b/packages/ckeditor5-core/lang/translations/kn.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/ko.po
+++ b/packages/ckeditor5-core/lang/translations/ko.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "뒤로"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "텍스트 줄 바꿈"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "텍스트 분리"

--- a/packages/ckeditor5-core/lang/translations/ko.po
+++ b/packages/ckeditor5-core/lang/translations/ko.po
@@ -154,3 +154,11 @@ msgstr "업데이트"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "뒤로"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "텍스트 줄 바꿈"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "텍스트 분리"

--- a/packages/ckeditor5-core/lang/translations/ku.po
+++ b/packages/ckeditor5-core/lang/translations/ku.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/ku.po
+++ b/packages/ckeditor5-core/lang/translations/ku.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/lt.po
+++ b/packages/ckeditor5-core/lang/translations/lt.po
@@ -154,3 +154,11 @@ msgstr "Atnaujinti"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Grįžti"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Perkelti tekstą į kitą eilutę"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Suskaidyti tekstą"

--- a/packages/ckeditor5-core/lang/translations/lt.po
+++ b/packages/ckeditor5-core/lang/translations/lt.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Grįžti"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Perkelti tekstą į kitą eilutę"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Suskaidyti tekstą"

--- a/packages/ckeditor5-core/lang/translations/lv.po
+++ b/packages/ckeditor5-core/lang/translations/lv.po
@@ -154,3 +154,11 @@ msgstr "Atjaunināt"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Atpakaļ"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Aplauzt tekstu"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Pārtraukt tekstu"

--- a/packages/ckeditor5-core/lang/translations/lv.po
+++ b/packages/ckeditor5-core/lang/translations/lv.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Atpakaļ"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Aplauzt tekstu"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Pārtraukt tekstu"

--- a/packages/ckeditor5-core/lang/translations/ms.po
+++ b/packages/ckeditor5-core/lang/translations/ms.po
@@ -154,3 +154,11 @@ msgstr "Kemaskini"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Kembali"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Balut teks"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Potong teks"

--- a/packages/ckeditor5-core/lang/translations/ms.po
+++ b/packages/ckeditor5-core/lang/translations/ms.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Kembali"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Balut teks"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Potong teks"

--- a/packages/ckeditor5-core/lang/translations/nb.po
+++ b/packages/ckeditor5-core/lang/translations/nb.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/nb.po
+++ b/packages/ckeditor5-core/lang/translations/nb.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/ne.po
+++ b/packages/ckeditor5-core/lang/translations/ne.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/ne.po
+++ b/packages/ckeditor5-core/lang/translations/ne.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/nl.po
+++ b/packages/ckeditor5-core/lang/translations/nl.po
@@ -154,3 +154,11 @@ msgstr "Update"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Terug"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Tekstterugloop"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Tekst afbreken"

--- a/packages/ckeditor5-core/lang/translations/nl.po
+++ b/packages/ckeditor5-core/lang/translations/nl.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Terug"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Tekstterugloop"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Tekst afbreken"

--- a/packages/ckeditor5-core/lang/translations/no.po
+++ b/packages/ckeditor5-core/lang/translations/no.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Tilbake"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Omslutt"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Bryt tekst"

--- a/packages/ckeditor5-core/lang/translations/no.po
+++ b/packages/ckeditor5-core/lang/translations/no.po
@@ -154,3 +154,11 @@ msgstr "Oppdater"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Tilbake"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Omslutt"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Bryt tekst"

--- a/packages/ckeditor5-core/lang/translations/oc.po
+++ b/packages/ckeditor5-core/lang/translations/oc.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/oc.po
+++ b/packages/ckeditor5-core/lang/translations/oc.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/pl.po
+++ b/packages/ckeditor5-core/lang/translations/pl.po
@@ -154,3 +154,11 @@ msgstr "Zaktualizuj"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Wróć"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Zawijaj tekst"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Rozbijaj tekst"

--- a/packages/ckeditor5-core/lang/translations/pl.po
+++ b/packages/ckeditor5-core/lang/translations/pl.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Wróć"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Zawijaj tekst"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Rozbijaj tekst"

--- a/packages/ckeditor5-core/lang/translations/pt-br.po
+++ b/packages/ckeditor5-core/lang/translations/pt-br.po
@@ -154,3 +154,11 @@ msgstr "Atualizar"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Voltar"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Texto ao redor"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Quebrar texto"

--- a/packages/ckeditor5-core/lang/translations/pt-br.po
+++ b/packages/ckeditor5-core/lang/translations/pt-br.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Voltar"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Texto ao redor"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Quebrar texto"

--- a/packages/ckeditor5-core/lang/translations/pt.po
+++ b/packages/ckeditor5-core/lang/translations/pt.po
@@ -154,3 +154,11 @@ msgstr "Atualizar"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Voltar"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Envolver texto"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Quebrar texto"

--- a/packages/ckeditor5-core/lang/translations/pt.po
+++ b/packages/ckeditor5-core/lang/translations/pt.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Voltar"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Envolver texto"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Quebrar texto"

--- a/packages/ckeditor5-core/lang/translations/ro.po
+++ b/packages/ckeditor5-core/lang/translations/ro.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Înapoi"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Încadrare text"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Segmentare text"

--- a/packages/ckeditor5-core/lang/translations/ro.po
+++ b/packages/ckeditor5-core/lang/translations/ro.po
@@ -154,3 +154,11 @@ msgstr "Actualizează"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Înapoi"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Încadrare text"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Segmentare text"

--- a/packages/ckeditor5-core/lang/translations/ru.po
+++ b/packages/ckeditor5-core/lang/translations/ru.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Назад"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Обтекать текст"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Разрывать текст"

--- a/packages/ckeditor5-core/lang/translations/ru.po
+++ b/packages/ckeditor5-core/lang/translations/ru.po
@@ -154,3 +154,11 @@ msgstr "Обновить"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Назад"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Обтекать текст"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Разрывать текст"

--- a/packages/ckeditor5-core/lang/translations/si.po
+++ b/packages/ckeditor5-core/lang/translations/si.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/si.po
+++ b/packages/ckeditor5-core/lang/translations/si.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/sk.po
+++ b/packages/ckeditor5-core/lang/translations/sk.po
@@ -154,3 +154,11 @@ msgstr "Aktualizovať"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Naspäť"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Obtekanie textu"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Zalomenie textu"

--- a/packages/ckeditor5-core/lang/translations/sk.po
+++ b/packages/ckeditor5-core/lang/translations/sk.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Naspäť"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Obtekanie textu"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Zalomenie textu"

--- a/packages/ckeditor5-core/lang/translations/sl.po
+++ b/packages/ckeditor5-core/lang/translations/sl.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/sl.po
+++ b/packages/ckeditor5-core/lang/translations/sl.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/sq.po
+++ b/packages/ckeditor5-core/lang/translations/sq.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/sq.po
+++ b/packages/ckeditor5-core/lang/translations/sq.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-core/lang/translations/sr-latn.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Prelomiti tekst"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Prelom teksta"

--- a/packages/ckeditor5-core/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-core/lang/translations/sr-latn.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Prelomiti tekst"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Prelom teksta"

--- a/packages/ckeditor5-core/lang/translations/sr.po
+++ b/packages/ckeditor5-core/lang/translations/sr.po
@@ -154,3 +154,11 @@ msgstr "Ažuriraj"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Natrag"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Преломити текст"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Прелом текста"

--- a/packages/ckeditor5-core/lang/translations/sr.po
+++ b/packages/ckeditor5-core/lang/translations/sr.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Natrag"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Преломити текст"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Прелом текста"

--- a/packages/ckeditor5-core/lang/translations/sv.po
+++ b/packages/ckeditor5-core/lang/translations/sv.po
@@ -154,3 +154,11 @@ msgstr "Uppdatera"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Tillbaka"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Omslut med text"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Bryt upp text"

--- a/packages/ckeditor5-core/lang/translations/sv.po
+++ b/packages/ckeditor5-core/lang/translations/sv.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Tillbaka"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Omslut med text"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Bryt upp text"

--- a/packages/ckeditor5-core/lang/translations/th.po
+++ b/packages/ckeditor5-core/lang/translations/th.po
@@ -154,3 +154,11 @@ msgstr "อัปเดต"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "ย้อนกลับ"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "ตัดคำข้อความ"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "แบ่งข้อความ"

--- a/packages/ckeditor5-core/lang/translations/th.po
+++ b/packages/ckeditor5-core/lang/translations/th.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "ย้อนกลับ"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "ตัดคำข้อความ"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "แบ่งข้อความ"

--- a/packages/ckeditor5-core/lang/translations/ti.po
+++ b/packages/ckeditor5-core/lang/translations/ti.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/ti.po
+++ b/packages/ckeditor5-core/lang/translations/ti.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/tk.po
+++ b/packages/ckeditor5-core/lang/translations/tk.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/tk.po
+++ b/packages/ckeditor5-core/lang/translations/tk.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/tr.po
+++ b/packages/ckeditor5-core/lang/translations/tr.po
@@ -154,3 +154,11 @@ msgstr "Güncelle"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Geri"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Metni kaydır"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Metni böl"

--- a/packages/ckeditor5-core/lang/translations/tr.po
+++ b/packages/ckeditor5-core/lang/translations/tr.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Geri"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Metni kaydır"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Metni böl"

--- a/packages/ckeditor5-core/lang/translations/tt.po
+++ b/packages/ckeditor5-core/lang/translations/tt.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/tt.po
+++ b/packages/ckeditor5-core/lang/translations/tt.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/ug.po
+++ b/packages/ckeditor5-core/lang/translations/ug.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "تېكىست چۆرىدەت"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "تېكىست ئۈز"

--- a/packages/ckeditor5-core/lang/translations/ug.po
+++ b/packages/ckeditor5-core/lang/translations/ug.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "تېكىست چۆرىدەت"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "تېكىست ئۈز"

--- a/packages/ckeditor5-core/lang/translations/uk.po
+++ b/packages/ckeditor5-core/lang/translations/uk.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Назад"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Обернути текст"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Розірвати тексту"

--- a/packages/ckeditor5-core/lang/translations/uk.po
+++ b/packages/ckeditor5-core/lang/translations/uk.po
@@ -154,3 +154,11 @@ msgstr "Оновити"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Назад"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Обернути текст"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Розірвати тексту"

--- a/packages/ckeditor5-core/lang/translations/ur.po
+++ b/packages/ckeditor5-core/lang/translations/ur.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "ملفوف متن"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "متن تقسیم کریں"

--- a/packages/ckeditor5-core/lang/translations/ur.po
+++ b/packages/ckeditor5-core/lang/translations/ur.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "ملفوف متن"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "متن تقسیم کریں"

--- a/packages/ckeditor5-core/lang/translations/uz.po
+++ b/packages/ckeditor5-core/lang/translations/uz.po
@@ -154,3 +154,11 @@ msgstr ""
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr ""
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr ""

--- a/packages/ckeditor5-core/lang/translations/uz.po
+++ b/packages/ckeditor5-core/lang/translations/uz.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr ""
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr ""

--- a/packages/ckeditor5-core/lang/translations/vi.po
+++ b/packages/ckeditor5-core/lang/translations/vi.po
@@ -154,3 +154,11 @@ msgstr "Cập nhật"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Quay lại"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "Bọc văn bản"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "Ngắt văn bản"

--- a/packages/ckeditor5-core/lang/translations/vi.po
+++ b/packages/ckeditor5-core/lang/translations/vi.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "Quay lại"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "Bọc văn bản"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "Ngắt văn bản"

--- a/packages/ckeditor5-core/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-core/lang/translations/zh-cn.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "返回"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "文字环绕"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "文字断行"

--- a/packages/ckeditor5-core/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-core/lang/translations/zh-cn.po
@@ -154,3 +154,11 @@ msgstr "更新"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "返回"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "文字环绕"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "文字断行"

--- a/packages/ckeditor5-core/lang/translations/zh.po
+++ b/packages/ckeditor5-core/lang/translations/zh.po
@@ -154,3 +154,11 @@ msgstr "更新"
 msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "返回"
+
+msgctxt "The label for the image style button that wraps text around the image."
+msgid "Wrap text"
+msgstr "文繞圖"
+
+msgctxt "The label for the image style button that breaks the text around the image."
+msgid "Break text"
+msgstr "上及下"

--- a/packages/ckeditor5-core/lang/translations/zh.po
+++ b/packages/ckeditor5-core/lang/translations/zh.po
@@ -155,10 +155,10 @@ msgctxt "Label for the Back button."
 msgid "Back"
 msgstr "返回"
 
-msgctxt "The label for the image style button that wraps text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that wraps text around the object."
 msgid "Wrap text"
 msgstr "文繞圖"
 
-msgctxt "The label for the image style button that breaks the text around the image."
+msgctxt "The label for the object (e.g. image, media) style button that breaks the text around the object."
 msgid "Break text"
 msgstr "上及下"

--- a/packages/ckeditor5-image/lang/contexts.json
+++ b/packages/ckeditor5-image/lang/contexts.json
@@ -16,7 +16,7 @@
 	"Upload image from computer": "The label for the upload image from computer toolbar button.",
 	"Image from computer": "The label for the upload image from computer menu bar button (standalone button).",
 	"From computer": "The label for the upload image from computer menu bar button (inside 'Image' menu).",
-  	"Replace image from computer": "The label for the replace image by upload from computer toolbar button.",
+	"Replace image from computer": "The label for the replace image by upload from computer toolbar button.",
 	"Upload failed": "The title of the notification displayed when upload fails.",
 	"You have no image upload permissions.": "The title of the notification displayed when there is no permission to upload assets.",
 	"Image toolbar": "The label used by assistive technologies describing an image toolbar attached to an image widget.",

--- a/packages/ckeditor5-image/lang/translations/af.po
+++ b/packages/ckeditor5-image/lang/translations/af.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/ar.po
+++ b/packages/ckeditor5-image/lang/translations/ar.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "عنصر الصورة"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "التفاف النص"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "اعتراض النص"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "سطري مع النص"

--- a/packages/ckeditor5-image/lang/translations/ast.po
+++ b/packages/ckeditor5-image/lang/translations/ast.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "complementu d'imaxen"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/az.po
+++ b/packages/ckeditor5-image/lang/translations/az.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Şəkil vidgetı"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/be.po
+++ b/packages/ckeditor5-image/lang/translations/be.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Віджэт відарыса"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Абгарнуць тэкст"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Разрываць тэкст"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "У тэксце"

--- a/packages/ckeditor5-image/lang/translations/bg.po
+++ b/packages/ckeditor5-image/lang/translations/bg.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Компонент за изображение"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Събери текст"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Раздели текст"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "В линия"

--- a/packages/ckeditor5-image/lang/translations/bn.po
+++ b/packages/ckeditor5-image/lang/translations/bn.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "ছবির উইজেট"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "টেক্সট মোড়ানো"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "টেক্সট ভেঙ্গে ফেলুন"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "সঙ্গতিপূর্ণভাবে"

--- a/packages/ckeditor5-image/lang/translations/bs.po
+++ b/packages/ckeditor5-image/lang/translations/bs.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Prelomi tekst"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/ca.po
+++ b/packages/ckeditor5-image/lang/translations/ca.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "giny d'imatge"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Embolcallar el text"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Parteix el text"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "A la línia"

--- a/packages/ckeditor5-image/lang/translations/cs.po
+++ b/packages/ckeditor5-image/lang/translations/cs.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "ovládací prvek obrázku"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Text nahoře a dole"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Obtékání textu"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "Rovnoběžně s textem"

--- a/packages/ckeditor5-image/lang/translations/da.po
+++ b/packages/ckeditor5-image/lang/translations/da.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "billed widget"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Ombryd tekst"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Opdel tekst"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "På linje"

--- a/packages/ckeditor5-image/lang/translations/de-ch.po
+++ b/packages/ckeditor5-image/lang/translations/de-ch.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Bild-Steuerelement"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/de.po
+++ b/packages/ckeditor5-image/lang/translations/de.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Bild-Steuerelement"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Text umfließt Bild"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Bild teilt Text"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "Text in Zeile"

--- a/packages/ckeditor5-image/lang/translations/el.po
+++ b/packages/ckeditor5-image/lang/translations/el.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Γραφικό στοιχείο εικόνας"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Αναδίπλωση κειμένου"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Κατάτμηση κειμένου"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "Εντός γραμμής"

--- a/packages/ckeditor5-image/lang/translations/en-au.po
+++ b/packages/ckeditor5-image/lang/translations/en-au.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "image widget"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Wrap text"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Break text"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "In line"

--- a/packages/ckeditor5-image/lang/translations/en-gb.po
+++ b/packages/ckeditor5-image/lang/translations/en-gb.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Image widget"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/en.po
+++ b/packages/ckeditor5-image/lang/translations/en.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "image widget"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Wrap text"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Break text"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "In line"

--- a/packages/ckeditor5-image/lang/translations/eo.po
+++ b/packages/ckeditor5-image/lang/translations/eo.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "bilda fenestraĵo"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/es-co.po
+++ b/packages/ckeditor5-image/lang/translations/es-co.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/es.po
+++ b/packages/ckeditor5-image/lang/translations/es.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Widget de imagen"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Mantener texto unido"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Permitir quebrar texto"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "En línea"

--- a/packages/ckeditor5-image/lang/translations/et.po
+++ b/packages/ckeditor5-image/lang/translations/et.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "pildi vidin"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Murra teksti ridu"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Murra teksti"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "Joone sees"

--- a/packages/ckeditor5-image/lang/translations/eu.po
+++ b/packages/ckeditor5-image/lang/translations/eu.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "irudi widgeta"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/fa.po
+++ b/packages/ckeditor5-image/lang/translations/fa.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "ابزاره تصویر"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/fi.po
+++ b/packages/ckeditor5-image/lang/translations/fi.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Kuvavimpain"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Sovita teksti"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Irrota teksti"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "Rivin sisällä"

--- a/packages/ckeditor5-image/lang/translations/fr.po
+++ b/packages/ckeditor5-image/lang/translations/fr.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Objet image"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Retour à la ligne"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Saut de ligne"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "Aligné"

--- a/packages/ckeditor5-image/lang/translations/gl.po
+++ b/packages/ckeditor5-image/lang/translations/gl.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Trebello de imaxe"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Envolver o texto"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Romper o texto"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "En liña"

--- a/packages/ckeditor5-image/lang/translations/gu.po
+++ b/packages/ckeditor5-image/lang/translations/gu.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/he.po
+++ b/packages/ckeditor5-image/lang/translations/he.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "תמונה"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "גלישת טקסט"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "שבירת טקסט"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "בתוך השורה"

--- a/packages/ckeditor5-image/lang/translations/hi.po
+++ b/packages/ckeditor5-image/lang/translations/hi.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "image widget"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "टेक्स्ट रैप करें"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "टेक्स्ट तोड़ें"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "इन - लाइन"

--- a/packages/ckeditor5-image/lang/translations/hr.po
+++ b/packages/ckeditor5-image/lang/translations/hr.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Slika widget"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Prelamanje teksta"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Prelomi tekst"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "U istom redu"

--- a/packages/ckeditor5-image/lang/translations/hu.po
+++ b/packages/ckeditor5-image/lang/translations/hu.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "képmodul"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Körbefuttatás"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Sortörés"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "Soron belül"

--- a/packages/ckeditor5-image/lang/translations/hy.po
+++ b/packages/ckeditor5-image/lang/translations/hy.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/id.po
+++ b/packages/ckeditor5-image/lang/translations/id.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "widget gambar"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Bungkus teks"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Pecahkan teks"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "Sebaris"

--- a/packages/ckeditor5-image/lang/translations/it.po
+++ b/packages/ckeditor5-image/lang/translations/it.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Widget immagine"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Testo a capo"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Interrompi testo"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "In linea"

--- a/packages/ckeditor5-image/lang/translations/ja.po
+++ b/packages/ckeditor5-image/lang/translations/ja.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "画像ウィジェット"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "テキストを折り返す"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "テキストを分割する"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "インライン"

--- a/packages/ckeditor5-image/lang/translations/jv.po
+++ b/packages/ckeditor5-image/lang/translations/jv.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/kk.po
+++ b/packages/ckeditor5-image/lang/translations/kk.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/km.po
+++ b/packages/ckeditor5-image/lang/translations/km.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "វិដជិត​រូបភាព"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/kn.po
+++ b/packages/ckeditor5-image/lang/translations/kn.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "‍ಚಿತ್ರ ವಿಜೆಟ್"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/ko.po
+++ b/packages/ckeditor5-image/lang/translations/ko.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "사진 위젯"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "텍스트 줄 바꿈"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "텍스트 분리"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "줄 안에"

--- a/packages/ckeditor5-image/lang/translations/ku.po
+++ b/packages/ckeditor5-image/lang/translations/ku.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "وێدجیتی وێنە"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/lt.po
+++ b/packages/ckeditor5-image/lang/translations/lt.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "vaizdų valdiklis"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Perkelti tekstą į kitą eilutę"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Suskaidyti tekstą"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "tolygiai"

--- a/packages/ckeditor5-image/lang/translations/lv.po
+++ b/packages/ckeditor5-image/lang/translations/lv.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "attēla sīkrīks"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Aplauzt tekstu"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Pārtraukt tekstu"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "Rindā"

--- a/packages/ckeditor5-image/lang/translations/ms.po
+++ b/packages/ckeditor5-image/lang/translations/ms.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "widget imej"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Balut teks"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Potong teks"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "Dalam baris"

--- a/packages/ckeditor5-image/lang/translations/nb.po
+++ b/packages/ckeditor5-image/lang/translations/nb.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Bilde-widget"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/ne.po
+++ b/packages/ckeditor5-image/lang/translations/ne.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "तस्वीर विजेट"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/nl.po
+++ b/packages/ckeditor5-image/lang/translations/nl.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "afbeeldingswidget"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Tekstterugloop"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Tekst afbreken"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "In lijn"

--- a/packages/ckeditor5-image/lang/translations/no.po
+++ b/packages/ckeditor5-image/lang/translations/no.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Bilde-widget"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Omslutt"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Bryt tekst"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "Innlemmet"

--- a/packages/ckeditor5-image/lang/translations/oc.po
+++ b/packages/ckeditor5-image/lang/translations/oc.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/pl.po
+++ b/packages/ckeditor5-image/lang/translations/pl.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Obraz"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Zawijaj tekst"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Rozbijaj tekst"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "W linii"

--- a/packages/ckeditor5-image/lang/translations/pt-br.po
+++ b/packages/ckeditor5-image/lang/translations/pt-br.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Ferramenta de imagem"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Texto ao redor"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Quebrar texto"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "Na linha"

--- a/packages/ckeditor5-image/lang/translations/pt.po
+++ b/packages/ckeditor5-image/lang/translations/pt.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "módulo de imagem"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Envolver texto"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Quebrar texto"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "Em linha"

--- a/packages/ckeditor5-image/lang/translations/ro.po
+++ b/packages/ckeditor5-image/lang/translations/ro.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "widget imagine"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Încadrare text"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Segmentare text"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "În linie"

--- a/packages/ckeditor5-image/lang/translations/ru.po
+++ b/packages/ckeditor5-image/lang/translations/ru.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Виджет изображений"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Обтекать текст"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Разрывать текст"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "В тексте"

--- a/packages/ckeditor5-image/lang/translations/si.po
+++ b/packages/ckeditor5-image/lang/translations/si.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/sk.po
+++ b/packages/ckeditor5-image/lang/translations/sk.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "widget obrázka"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Obtekanie textu"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Zalomenie textu"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "V riadku"

--- a/packages/ckeditor5-image/lang/translations/sl.po
+++ b/packages/ckeditor5-image/lang/translations/sl.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/sq.po
+++ b/packages/ckeditor5-image/lang/translations/sq.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Vegla e fotos"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-image/lang/translations/sr-latn.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "modul sa slikom"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Prelomiti tekst"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Prelom teksta"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "U redu"

--- a/packages/ckeditor5-image/lang/translations/sr.po
+++ b/packages/ckeditor5-image/lang/translations/sr.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "модул са сликом"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Преломити текст"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Прелом текста"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "У реду"

--- a/packages/ckeditor5-image/lang/translations/sv.po
+++ b/packages/ckeditor5-image/lang/translations/sv.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "image widget"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Omslut med text"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Bryt upp text"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "På rad"

--- a/packages/ckeditor5-image/lang/translations/th.po
+++ b/packages/ckeditor5-image/lang/translations/th.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "วิดเจ็ตรูปภาพ"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "ตัดคำข้อความ"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "แบ่งข้อความ"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "ในบรรทัด"

--- a/packages/ckeditor5-image/lang/translations/ti.po
+++ b/packages/ckeditor5-image/lang/translations/ti.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/tk.po
+++ b/packages/ckeditor5-image/lang/translations/tk.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "surat widjeti"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/tr.po
+++ b/packages/ckeditor5-image/lang/translations/tr.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "resim aracı"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Metni kaydır"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Metni böl"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "Aynı hizada"

--- a/packages/ckeditor5-image/lang/translations/tt.po
+++ b/packages/ckeditor5-image/lang/translations/tt.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr ""
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/ug.po
+++ b/packages/ckeditor5-image/lang/translations/ug.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "رەسىمچىك"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "تېكىست چۆرىدەت"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "تېكىست ئۈز"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "قۇردا"

--- a/packages/ckeditor5-image/lang/translations/uk.po
+++ b/packages/ckeditor5-image/lang/translations/uk.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Віджет зображення"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Обернути текст"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Розірвати тексту"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "В тексті"

--- a/packages/ckeditor5-image/lang/translations/ur.po
+++ b/packages/ckeditor5-image/lang/translations/ur.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "آلۂ عکس"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "ملفوف متن"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "متن تقسیم کریں"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/uz.po
+++ b/packages/ckeditor5-image/lang/translations/uz.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "Tasvirlar vidjeti"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr ""
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr ""
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr ""

--- a/packages/ckeditor5-image/lang/translations/vi.po
+++ b/packages/ckeditor5-image/lang/translations/vi.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "tiện ích ảnh"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "Bọc văn bản"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "Ngắt văn bản"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "Nội dòng"

--- a/packages/ckeditor5-image/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-image/lang/translations/zh-cn.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "图片组件"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "文字环绕"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "文字断行"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "行内"

--- a/packages/ckeditor5-image/lang/translations/zh.po
+++ b/packages/ckeditor5-image/lang/translations/zh.po
@@ -15,14 +15,6 @@ msgctxt "The label for the image widget."
 msgid "image widget"
 msgstr "圖片小工具"
 
-msgctxt "The label for the image style button that wraps text around the image."
-msgid "Wrap text"
-msgstr "文繞圖"
-
-msgctxt "The label for the image style button that breaks the text around the image."
-msgid "Break text"
-msgstr "上及下"
-
 msgctxt "The label for the image style button that places the image inside the line of text."
 msgid "In line"
 msgstr "行中"

--- a/packages/ckeditor5-link/lang/translations/af.po
+++ b/packages/ckeditor5-link/lang/translations/af.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/ar.po
+++ b/packages/ckeditor5-link/lang/translations/ar.po
@@ -66,3 +66,7 @@ msgstr "النص المعروض"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "لا توجد روابط متاحة"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/ast.po
+++ b/packages/ckeditor5-link/lang/translations/ast.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/az.po
+++ b/packages/ckeditor5-link/lang/translations/az.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/be.po
+++ b/packages/ckeditor5-link/lang/translations/be.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/bg.po
+++ b/packages/ckeditor5-link/lang/translations/bg.po
@@ -66,3 +66,7 @@ msgstr "Показан текст"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Няма налични връзки"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/bn.po
+++ b/packages/ckeditor5-link/lang/translations/bn.po
@@ -68,3 +68,7 @@ msgstr "প্রদর্শিত টেক্সট"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "কোনো লিঙ্ক উপলব্ধ নেই"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/bs.po
+++ b/packages/ckeditor5-link/lang/translations/bs.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/ca.po
+++ b/packages/ckeditor5-link/lang/translations/ca.po
@@ -66,3 +66,7 @@ msgstr "Text que es mostra"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "No hi ha cap enllaç disponible"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/cs.po
+++ b/packages/ckeditor5-link/lang/translations/cs.po
@@ -66,3 +66,7 @@ msgstr "Zobrazený text"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Žádné dostupné odkazy"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/da.po
+++ b/packages/ckeditor5-link/lang/translations/da.po
@@ -66,3 +66,7 @@ msgstr "Vist tekst"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Ingen links tilgængelige"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/de-ch.po
+++ b/packages/ckeditor5-link/lang/translations/de-ch.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/de.po
+++ b/packages/ckeditor5-link/lang/translations/de.po
@@ -66,3 +66,7 @@ msgstr "Angezeigter Text"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Keine Links verfügbar"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/el.po
+++ b/packages/ckeditor5-link/lang/translations/el.po
@@ -66,3 +66,7 @@ msgstr "Εμφανιζόμενο κείμενο"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Δεν υπάρχουν διαθέσιμοι σύνδεσμοι"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/en-au.po
+++ b/packages/ckeditor5-link/lang/translations/en-au.po
@@ -66,3 +66,7 @@ msgstr "Displayed text"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "No links available"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr "This link has no URL"

--- a/packages/ckeditor5-link/lang/translations/en-gb.po
+++ b/packages/ckeditor5-link/lang/translations/en-gb.po
@@ -66,3 +66,7 @@ msgstr "Displayed text"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "No links available"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr "This link has no URL"

--- a/packages/ckeditor5-link/lang/translations/en.po
+++ b/packages/ckeditor5-link/lang/translations/en.po
@@ -66,3 +66,7 @@ msgstr "Displayed text"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "No links available"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr "This link has no URL"

--- a/packages/ckeditor5-link/lang/translations/eo.po
+++ b/packages/ckeditor5-link/lang/translations/eo.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/es-co.po
+++ b/packages/ckeditor5-link/lang/translations/es-co.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/es.po
+++ b/packages/ckeditor5-link/lang/translations/es.po
@@ -66,3 +66,7 @@ msgstr "Texto mostrado"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "No hay enlaces disponibles"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/et.po
+++ b/packages/ckeditor5-link/lang/translations/et.po
@@ -66,3 +66,7 @@ msgstr "Kuvatud tekst"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Ühtegi linki pole saadaval"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/eu.po
+++ b/packages/ckeditor5-link/lang/translations/eu.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/fa.po
+++ b/packages/ckeditor5-link/lang/translations/fa.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/fi.po
+++ b/packages/ckeditor5-link/lang/translations/fi.po
@@ -66,3 +66,7 @@ msgstr "Näytettävä teksti"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Linkkejä ei käytettävissä"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/fr.po
+++ b/packages/ckeditor5-link/lang/translations/fr.po
@@ -66,3 +66,7 @@ msgstr "Texte affiché"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Aucun lien disponible"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/gl.po
+++ b/packages/ckeditor5-link/lang/translations/gl.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/gu.po
+++ b/packages/ckeditor5-link/lang/translations/gu.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/he.po
+++ b/packages/ckeditor5-link/lang/translations/he.po
@@ -66,3 +66,7 @@ msgstr "טקסט מוצג"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "אין קישורים זמינים"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/hi.po
+++ b/packages/ckeditor5-link/lang/translations/hi.po
@@ -66,3 +66,7 @@ msgstr "प्रदर्शित टेक्स्ट"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "कोई लिंक उपलब्ध नहीं है"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/hr.po
+++ b/packages/ckeditor5-link/lang/translations/hr.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/hu.po
+++ b/packages/ckeditor5-link/lang/translations/hu.po
@@ -66,3 +66,7 @@ msgstr "Megjelenő szöveg"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Nincs elérhető link"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/hy.po
+++ b/packages/ckeditor5-link/lang/translations/hy.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/id.po
+++ b/packages/ckeditor5-link/lang/translations/id.po
@@ -66,3 +66,7 @@ msgstr "Teks yang ditampilkan"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Tautan tidak tersedia"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/it.po
+++ b/packages/ckeditor5-link/lang/translations/it.po
@@ -66,3 +66,7 @@ msgstr "Testo visualizzato"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Nessun link disponibile"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/ja.po
+++ b/packages/ckeditor5-link/lang/translations/ja.po
@@ -66,3 +66,7 @@ msgstr "表示されるテキスト"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "利用できるリンクがありません"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/jv.po
+++ b/packages/ckeditor5-link/lang/translations/jv.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/kk.po
+++ b/packages/ckeditor5-link/lang/translations/kk.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/km.po
+++ b/packages/ckeditor5-link/lang/translations/km.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/kn.po
+++ b/packages/ckeditor5-link/lang/translations/kn.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/ko.po
+++ b/packages/ckeditor5-link/lang/translations/ko.po
@@ -66,3 +66,7 @@ msgstr "표시 텍스트"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "사용 가능한 링크 없음"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/ku.po
+++ b/packages/ckeditor5-link/lang/translations/ku.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/lt.po
+++ b/packages/ckeditor5-link/lang/translations/lt.po
@@ -66,3 +66,7 @@ msgstr "Rodomas tekstas"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Nėra jokių nuorodų"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/lv.po
+++ b/packages/ckeditor5-link/lang/translations/lv.po
@@ -66,3 +66,7 @@ msgstr "Attēlotais teksts"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Nav pieejama neviena saite"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/ms.po
+++ b/packages/ckeditor5-link/lang/translations/ms.po
@@ -66,3 +66,7 @@ msgstr "Teks yang dipaparkan"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Tiada pautan tersedia"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/nb.po
+++ b/packages/ckeditor5-link/lang/translations/nb.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/ne.po
+++ b/packages/ckeditor5-link/lang/translations/ne.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/nl.po
+++ b/packages/ckeditor5-link/lang/translations/nl.po
@@ -66,3 +66,7 @@ msgstr "Weergegeven tekst"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Geen links beschikbaar"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/no.po
+++ b/packages/ckeditor5-link/lang/translations/no.po
@@ -66,3 +66,7 @@ msgstr "Vist tekst"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Ingen lenker tilgjengelig"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/oc.po
+++ b/packages/ckeditor5-link/lang/translations/oc.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/pl.po
+++ b/packages/ckeditor5-link/lang/translations/pl.po
@@ -66,3 +66,7 @@ msgstr "Wyświetlany tekst"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Brak dostępnych linków"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/pt-br.po
+++ b/packages/ckeditor5-link/lang/translations/pt-br.po
@@ -66,3 +66,7 @@ msgstr "Texto mostrado"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Nenhum link disponível"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/pt.po
+++ b/packages/ckeditor5-link/lang/translations/pt.po
@@ -66,3 +66,7 @@ msgstr "Texto exibido"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Sem ligações disponíveis"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/ro.po
+++ b/packages/ckeditor5-link/lang/translations/ro.po
@@ -66,3 +66,7 @@ msgstr "Textul afișat"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Niciun link disponibil"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/ru.po
+++ b/packages/ckeditor5-link/lang/translations/ru.po
@@ -66,3 +66,7 @@ msgstr "Отображаемый текст"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Нет доступных ссылок"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/si.po
+++ b/packages/ckeditor5-link/lang/translations/si.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/sk.po
+++ b/packages/ckeditor5-link/lang/translations/sk.po
@@ -66,3 +66,7 @@ msgstr "Zobrazený text"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Nie sú dostupné žiadne odkazy"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/sl.po
+++ b/packages/ckeditor5-link/lang/translations/sl.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/sq.po
+++ b/packages/ckeditor5-link/lang/translations/sq.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-link/lang/translations/sr-latn.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/sr.po
+++ b/packages/ckeditor5-link/lang/translations/sr.po
@@ -66,3 +66,7 @@ msgstr "Prikazani tekst"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Nema dostupnih veza"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/sv.po
+++ b/packages/ckeditor5-link/lang/translations/sv.po
@@ -66,3 +66,7 @@ msgstr "Visad text"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Inga länkar tillgängliga"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/th.po
+++ b/packages/ckeditor5-link/lang/translations/th.po
@@ -66,3 +66,7 @@ msgstr "ข้อความที่แสดง"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "ไม่มีลิงก์พร้อมใช้งาน"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/ti.po
+++ b/packages/ckeditor5-link/lang/translations/ti.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/tk.po
+++ b/packages/ckeditor5-link/lang/translations/tk.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/tr.po
+++ b/packages/ckeditor5-link/lang/translations/tr.po
@@ -66,3 +66,7 @@ msgstr "Görüntülenen metin"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Kullanılabilir bağlantı yok"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/tt.po
+++ b/packages/ckeditor5-link/lang/translations/tt.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/ug.po
+++ b/packages/ckeditor5-link/lang/translations/ug.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/uk.po
+++ b/packages/ckeditor5-link/lang/translations/uk.po
@@ -66,3 +66,7 @@ msgstr "Відображений текст"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Немає доступних посилань"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/ur.po
+++ b/packages/ckeditor5-link/lang/translations/ur.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/uz.po
+++ b/packages/ckeditor5-link/lang/translations/uz.po
@@ -66,3 +66,7 @@ msgstr ""
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr ""
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/vi.po
+++ b/packages/ckeditor5-link/lang/translations/vi.po
@@ -66,3 +66,7 @@ msgstr "Văn bản đã hiển thị"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "Không có đường liên kết khả dụng"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-link/lang/translations/zh-cn.po
@@ -66,3 +66,7 @@ msgstr "显示的文本"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "无可用链接"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-link/lang/translations/zh.po
+++ b/packages/ckeditor5-link/lang/translations/zh.po
@@ -66,3 +66,7 @@ msgstr "顯示的文字"
 msgctxt "Placeholder shown when placeholder items view is empty."
 msgid "No links available"
 msgstr "無可用連結"
+
+msgctxt "The label of the switch button shown when link has empty href attribute."
+msgid "This link has no URL"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/af.po
+++ b/packages/ckeditor5-media-embed/lang/translations/af.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/ar.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ar.po
@@ -54,3 +54,15 @@ msgstr "فتح الوسائط في علامة تبويب جديدة"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "تضمين الوسائط"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/ast.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ast.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/az.po
+++ b/packages/ckeditor5-media-embed/lang/translations/az.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/be.po
+++ b/packages/ckeditor5-media-embed/lang/translations/be.po
@@ -54,3 +54,15 @@ msgstr "Адкрыць медыя ў новай картцы"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/bg.po
+++ b/packages/ckeditor5-media-embed/lang/translations/bg.po
@@ -54,3 +54,15 @@ msgstr "Отворете мултимедията в нов раздел"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Вмъкване на мултимедия"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/bn.po
+++ b/packages/ckeditor5-media-embed/lang/translations/bn.po
@@ -54,3 +54,15 @@ msgstr "নতুন ট্যাবে মিডিয়া খুলুন"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "মিডিয়া এম্বেড"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/bs.po
+++ b/packages/ckeditor5-media-embed/lang/translations/bs.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/ca.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ca.po
@@ -54,3 +54,15 @@ msgstr "Obriu l'enllaç a una nova pestanya"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Insereix contingut multimèdia"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/cs.po
+++ b/packages/ckeditor5-media-embed/lang/translations/cs.po
@@ -54,3 +54,15 @@ msgstr "Otevřete média na nové kartě"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Vložení médií"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/da.po
+++ b/packages/ckeditor5-media-embed/lang/translations/da.po
@@ -54,3 +54,15 @@ msgstr "Åbn medie i ny fane"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Medieindlejring"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/de-ch.po
+++ b/packages/ckeditor5-media-embed/lang/translations/de-ch.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/de.po
+++ b/packages/ckeditor5-media-embed/lang/translations/de.po
@@ -54,3 +54,15 @@ msgstr "Medien in neuem Tab öffnen"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Medieneinbettung"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/el.po
+++ b/packages/ckeditor5-media-embed/lang/translations/el.po
@@ -54,3 +54,15 @@ msgstr "Άνοιγμα πολυμέσων σε νέα καρτέλα"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Ενσωμάτωση πολυμέσων"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/en-au.po
+++ b/packages/ckeditor5-media-embed/lang/translations/en-au.po
@@ -54,3 +54,15 @@ msgstr "Open media in new tab"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Media embed"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr "Left aligned media"
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr "Centered media"
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr "Right aligned media"

--- a/packages/ckeditor5-media-embed/lang/translations/en-gb.po
+++ b/packages/ckeditor5-media-embed/lang/translations/en-gb.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Media embed"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr "Left aligned media"
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr "Centered media"
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr "Right aligned media"

--- a/packages/ckeditor5-media-embed/lang/translations/en.po
+++ b/packages/ckeditor5-media-embed/lang/translations/en.po
@@ -54,3 +54,15 @@ msgstr "Open media in new tab"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Media embed"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr "Left aligned media"
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr "Centered media"
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr "Right aligned media"

--- a/packages/ckeditor5-media-embed/lang/translations/eo.po
+++ b/packages/ckeditor5-media-embed/lang/translations/eo.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/es-co.po
+++ b/packages/ckeditor5-media-embed/lang/translations/es-co.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/es.po
+++ b/packages/ckeditor5-media-embed/lang/translations/es.po
@@ -54,3 +54,15 @@ msgstr "Abrir medio en una pestaña nueva"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Inserción de medios"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/et.po
+++ b/packages/ckeditor5-media-embed/lang/translations/et.po
@@ -54,3 +54,15 @@ msgstr "Avage meedia uuel vahekaardil"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Meedium manustatud"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/eu.po
+++ b/packages/ckeditor5-media-embed/lang/translations/eu.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/fa.po
+++ b/packages/ckeditor5-media-embed/lang/translations/fa.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/fi.po
+++ b/packages/ckeditor5-media-embed/lang/translations/fi.po
@@ -54,3 +54,15 @@ msgstr "Avaa media uudessa välilehdessä"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Median upotus"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/fr.po
+++ b/packages/ckeditor5-media-embed/lang/translations/fr.po
@@ -54,3 +54,15 @@ msgstr "Ouvrir le média dans un nouvel onglet"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Intégration de médias"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/gl.po
+++ b/packages/ckeditor5-media-embed/lang/translations/gl.po
@@ -54,3 +54,15 @@ msgstr "Abrir multimedia nunha nova lapela"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/gu.po
+++ b/packages/ckeditor5-media-embed/lang/translations/gu.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/he.po
+++ b/packages/ckeditor5-media-embed/lang/translations/he.po
@@ -54,3 +54,15 @@ msgstr "פתח מדיה בכרטיסיה חדשה"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "הטמעת מדיה"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/hi.po
+++ b/packages/ckeditor5-media-embed/lang/translations/hi.po
@@ -54,3 +54,15 @@ msgstr "नए टैब में मीडिया खोलें"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "मीडिया एंबेड"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/hr.po
+++ b/packages/ckeditor5-media-embed/lang/translations/hr.po
@@ -54,3 +54,15 @@ msgstr "Otvori medije u novoj kartici"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/hu.po
+++ b/packages/ckeditor5-media-embed/lang/translations/hu.po
@@ -54,3 +54,15 @@ msgstr "Nyissa meg a médiát új lapon"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Média beágyazása"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/hy.po
+++ b/packages/ckeditor5-media-embed/lang/translations/hy.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/id.po
+++ b/packages/ckeditor5-media-embed/lang/translations/id.po
@@ -54,3 +54,15 @@ msgstr "Buka media di tab baru"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Sematkan media"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/it.po
+++ b/packages/ckeditor5-media-embed/lang/translations/it.po
@@ -54,3 +54,15 @@ msgstr "Apri media in nuova scheda"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Incorporamento multimediale"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/ja.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ja.po
@@ -54,3 +54,15 @@ msgstr "新しいタブでメディアを開く"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "メディアの埋め込み"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/jv.po
+++ b/packages/ckeditor5-media-embed/lang/translations/jv.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/kk.po
+++ b/packages/ckeditor5-media-embed/lang/translations/kk.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/km.po
+++ b/packages/ckeditor5-media-embed/lang/translations/km.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/kn.po
+++ b/packages/ckeditor5-media-embed/lang/translations/kn.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/ko.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ko.po
@@ -54,3 +54,15 @@ msgstr "새 탭에서 미디어 열기"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "미디어 삽입"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/ku.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ku.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/lt.po
+++ b/packages/ckeditor5-media-embed/lang/translations/lt.po
@@ -54,3 +54,15 @@ msgstr "Atidaryti mediją naujame skirtuke"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Medijos įterpimas"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/lv.po
+++ b/packages/ckeditor5-media-embed/lang/translations/lv.po
@@ -54,3 +54,15 @@ msgstr "Atvērt mediju jaunā cilnē"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Multivides saites"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/ms.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ms.po
@@ -54,3 +54,15 @@ msgstr "Buka media dalam tab baru"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Benam media"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/nb.po
+++ b/packages/ckeditor5-media-embed/lang/translations/nb.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/ne.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ne.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/nl.po
+++ b/packages/ckeditor5-media-embed/lang/translations/nl.po
@@ -54,3 +54,15 @@ msgstr "Open media in nieuw tabblad"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Media insluiten"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/no.po
+++ b/packages/ckeditor5-media-embed/lang/translations/no.po
@@ -54,3 +54,15 @@ msgstr "Åpne media i ny fane"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Medieinnbygging"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/oc.po
+++ b/packages/ckeditor5-media-embed/lang/translations/oc.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/pl.po
+++ b/packages/ckeditor5-media-embed/lang/translations/pl.po
@@ -54,3 +54,15 @@ msgstr "Otwórz media w nowej zakładce"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Osadzanie multimediów"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/pt-br.po
+++ b/packages/ckeditor5-media-embed/lang/translations/pt-br.po
@@ -54,3 +54,15 @@ msgstr "Abrir mídia em nova aba"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Incorporar elemento de mídia"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/pt.po
+++ b/packages/ckeditor5-media-embed/lang/translations/pt.po
@@ -54,3 +54,15 @@ msgstr "Abrir ficheiro multimédia em novo separador"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Incorporar média"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/ro.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ro.po
@@ -54,3 +54,15 @@ msgstr "Deschideți conținutul media într-o filă nouă"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Încorporare media"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/ru.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ru.po
@@ -54,3 +54,15 @@ msgstr "Откройте медиа в новой вкладке"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Внедрение мультимедиа"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/si.po
+++ b/packages/ckeditor5-media-embed/lang/translations/si.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/sk.po
+++ b/packages/ckeditor5-media-embed/lang/translations/sk.po
@@ -54,3 +54,15 @@ msgstr "Otvoriť médiá na novej karte"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Vloženie médií"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/sl.po
+++ b/packages/ckeditor5-media-embed/lang/translations/sl.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/sq.po
+++ b/packages/ckeditor5-media-embed/lang/translations/sq.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/sr-latn.po
+++ b/packages/ckeditor5-media-embed/lang/translations/sr-latn.po
@@ -54,3 +54,15 @@ msgstr "Otvorite medije u novoj kartici"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/sr.po
+++ b/packages/ckeditor5-media-embed/lang/translations/sr.po
@@ -54,3 +54,15 @@ msgstr "Отворите медије у новој картици"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Ugradi medij"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/sv.po
+++ b/packages/ckeditor5-media-embed/lang/translations/sv.po
@@ -54,3 +54,15 @@ msgstr "Öppna media i ny flik"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Medieinbäddning"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/th.po
+++ b/packages/ckeditor5-media-embed/lang/translations/th.po
@@ -54,3 +54,15 @@ msgstr "เปิดสื่อในแท็บใหม่"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "สื่อที่ฝัง"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/ti.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ti.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/tk.po
+++ b/packages/ckeditor5-media-embed/lang/translations/tk.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/tr.po
+++ b/packages/ckeditor5-media-embed/lang/translations/tr.po
@@ -54,3 +54,15 @@ msgstr "Medyayı yeni sekmede aç"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Medya yerleştirme"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/tt.po
+++ b/packages/ckeditor5-media-embed/lang/translations/tt.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/ug.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ug.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/uk.po
+++ b/packages/ckeditor5-media-embed/lang/translations/uk.po
@@ -54,3 +54,15 @@ msgstr "Відкрити медіа у новій вкладці"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Вбудувати медіа"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/ur.po
+++ b/packages/ckeditor5-media-embed/lang/translations/ur.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/uz.po
+++ b/packages/ckeditor5-media-embed/lang/translations/uz.po
@@ -54,3 +54,15 @@ msgstr ""
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr ""
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/vi.po
+++ b/packages/ckeditor5-media-embed/lang/translations/vi.po
@@ -54,3 +54,15 @@ msgstr "Mở nội dung nghe nhìn trong tab mới"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "Nhúng tệp đa phương tiện"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-media-embed/lang/translations/zh-cn.po
@@ -54,3 +54,15 @@ msgstr "在新标签页打开媒体"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "已嵌入媒体"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""

--- a/packages/ckeditor5-media-embed/lang/translations/zh.po
+++ b/packages/ckeditor5-media-embed/lang/translations/zh.po
@@ -54,3 +54,15 @@ msgstr "在新分頁打開媒體"
 msgctxt "The label for the Media Embed balloon."
 msgid "Media embed"
 msgstr "媒體嵌入"
+
+msgctxt "The label for the left aligned media option."
+msgid "Left aligned media"
+msgstr ""
+
+msgctxt "The label for the centered media option."
+msgid "Centered media"
+msgstr ""
+
+msgctxt "The label for the right aligned media option."
+msgid "Right aligned media"
+msgstr ""


### PR DESCRIPTION
### 🚀 Summary

1. Move shared `Wrap text` and `Break text` translations to core via `pnpm run translations:move`.
2. Run `pnpm run translations:synchronize` to synchronize translations.

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [ ] Is the change backward-compatible?
- [ ] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [ ] Has the change been manually verified in the relevant setups?
- [ ] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [ ] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
