### PR TITLE
Don't crash when translations is an empty array

### DIFF
--- a/packages/ckeditor5-utils/src/translation-service.ts
+++ b/packages/ckeditor5-utils/src/translation-service.ts
@@ -233,7 +233,7 @@ export function _clear(): void {
 export function _unifyTranslations(
 	translations?: ArrayOrItem<Translations>
 ): Translations | undefined {
-	return Array.isArray( translations ) ?
+	return Array.isArray(translations) && translations.length != 0 ?
 		translations.reduce( ( acc, translation ) => merge( acc, translation ) ) :
 		translations;
 }

--- a/packages/ckeditor5-utils/tests/translation-service.js
+++ b/packages/ckeditor5-utils/tests/translation-service.js
@@ -227,7 +227,11 @@ describe( 'translation-service', () => {
 
 		it( 'should return undifined if undifined', () => {
 			expect( _unifyTranslations( undefined ) ).toBeUndefined();
-		} );
+		});
+
+		it( 'should return an array if array', () => {
+			expect(_unifyTranslations([])).toEqual([]);
+		});
 	} );
 
 	describe( '_clear()', () => {


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate an `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Prevents crash when passing an empty `translations` array.

---

### 📌 Related issues

* Closes #20226

---

### 💡 Additional information

None

---

### 🧾 Checklists

Use the following checklists to ensure important areas were not overlooked.
This does not apply to feature-branch merges.
If an item is **not relevant** to this type of change, simply leave it unchecked.

#### Author checklist

- [x] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions? _(e.g., classic/inline/multi-root/many editors, typing, selection, paste, tables, lists, images, collaboration, pagination)_
- [x] Has the change been manually verified in the relevant setups?
- [x] Does this change affect any of the above?
- [x] Is performance impacted?
- [x] Is accessibility affected?
- [x] Have tests been added that fail without this change (against regression)?
- [x] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [x] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [x] Are there any changes the team should be informed about (e.g. architectural, difficult to revert in future versions or having impact on other features)?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach (especially when  performance, API, or UX is affected).
- [ ] The changelog entry is clear, user‑ or integrator-facing, and it describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md (if any).
- [ ] All human-readable, translateable strings in this PR been introduced using `t()` (if any).
- [ ] I manually verified the change (e.g., in manual tests or documentation).
- [ ] The target branch is correct.
