### PR TITLE
Fix (mention): The mention suggestions panel no longer overflows the viewport on narrow screens

### DIFF
--- a/.changelog/20260612135133_i_20182.md
+++ b/.changelog/20260612135133_i_20182.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-mention
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/20182
+---
+
+The mention suggestions panel no longer overflows the viewport on narrow screens. When the caret is close to the screen edge, the panel is shifted horizontally so the whole list stays visible.

--- a/packages/ckeditor5-mention/src/mentionui.ts
+++ b/packages/ckeditor5-mention/src/mentionui.ts
@@ -601,10 +601,10 @@ function getBalloonPanelPositions(
 ): DomOptimalPositionOptions['positions'] {
 	const positions: Record<string, DomOptimalPositionOptions['positions'][0]> = {
 		// Positions the panel to the southeast of the caret rectangle.
-		'caret_se': ( targetRect: Rect ) => {
+		'caret_se': ( targetRect: Rect, balloonRect: Rect, viewportRect: Rect ) => {
 			return {
 				top: targetRect.bottom + VERTICAL_SPACING,
-				left: targetRect.right,
+				left: fitLeftInViewport( targetRect.right, balloonRect, viewportRect ),
 				name: 'caret_se',
 				config: {
 					withArrow: false
@@ -613,10 +613,10 @@ function getBalloonPanelPositions(
 		},
 
 		// Positions the panel to the northeast of the caret rectangle.
-		'caret_ne': ( targetRect: Rect, balloonRect: Rect ) => {
+		'caret_ne': ( targetRect: Rect, balloonRect: Rect, viewportRect: Rect ) => {
 			return {
 				top: targetRect.top - balloonRect.height - VERTICAL_SPACING,
-				left: targetRect.right,
+				left: fitLeftInViewport( targetRect.right, balloonRect, viewportRect ),
 				name: 'caret_ne',
 				config: {
 					withArrow: false
@@ -625,10 +625,10 @@ function getBalloonPanelPositions(
 		},
 
 		// Positions the panel to the southwest of the caret rectangle.
-		'caret_sw': ( targetRect: Rect, balloonRect: Rect ) => {
+		'caret_sw': ( targetRect: Rect, balloonRect: Rect, viewportRect: Rect ) => {
 			return {
 				top: targetRect.bottom + VERTICAL_SPACING,
-				left: targetRect.right - balloonRect.width,
+				left: fitLeftInViewport( targetRect.right - balloonRect.width, balloonRect, viewportRect ),
 				name: 'caret_sw',
 				config: {
 					withArrow: false
@@ -637,10 +637,10 @@ function getBalloonPanelPositions(
 		},
 
 		// Positions the panel to the northwest of the caret rect.
-		'caret_nw': ( targetRect: Rect, balloonRect: Rect ) => {
+		'caret_nw': ( targetRect: Rect, balloonRect: Rect, viewportRect: Rect ) => {
 			return {
 				top: targetRect.top - balloonRect.height - VERTICAL_SPACING,
-				left: targetRect.right - balloonRect.width,
+				left: fitLeftInViewport( targetRect.right - balloonRect.width, balloonRect, viewportRect ),
 				name: 'caret_nw',
 				config: {
 					withArrow: false
@@ -668,6 +668,16 @@ function getBalloonPanelPositions(
 		positions.caret_nw,
 		positions.caret_ne
 	];
+}
+
+/**
+ * Keeps the panel within the viewport horizontally, so it does not get cut off
+ * when the caret is close to the screen edge (e.g. on mobile).
+ *
+ * See https://github.com/ckeditor/ckeditor5/issues/20182.
+ */
+function fitLeftInViewport( left: number, balloonRect: Rect, viewportRect: Rect ): number {
+	return Math.max( viewportRect.left, Math.min( left, viewportRect.right - balloonRect.width ) );
 }
 
 /**

--- a/packages/ckeditor5-mention/tests/mentionui.js
+++ b/packages/ckeditor5-mention/tests/mentionui.js
@@ -166,6 +166,15 @@ describe( 'MentionUI', () => {
 			width: 200
 		};
 
+		const viewportRect = {
+			bottom: 1000,
+			height: 1000,
+			left: 0,
+			right: 1000,
+			top: 0,
+			width: 1000
+		};
+
 		beforeEach( () => {
 			return createClassicTestEditor( staticConfig ).then( () => {
 				pinSpy = vi.spyOn( panelView, 'pin' );
@@ -217,7 +226,7 @@ describe( 'MentionUI', () => {
 					const caretNorthEast = positions[ 2 ];
 					const caretNorthWest = positions[ 3 ];
 
-					expect( caretSouthEast( caretRect, balloonRect ) ).toEqual( {
+					expect( caretSouthEast( caretRect, balloonRect, viewportRect ) ).toEqual( {
 						left: 501,
 						name: 'caret_se',
 						top: 31,
@@ -226,7 +235,7 @@ describe( 'MentionUI', () => {
 						}
 					} );
 
-					expect( caretSouthWest( caretRect, balloonRect ) ).toEqual( {
+					expect( caretSouthWest( caretRect, balloonRect, viewportRect ) ).toEqual( {
 						left: 301,
 						name: 'caret_sw',
 						top: 31,
@@ -235,7 +244,7 @@ describe( 'MentionUI', () => {
 						}
 					} );
 
-					expect( caretNorthEast( caretRect, balloonRect ) ).toEqual( {
+					expect( caretNorthEast( caretRect, balloonRect, viewportRect ) ).toEqual( {
 						left: 501,
 						name: 'caret_ne',
 						top: -143,
@@ -244,7 +253,7 @@ describe( 'MentionUI', () => {
 						}
 					} );
 
-					expect( caretNorthWest( caretRect, balloonRect ) ).toEqual( {
+					expect( caretNorthWest( caretRect, balloonRect, viewportRect ) ).toEqual( {
 						left: 301,
 						name: 'caret_nw',
 						top: -143,
@@ -252,6 +261,46 @@ describe( 'MentionUI', () => {
 							withArrow: false
 						}
 					} );
+				} );
+		} );
+
+		it( 'should keep the panel inside the viewport horizontally on narrow screens', () => {
+			_setModelData( model, '<paragraph>foo []</paragraph>' );
+			stubSelectionRects( [ caretRect ] );
+
+			model.change( writer => {
+				writer.insertText( '@', doc.selection.getFirstPosition() );
+			} );
+
+			return waitForDebounce()
+				.then( () => {
+					const { positions } = pinSpy.mock.calls[ 0 ][ 0 ];
+
+					const caretSouthEast = positions[ 0 ];
+					const caretSouthWest = positions[ 1 ];
+
+					const narrowViewportRect = {
+						bottom: 800,
+						height: 800,
+						left: 0,
+						right: 390,
+						top: 0,
+						width: 390
+					};
+
+					// The caret is close to the right edge of the screen.
+					const caretNearRightEdge = { ...caretRect, left: 350, right: 351 };
+
+					// The panel would stick out beyond the right edge of the viewport (351 + 200 > 390),
+					// so it is moved left to stay fully visible.
+					expect( caretSouthEast( caretNearRightEdge, balloonRect, narrowViewportRect ).left ).toBe( 190 );
+
+					// The caret is close to the left edge of the screen.
+					const caretNearLeftEdge = { ...caretRect, left: 9, right: 10 };
+
+					// The panel would stick out beyond the left edge of the viewport (10 - 200 < 0),
+					// so it is moved right to stay fully visible.
+					expect( caretSouthWest( caretNearLeftEdge, balloonRect, narrowViewportRect ).left ).toBe( 0 );
 				} );
 		} );
 


### PR DESCRIPTION
Closes #20182.

On narrow screens the mention suggestions panel could stick out of the viewport. All four balloon positions anchor the panel to the caret, so when a wide panel did not fit on either side of the caret, whichever position got picked still overflowed the screen and the suggestions were cut off.

The position callbacks now clamp the panel's left coordinate to the viewport rect, which `getOptimalPosition()` already passes to positioning functions. If the panel would stick out, it is shifted just enough to stay fully visible. Vertical behavior is unchanged.

Tested on the `mention-custom-renderer` manual test at a 390px viewport. Before, the panel rect ended at 414px with its right side cut off. After, it ends right at the 390px edge:

![Before and after at a 390px viewport](https://raw.githubusercontent.com/ELHart05/ckeditor5/assets-20182/mention-20182-before-after.gif)

The existing position tests were updated because the callbacks now take the viewport rect as a third argument, and a new test covers the clamping on both screen edges. The `ckeditor5-mention` suite passes with 100% coverage. A changelog entry is included.