### PR TITLE
Keep external drop effect as copy

### DIFF
--- a/.changelog/20260519225000_i_20161.md
+++ b/.changelog/20260519225000_i_20161.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-clipboard
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/20161
+---
+
+External content dragged into the editor now keeps the copy drop effect instead of being treated as a move operation.

--- a/packages/ckeditor5-clipboard/src/dragdrop.ts
+++ b/packages/ckeditor5-clipboard/src/dragdrop.ts
@@ -376,10 +376,8 @@ export class DragDrop extends Plugin {
 			// is not possible until 'dragend' event case will be fixed.
 			if ( !this._draggedRange ) {
 				data.dataTransfer.dropEffect = 'copy';
-			}
-
-			// In Firefox it is already set and effect allowed remains the same as originally set.
-			if ( !env.isGecko ) {
+			} else if ( !env.isGecko ) {
+				// In Firefox it is already set and effect allowed remains the same as originally set.
 				if ( data.dataTransfer.effectAllowed == 'copy' ) {
 					data.dataTransfer.dropEffect = 'copy';
 				} else if ( [ 'all', 'copyMove' ].includes( data.dataTransfer.effectAllowed ) ) {

--- a/packages/ckeditor5-clipboard/tests/dragdrop.js
+++ b/packages/ckeditor5-clipboard/tests/dragdrop.js
@@ -200,6 +200,7 @@ describe( 'Drag and Drop', () => {
 			// Dragging.
 
 			targetPosition = model.createPositionAt( root.getChild( 0 ), 5 );
+			dataTransferMock.effectAllowed = 'copyMove';
 			fireDragging( dataTransferMock, targetPosition );
 			clock.tick( 100 );
 


### PR DESCRIPTION
### 🚀 Summary

Keeps external drag operations advertised as `copy` in the clipboard drag/drop plugin.

The `dragging` handler already detects external drags with `!this._draggedRange` and sets `dataTransfer.dropEffect = 'copy'`. In non-Gecko browsers, the next branch could immediately overwrite that value to `move` when `effectAllowed` was `all` or `copyMove`.

This change only runs the non-Gecko `effectAllowed` fallback for internal editor drags. External drags keep the explicit `copy` drop effect.

---

### 📌 Related issues

* Closes #20161

---

### 💡 Additional information

Manually verified using the clipboard drag/drop manual test page in Chromium. External file drags over the editor no longer forced `dropEffect = "move"`.

Automated regression coverage added in `packages/ckeditor5-clipboard/tests/dragdrop.js`.

Checked locally with:

```shell
npx pnpm@10.28.0 run test --files=clipboard/dragdrop
```

---

### 🧾 Checklists

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [x] Does this change affect any of the above?
- [ ] Is performance impacted?
- [ ] Is accessibility affected?
- [x] Have tests been added that fail without this change (against regression)?
- [ ] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [ ] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [ ] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
