### PR TITLE
Fix tooltip listeners in non-global documents

### DIFF
--- a/.changelog/20260910120000_mm_tooltips_foreign_documents.md
+++ b/.changelog/20260910120000_mm_tooltips_foreign_documents.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope:
+    - ckeditor5-ui
+---
+
+Tooltips now work for editor user interfaces rendered in iframe and other non-global documents. The shared tooltip manager listens to every document registered by an editor body collection and renders the tooltip in the matching document.

--- a/packages/ckeditor5-ui/src/tooltipmanager.ts
+++ b/packages/ckeditor5-ui/src/tooltipmanager.ts
@@ -15,7 +15,6 @@ import {
 	DomEmitterMixin,
 	containsNode,
 	first,
-	global,
 	isShadowHostOf,
 	isShadowRoot,
 	isVisible,
@@ -148,6 +147,11 @@ export class TooltipManager extends TooltipManagerBase {
 	private _shadowRoots = new Set<ShadowRoot>();
 
 	/**
+	 * Documents the manager currently has listeners attached to.
+	 */
+	private _documents = new Set<Document>();
+
+	/**
 	 * Maps each DOM tree (the document or a shadow root) that hosts tooltip-bearing UI to the body collection
 	 * the shared tooltip balloon should be pinned into for targets in that tree. Rebuilt from
 	 * {@link module:ui/tooltipmanager~TooltipManager._registrations} by {@link #_rebuild}.
@@ -232,23 +236,6 @@ export class TooltipManager extends TooltipManagerBase {
 		this._pinTooltipDebounced = debounce( this._pinTooltip, 600 );
 		this._unpinTooltipDebounced = debounce( this._unpinTooltip, 400 );
 
-		this.listenTo( global.document, 'keydown', this._onKeyDown.bind( this ), { useCapture: true } );
-
-		// These are all attached on `document` to cover the light (non-shadow) DOM. Shadow roots get their
-		// own listeners for the same events, see #_resyncShadowRootListeners — `document`'s copies either never
-		// fire for shadow-originated events (`mouseenter`, `mouseleave`, `scroll`, all non-`composed`) or fire
-		// with a retargeted, unusable target (`focus`, `blur`, which are `composed`).
-		//
-		// Unlike these, set up once here, the shadow-root listeners are attached and detached over time by
-		// `#_resyncShadowRootListeners`, as registered body collections and their shadow roots come and go.
-		this.listenTo( global.document, 'mouseenter', this._onEnterOrFocus.bind( this ), { useCapture: true } );
-		this.listenTo( global.document, 'mouseleave', this._onLeaveOrBlur.bind( this ), { useCapture: true } );
-
-		this.listenTo( global.document, 'focus', this._onEnterOrFocus.bind( this ), { useCapture: true } );
-		this.listenTo( global.document, 'blur', this._onLeaveOrBlur.bind( this ), { useCapture: true } );
-
-		this.listenTo( global.document, 'scroll', this._onScroll.bind( this ), { useCapture: true } );
-
 		// Because this class is a singleton, its only instance is shared across all editors and connects them through the reference.
 		// Error attribution walks those references to work out which editor an error came from, and the shared tooltip manager
 		// would make every error look like it belongs to every editor. This flag excludes the instance from that walk.
@@ -274,6 +261,7 @@ export class TooltipManager extends TooltipManagerBase {
 
 		TooltipManager._registrations.clear();
 		this._bodyCollectionByTree.clear();
+		this._documents.clear();
 		this._shadowRoots.clear();
 
 		TooltipManager._instance = null;
@@ -421,7 +409,41 @@ export class TooltipManager extends TooltipManagerBase {
 
 		this._bodyCollectionByTree = map;
 
+		this._resyncDocumentListeners();
 		this._resyncShadowRootListeners();
+	}
+
+	/**
+	 * Attaches or detaches listeners on documents so they match the documents containing registered UI.
+	 */
+	private _resyncDocumentListeners(): void {
+		const currentDocuments = new Set<Document>();
+
+		for ( const tree of this._bodyCollectionByTree.keys() ) {
+			currentDocuments.add( isShadowRoot( tree ) ? tree.ownerDocument : tree );
+		}
+
+		for ( const document of this._documents ) {
+			if ( !currentDocuments.has( document ) ) {
+				this.stopListening( document );
+				this._documents.delete( document );
+			}
+		}
+
+		for ( const document of currentDocuments ) {
+			if ( this._documents.has( document ) ) {
+				continue;
+			}
+
+			this.listenTo( document, 'keydown', this._onKeyDown.bind( this ), { useCapture: true } );
+			this.listenTo( document, 'mouseenter', this._onEnterOrFocus.bind( this ), { useCapture: true } );
+			this.listenTo( document, 'mouseleave', this._onLeaveOrBlur.bind( this ), { useCapture: true } );
+			this.listenTo( document, 'focus', this._onEnterOrFocus.bind( this ), { useCapture: true } );
+			this.listenTo( document, 'blur', this._onLeaveOrBlur.bind( this ), { useCapture: true } );
+			this.listenTo( document, 'scroll', this._onScroll.bind( this ), { useCapture: true } );
+
+			this._documents.add( document );
+		}
 	}
 
 	/**

--- a/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
+++ b/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
@@ -256,6 +256,42 @@ describe( 'TooltipManager', () => {
 		} );
 	} );
 
+	describe( 'registered documents', () => {
+		it( 'should listen for and render tooltips in each registered document', () => {
+			const iframe = document.createElement( 'iframe' );
+
+			document.body.appendChild( iframe );
+
+			const iframeDocument = iframe.contentDocument;
+			const iframeBody = new BodyCollection( editor.locale );
+			const button = iframeDocument.createElement( 'button' );
+			const pinSpy = vi.spyOn( tooltipManager.balloonPanelView, 'pin' );
+
+			iframeBody.attachToDom( iframeDocument.body );
+			tooltipManager.registerBodyCollection( iframeBody );
+
+			button.dataset.ckeTooltipText = 'Iframe tooltip';
+			button.dataset.ckeTooltipInstant = 'true';
+			iframeDocument.body.appendChild( button );
+
+			button.dispatchEvent( new iframe.contentWindow.MouseEvent( 'mouseenter' ) );
+
+			expect( tooltipManager._documents.has( iframeDocument ) ).toBe( true );
+			expect( iframeBody.has( tooltipManager.balloonPanelView ) ).toBe( true );
+			expect( pinSpy ).toHaveBeenCalledWith( {
+				target: button,
+				positions: expect.any( Array )
+			} );
+
+			tooltipManager.unregisterBodyCollection( iframeBody );
+
+			expect( tooltipManager._documents.has( iframeDocument ) ).toBe( false );
+
+			iframeBody.destroy();
+			iframe.remove();
+		} );
+	} );
+
 	describe( 'destroy()', () => {
 		describe( 'singleton', () => {
 			it( 'should not be destroyed until the last editor instance gets destroyed', async () => {


### PR DESCRIPTION
### 🚀 Summary

This PR fixes tooltips for editor UI rendered in iframes and other non-global documents.

`TooltipManager` now listens to every document associated with a registered body collection instead of listening only to the global document. It synchronizes listeners as body collections are registered or unregistered, while continuing to render each tooltip in the matching document.

A regression test covers tooltip activation inside an iframe and verifies that document listeners are removed after unregistering the body collection. A user-facing changelog entry is included.

---

### 📌 Related issues

N/A

---

### 💡 Additional information

The behavior was manually verified with an editor UI hosted in a non-global document. The tooltip appeared in the correct document, and contextual editor UI continued to work as expected.

The automated test was added but could not be run locally because dependency installation was blocked by a package-feed resolution failure.

---

### 🧾 Checklists

#### Author checklist

- [ ] Is the changelog entry intentionally omitted?
- [x] Is the change backward-compatible?
- [x] Have you considered the impact on different editor setups and core interactions?
- [x] Has the change been manually verified in the relevant setups?
- [x] Does this change affect any of the above?
- [ ] Is performance impacted?
- [x] Is accessibility affected?
- [x] Have tests been added that fail without this change (against regression)?
- [x] Have the API documentation, guides, feature digest, and related feature sections been updated where needed?
- [x] Have metadata files (ckeditor5-metadata.json) been updated if needed?
- [x] Are there any changes the team should be informed about?
- [ ] Were these changes documented (in Logbook)?

#### Reviewer checklist

- [ ] PR description explains the changes and the chosen approach.
- [ ] The changelog entry is clear, user- or integrator-facing, and describes any breaking changes.
- [ ] All new external dependencies have been approved and mentioned in LICENSE.md.
- [ ] All human-readable, translatable strings have been introduced using `t()`.
- [ ] I manually verified the change.
- [ ] The target branch is correct.