### PR TITLE
[codex] Keep external drop effect as copy

### DIFF
--- a/packages/ckeditor5-clipboard/src/dragdrop.ts
+++ b/packages/ckeditor5-clipboard/src/dragdrop.ts
@@ -376,10 +376,8 @@ export class DragDrop extends Plugin {
 			// is not possible until 'dragend' event case will be fixed.
 			if ( !this._draggedRange ) {
 				data.dataTransfer.dropEffect = 'copy';
-			}
-
-			// In Firefox it is already set and effect allowed remains the same as originally set.
-			if ( !env.isGecko ) {
+			} else if ( !env.isGecko ) {
+				// In Firefox it is already set and effect allowed remains the same as originally set.
 				if ( data.dataTransfer.effectAllowed == 'copy' ) {
 					data.dataTransfer.dropEffect = 'copy';
 				} else if ( [ 'all', 'copyMove' ].includes( data.dataTransfer.effectAllowed ) ) {


### PR DESCRIPTION
## Summary

Keeps external drag operations advertised as `copy` in the clipboard drag/drop plugin.

## Root cause

The `dragging` handler already detects external drags with `!this._draggedRange` and sets `dataTransfer.dropEffect = 'copy'`.

In non-Gecko browsers, the next branch could immediately overwrite that value to `move` when `effectAllowed` was `all` or `copyMove`. That made external drags behave like editor-internal moves in Chrome/Edge.

## Change

Only run the non-Gecko `effectAllowed` fallback for internal editor drags. External drags keep the explicit `copy` drop effect.

Fixes ckeditor/ckeditor5#20161.
